### PR TITLE
feat: execute full pipeline composition runtime + production readiness gate v1

### DIFF
--- a/.github/workflows/production-readiness-gate-v1.yml
+++ b/.github/workflows/production-readiness-gate-v1.yml
@@ -1,0 +1,167 @@
+name: Production Readiness Gate v1
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/production-readiness-gate-v1.yml"
+      - "docs/ProductionReadinessGate-v1.md"
+      - "src/Nexo.Core.Application/Pipelines/**"
+      - "src/Nexo.Infrastructure/Pipelines/**"
+      - "src/Nexo.CLI/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/Pipelines/**"
+      - "src/Nexo.Tests.CLI/**"
+
+jobs:
+  gate-v1:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build checks
+        run: |
+          dotnet build src/Nexo.Core.Application/Nexo.Core.Application.csproj -f netstandard2.0 --no-restore -v minimal
+          dotnet build src/Nexo.Infrastructure/Nexo.Infrastructure.csproj --no-restore -v minimal
+          dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal
+
+      - name: Pipeline tests (net8)
+        run: |
+          dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj \
+            -f net8.0 \
+            --filter "FullyQualifiedName~Pipelines" \
+            --logger "console;verbosity=minimal" \
+            --logger "trx;LogFileName=gate-pipelines-net8.trx" \
+            --results-directory test-results
+
+      - name: Pipeline tests (net9)
+        run: |
+          dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj \
+            -f net9.0 \
+            --filter "FullyQualifiedName~Pipelines" \
+            --logger "console;verbosity=minimal" \
+            --logger "trx;LogFileName=gate-pipelines-net9.trx" \
+            --results-directory test-results
+
+      - name: Host DI smoke
+        run: |
+          dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj \
+            -f net8.0 \
+            --filter "FullyQualifiedName~HostingE2ESmokeTests.AddNexo_RegistersObservationPipeline_ByDefault|FullyQualifiedName~Pipelines.PipelineServiceCollectionExtensionsTests.AddNexo_RegistersPipelineCompositionLayerByDefault" \
+            --logger "console;verbosity=minimal" \
+            --logger "trx;LogFileName=gate-host-di.trx" \
+            --results-directory test-results
+
+      - name: CLI operational checks
+        run: |
+          cat > /tmp/pipeline_gate_demo.json <<'JSON'
+          {
+            "templateId": "gate-demo",
+            "version": "1.0",
+            "stages": [
+              { "id": "ingest", "name": "Ingest", "mode": "Deterministic" },
+              { "id": "hybrid", "name": "Hybrid", "mode": "Hybrid", "fallbackChain": ["Deterministic", "Agentic"] }
+            ],
+            "edges": [
+              { "fromStageId": "ingest", "toStageId": "hybrid" }
+            ]
+          }
+          JSON
+
+          dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline validate --template /tmp/pipeline_gate_demo.json | tee /tmp/gate-validate.log
+          dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-success --format-json | tee /tmp/gate-run-success.log
+          dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-fallback --input "fail:hybrid:deterministic=true" --format-json | tee /tmp/gate-run-fallback.log
+
+          python - <<'PY'
+          import json
+
+          def parse_final_json(path: str) -> dict:
+              with open(path, "r", encoding="utf-8") as fh:
+                  lines = [line.strip() for line in fh.readlines()]
+              json_lines = [line for line in lines if line.startswith("{") and line.endswith("}")]
+              if not json_lines:
+                  raise SystemExit(f"No JSON payload found in {path}")
+              return json.loads(json_lines[-1])
+
+          success = parse_final_json("/tmp/gate-run-success.log")
+          fallback = parse_final_json("/tmp/gate-run-fallback.log")
+
+          if not success.get("ok"):
+              raise SystemExit("Success run did not return ok=true")
+          if success.get("data", {}).get("state") != "Completed":
+              raise SystemExit("Success run did not complete")
+
+          stages = fallback.get("data", {}).get("stages", [])
+          hybrid = next((s for s in stages if s.get("stageId") == "hybrid"), None)
+          if hybrid is None:
+              raise SystemExit("Fallback run missing hybrid stage result")
+          if hybrid.get("workerType") != "Agentic":
+              raise SystemExit(f"Fallback run did not switch to Agentic worker, got {hybrid.get('workerType')}")
+          PY
+
+      - name: Durable resume checks (LiteDb)
+        run: |
+          set +e
+          NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db \
+          dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-source --input "fail:ingest:deterministic=true" --format-json | tee /tmp/gate-resume-source.log
+          source_exit=$?
+          set -e
+
+          if [ "$source_exit" -eq 0 ]; then
+            echo "Expected source run to fail for resume scenario"
+            exit 1
+          fi
+
+          NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db \
+          dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-target --resume-run-id gate-resume-source --resume-failed-stages --format-json | tee /tmp/gate-resume-target.log
+
+          python - <<'PY'
+          import json
+
+          def parse_final_json(path: str) -> dict:
+              with open(path, "r", encoding="utf-8") as fh:
+                  lines = [line.strip() for line in fh.readlines()]
+              json_lines = [line for line in lines if line.startswith("{") and line.endswith("}")]
+              if not json_lines:
+                  raise SystemExit(f"No JSON payload found in {path}")
+              return json.loads(json_lines[-1])
+
+          source = parse_final_json("/tmp/gate-resume-source.log")
+          target = parse_final_json("/tmp/gate-resume-target.log")
+
+          if source.get("data", {}).get("state") != "Failed":
+              raise SystemExit("Source run is expected to fail for durable resume check")
+          if not target.get("ok"):
+              raise SystemExit("Resumed target run did not return ok=true")
+          if target.get("data", {}).get("state") != "Completed":
+              raise SystemExit("Resumed target run did not complete")
+          PY
+
+      - name: Cleanup temp artifacts
+        if: always()
+        run: rm -f /tmp/pipeline_gate_demo.json /tmp/nexo_pipeline_gate_resume.db
+
+      - name: Upload test and gate artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-readiness-gate-v1-artifacts
+          path: |
+            test-results/**/*.trx
+            /tmp/gate-validate.log
+            /tmp/gate-run-success.log
+            /tmp/gate-run-fallback.log
+            /tmp/gate-resume-source.log
+            /tmp/gate-resume-target.log
+          retention-days: 14

--- a/docs/ProductionReadinessGate-v1.md
+++ b/docs/ProductionReadinessGate-v1.md
@@ -1,0 +1,202 @@
+# Production Readiness Gate v1
+
+This document defines a strict, repeatable gate for deciding whether Nexo is ready for production deployment in a given environment.
+
+The gate is intentionally binary:
+
+- **PASS**: all required checks pass, no unresolved High/Critical exceptions.
+- **FAIL**: any required check fails, or any High/Critical exception remains unresolved.
+
+---
+
+## 1) Scope and intent
+
+This gate covers:
+
+- Build integrity and framework compatibility.
+- Pipeline runtime correctness (validation, scheduling, fallback, retries, resume, durable persistence).
+- Host wiring and CLI operability for production-style workflows.
+- Minimal operational evidence from logs and JSON output.
+
+This gate does **not** replace:
+
+- Formal threat modeling.
+- Full load/performance certification.
+- Regulatory/compliance audits.
+
+Those should run as additional gates (v2+).
+
+---
+
+## 2) Required preconditions
+
+- .NET 8 SDK installed.
+- Repository checked out cleanly.
+- No local uncommitted production code modifications.
+- Optional: `NEXO_PIPELINE_STORE_PROVIDER` and `NEXO_PIPELINE_STORE_PATH` available for durable resume validation.
+
+---
+
+## 3) Gate criteria (PASS/FAIL)
+
+### A. Build and compatibility (required)
+
+1. `Nexo.Core.Application` builds for `netstandard2.0`.
+2. `Nexo.Infrastructure` builds.
+3. `Nexo.CLI` builds.
+
+**Fail conditions**
+
+- Any build command returns non-zero.
+- Any compile-time errors.
+
+---
+
+### B. Pipeline runtime correctness (required)
+
+1. Pipeline-focused infrastructure tests pass on `net8.0`.
+2. Pipeline-focused infrastructure tests pass on `net9.0`.
+3. Host DI smoke checks pass for default `AddNexo` registration with pipeline layer present.
+
+**Fail conditions**
+
+- Any of the above test commands return non-zero.
+
+---
+
+### C. CLI operational correctness (required)
+
+1. `pipeline validate` succeeds for a valid template.
+2. `pipeline run` succeeds and emits completed run output.
+3. `pipeline run` fallback path works (deterministic failure -> agentic success).
+
+**Fail conditions**
+
+- Validation fails for known-good template.
+- Run command exits non-zero for expected success path.
+- Fallback path does not switch workers as expected.
+
+---
+
+### D. Durable resume correctness (required for production readiness)
+
+Using `LiteDb` provider:
+
+1. Create a failed run in one process invocation.
+2. Resume from that run in a second process invocation.
+3. Resumed run completes successfully.
+
+**Fail conditions**
+
+- Prior run not persisted/readable.
+- Resume run cannot load source run.
+- Resume path fails to recover and complete.
+
+---
+
+### E. Exceptions policy (required)
+
+Any High/Critical exception to this gate requires:
+
+- owner
+- expiration date
+- mitigation plan
+- explicit sign-off
+
+If missing any of the above -> **FAIL**.
+
+---
+
+## 4) Exact command set (reference implementation)
+
+Run from repo root.
+
+### 4.1 Build checks
+
+```bash
+dotnet build src/Nexo.Core.Application/Nexo.Core.Application.csproj -f netstandard2.0
+dotnet build src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+dotnet build src/Nexo.CLI/Nexo.CLI.csproj
+```
+
+### 4.2 Pipeline correctness checks
+
+```bash
+dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter "FullyQualifiedName~Pipelines"
+dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net9.0 --filter "FullyQualifiedName~Pipelines"
+dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter "FullyQualifiedName~HostingE2ESmokeTests.AddNexo_RegistersObservationPipeline_ByDefault|FullyQualifiedName~Pipelines.PipelineServiceCollectionExtensionsTests.AddNexo_RegistersPipelineCompositionLayerByDefault"
+```
+
+### 4.3 CLI operational checks
+
+Create a temporary template file:
+
+```bash
+cat > /tmp/pipeline_gate_demo.json <<'JSON'
+{
+  "templateId": "gate-demo",
+  "version": "1.0",
+  "stages": [
+    { "id": "ingest", "name": "Ingest", "mode": "Deterministic" },
+    { "id": "hybrid", "name": "Hybrid", "mode": "Hybrid", "fallbackChain": ["Deterministic", "Agentic"] }
+  ],
+  "edges": [
+    { "fromStageId": "ingest", "toStageId": "hybrid" }
+  ]
+}
+JSON
+```
+
+Validate and run:
+
+```bash
+dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline validate --template /tmp/pipeline_gate_demo.json
+dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-success --format-json
+dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-fallback --input "fail:hybrid:deterministic=true" --format-json
+```
+
+### 4.4 Durable resume checks (LiteDb)
+
+```bash
+NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db \
+dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-source --input "fail:ingest:deterministic=true" --format-json
+
+NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db \
+dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-target --resume-run-id gate-resume-source --resume-failed-stages --format-json
+```
+
+Cleanup:
+
+```bash
+rm -f /tmp/pipeline_gate_demo.json /tmp/nexo_pipeline_gate_resume.db
+```
+
+---
+
+## 5) CI integration recommendation
+
+Add a dedicated workflow (recommended name: `production-readiness-gate-v1.yml`) that runs:
+
+1. Build checks.
+2. Pipeline tests for net8/net9.
+3. Host DI smoke filter.
+4. CLI validate/run/fallback checks.
+5. Durable resume checks (LiteDb).
+
+The workflow should:
+
+- upload logs/artifacts (`trx`, command output),
+- fail-fast on required command failures,
+- emit a single PASS/FAIL summary.
+
+---
+
+## 6) Exit checklist for release candidate
+
+Release candidate can proceed only when all are true:
+
+- [ ] All sections A-D pass.
+- [ ] No unapproved High/Critical exceptions.
+- [ ] CI gate green on target branch.
+- [ ] Rollback plan documented and tested.
+

--- a/src/Nexo.CLI/Commands/PipelineCommand.cs
+++ b/src/Nexo.CLI/Commands/PipelineCommand.cs
@@ -1,0 +1,216 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Nexo.CLI.Formatting;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.CLI.Commands;
+
+/// <summary>
+/// CLI command for pipeline template validation and execution.
+/// </summary>
+public sealed class PipelineCommand
+{
+    private readonly IPipelineTemplateValidator _validator;
+    private readonly IPipelineOrchestrator _orchestrator;
+    private readonly IConsoleRenderer _renderer;
+    private readonly ILogger<PipelineCommand> _logger;
+
+    public PipelineCommand(
+        IPipelineTemplateValidator validator,
+        IPipelineOrchestrator orchestrator,
+        IConsoleRenderer renderer,
+        ILogger<PipelineCommand> logger)
+    {
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+        _orchestrator = orchestrator ?? throw new ArgumentNullException(nameof(orchestrator));
+        _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public int Validate(string templatePath, bool json, bool verbose)
+    {
+        if (string.IsNullOrWhiteSpace(templatePath))
+            throw new ArgumentException("Template path is required.", nameof(templatePath));
+
+        var correlationId = Guid.NewGuid().ToString("N");
+        using var scope = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId
+        });
+
+        if (verbose)
+            _renderer.RenderProgressStart($"CorrelationId={correlationId} :: validating pipeline template {templatePath}");
+
+        try
+        {
+            var template = LoadTemplate(templatePath);
+            var result = _validator.Validate(template);
+            if (json)
+            {
+                _renderer.RenderJson(new
+                {
+                    ok = result.IsValid,
+                    correlationId,
+                    data = new
+                    {
+                        templateId = template.TemplateId,
+                        isValid = result.IsValid,
+                        errors = result.Errors
+                    }
+                });
+            }
+            else if (result.IsValid)
+            {
+                _renderer.RenderSuccess($"Pipeline template '{template.TemplateId}' is valid.");
+            }
+            else
+            {
+                _renderer.RenderError("Pipeline template is invalid:");
+                foreach (var error in result.Errors)
+                    _renderer.RenderError($"  - {error}");
+            }
+
+            if (verbose)
+                _renderer.RenderProgressComplete($"CorrelationId={correlationId} :: template validation finished");
+
+            return result.IsValid ? (int)ExitCode.Ok : (int)ExitCode.ValidationFailed;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Pipeline validation failed");
+            if (json)
+            {
+                _renderer.RenderJson(new { ok = false, correlationId, error = ex.Message });
+            }
+            else
+            {
+                _renderer.RenderError($"Pipeline validation failed: {ex.Message}");
+            }
+            return (int)ExitCode.UnexpectedError;
+        }
+    }
+
+    public async Task<int> RunAsync(
+        string templatePath,
+        bool json,
+        bool verbose,
+        string? runId,
+        string? resumeRunId,
+        bool resumeFailedStages,
+        IReadOnlyDictionary<string, string> inputs,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(templatePath))
+            throw new ArgumentException("Template path is required.", nameof(templatePath));
+
+        var correlationId = Guid.NewGuid().ToString("N");
+        using var scope = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId
+        });
+
+        if (verbose)
+            _renderer.RenderProgressStart($"CorrelationId={correlationId} :: running pipeline template {templatePath}");
+
+        try
+        {
+            var template = LoadTemplate(templatePath);
+            var run = await _orchestrator.RunAsync(new PipelineExecutionRequest
+            {
+                RunId = runId,
+                ResumeRunId = resumeRunId,
+                ResumeFailedStages = resumeFailedStages,
+                Inputs = inputs,
+                Template = template
+            }, cancellationToken);
+
+            if (json)
+            {
+                _renderer.RenderJson(new
+                {
+                    ok = run.State == PipelineRunState.Completed,
+                    correlationId,
+                    data = new
+                    {
+                        runId = run.RunId,
+                        templateId = run.TemplateId,
+                        state = run.State.ToString(),
+                        startedAt = run.StartedAt,
+                        completedAt = run.CompletedAt,
+                        stages = run.StageRuns.Select(s => new
+                        {
+                            stageId = s.StageId,
+                            state = s.State.ToString(),
+                            attempt = s.Attempt,
+                            workerType = s.WorkerType?.ToString(),
+                            workerId = s.WorkerId,
+                            error = s.Error,
+                            output = s.Output
+                        })
+                    }
+                });
+            }
+            else
+            {
+                var success = run.State == PipelineRunState.Completed;
+                if (success)
+                    _renderer.RenderSuccess($"Pipeline run completed: {run.RunId}");
+                else
+                    _renderer.RenderError($"Pipeline run ended with state {run.State}: {run.RunId}");
+
+                foreach (var stage in run.StageRuns.OrderBy(s => s.StageId, StringComparer.Ordinal))
+                {
+                    var line = $"{stage.StageId}: {stage.State} (attempt={stage.Attempt}, worker={stage.WorkerType?.ToString() ?? "n/a"})";
+                    if (stage.State == PipelineStageRunState.Failed)
+                    {
+                        _renderer.RenderError($"  - {line} :: {stage.Error}");
+                    }
+                    else
+                    {
+                        _renderer.RenderSuccess($"  - {line}");
+                    }
+                }
+            }
+
+            if (verbose)
+                _renderer.RenderProgressComplete($"CorrelationId={correlationId} :: pipeline run finished");
+
+            return run.State == PipelineRunState.Completed
+                ? (int)ExitCode.Ok
+                : (int)ExitCode.ValidationFailed;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Pipeline run failed");
+            if (json)
+            {
+                _renderer.RenderJson(new { ok = false, correlationId, error = ex.Message });
+            }
+            else
+            {
+                _renderer.RenderError($"Pipeline run failed: {ex.Message}");
+            }
+            return (int)ExitCode.UnexpectedError;
+        }
+    }
+
+    private static PipelineTemplate LoadTemplate(string templatePath)
+    {
+        var fullPath = Path.GetFullPath(templatePath);
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException($"Template file not found: {fullPath}", fullPath);
+
+        var json = File.ReadAllText(fullPath);
+        var template = JsonSerializer.Deserialize<PipelineTemplate>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        });
+        if (template == null)
+            throw new InvalidOperationException("Template JSON could not be parsed.");
+
+        return template;
+    }
+}

--- a/src/Nexo.CLI/Program.cs
+++ b/src/Nexo.CLI/Program.cs
@@ -737,6 +737,64 @@ static class Program
             verboseOpt);
         root.AddCommand(orchestrateCmd);
 
+        // nexo pipeline
+        var pipelineCmd = new Command("pipeline", "Validate and run pipeline templates.");
+
+        var pipelineValidateCmd = new Command("validate", "Validate a pipeline template file.");
+        var pipelineValidateTemplateOpt = new Option<FileInfo>("--template", "Pipeline template JSON file") { IsRequired = true };
+        pipelineValidateCmd.AddOption(pipelineValidateTemplateOpt);
+        pipelineValidateCmd.SetHandler(
+            (FileInfo template, bool json, bool verbose) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<PipelineCommand>();
+                var exitCode = cmd.Validate(template.FullName, json, verbose);
+                Environment.Exit(exitCode);
+            },
+            pipelineValidateTemplateOpt,
+            jsonOpt,
+            verboseOpt);
+        pipelineCmd.AddCommand(pipelineValidateCmd);
+
+        var pipelineRunCmd = new Command("run", "Run a pipeline template file.");
+        var pipelineRunTemplateOpt = new Option<FileInfo>("--template", "Pipeline template JSON file") { IsRequired = true };
+        var pipelineRunIdOpt = new Option<string?>("--run-id", "Optional explicit run id");
+        var pipelineResumeRunIdOpt = new Option<string?>("--resume-run-id", "Optional prior run id to resume from");
+        var pipelineResumeFailedOpt = new Option<bool>("--resume-failed-stages", () => false, "Resume only failed stages from prior run");
+        var pipelineInputOpt = new Option<string[]>("--input", "Key/value input in key=value format")
+        {
+            AllowMultipleArgumentsPerToken = true
+        };
+        pipelineRunCmd.AddOption(pipelineRunTemplateOpt);
+        pipelineRunCmd.AddOption(pipelineRunIdOpt);
+        pipelineRunCmd.AddOption(pipelineResumeRunIdOpt);
+        pipelineRunCmd.AddOption(pipelineResumeFailedOpt);
+        pipelineRunCmd.AddOption(pipelineInputOpt);
+        pipelineRunCmd.SetHandler(
+            async (FileInfo template, string? runId, string? resumeRunId, bool resumeFailedStages, string[] rawInputs, bool json, bool verbose) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<PipelineCommand>();
+                var inputs = ParsePipelineInputs(rawInputs);
+                var exitCode = await cmd.RunAsync(
+                    templatePath: template.FullName,
+                    json: json,
+                    verbose: verbose,
+                    runId: runId,
+                    resumeRunId: resumeRunId,
+                    resumeFailedStages: resumeFailedStages,
+                    inputs: inputs,
+                    cancellationToken: CancellationToken.None);
+                Environment.Exit(exitCode);
+            },
+            pipelineRunTemplateOpt,
+            pipelineRunIdOpt,
+            pipelineResumeRunIdOpt,
+            pipelineResumeFailedOpt,
+            pipelineInputOpt,
+            jsonOpt,
+            verboseOpt);
+        pipelineCmd.AddCommand(pipelineRunCmd);
+        root.AddCommand(pipelineCmd);
+
         // nexo escalate (resolves lazily)
         var escalateCmd = new Command("escalate", "Manage escalations and conflicts");
         
@@ -995,6 +1053,7 @@ static class Program
         services.AddScoped<OrchestrateCommand>();
         services.AddScoped<EscalateCommand>();
         services.AddScoped<MetricsCommand>();
+        services.AddScoped<PipelineCommand>();
         services.AddScoped<MaintenanceCommand>();
         services.AddScoped<BackgroundAgentCommand>();
         services.AddScoped<Nexo.CLI.Commands.BackgroundAgent.ExecuteBackgroundAgentCommand>();
@@ -1028,5 +1087,31 @@ static class Program
             'd' or 'D' => TimeSpan.FromDays(value),
             _ => null
         };
+    }
+
+    private static IReadOnlyDictionary<string, string> ParsePipelineInputs(string[]? rawInputs)
+    {
+        var inputs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (rawInputs == null || rawInputs.Length == 0)
+            return inputs;
+
+        foreach (var raw in rawInputs)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                continue;
+
+            var index = raw.IndexOf('=');
+            if (index <= 0 || index == raw.Length - 1)
+                throw new ArgumentException($"Invalid --input '{raw}'. Expected key=value format.");
+
+            var key = raw[..index].Trim();
+            var value = raw[(index + 1)..].Trim();
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException($"Invalid --input '{raw}'. Key cannot be empty.");
+
+            inputs[key] = value;
+        }
+
+        return inputs;
     }
 }

--- a/src/Nexo.Core.Application/Pipelines/Models/PipelineDefinitions.cs
+++ b/src/Nexo.Core.Application/Pipelines/Models/PipelineDefinitions.cs
@@ -156,6 +156,7 @@ public sealed record PipelineStageRun
     public int Attempt { get; init; }
     public string? WorkerId { get; init; }
     public PipelineWorkerType? WorkerType { get; init; }
+    public string? Output { get; init; }
     public string? Error { get; init; }
 }
 

--- a/src/Nexo.Core.Application/Pipelines/Models/PipelineDefinitions.cs
+++ b/src/Nexo.Core.Application/Pipelines/Models/PipelineDefinitions.cs
@@ -1,0 +1,197 @@
+namespace Nexo.Core.Application.Pipelines.Models;
+
+/// <summary>
+/// Execution mode for a pipeline stage.
+/// </summary>
+public enum PipelineExecutionMode
+{
+    Deterministic,
+    Agentic,
+    Hybrid
+}
+
+/// <summary>
+/// Fan-in strategy for joining predecessor stage results.
+/// </summary>
+public enum PipelineJoinStrategy
+{
+    All,
+    FirstSuccess,
+    Quorum
+}
+
+/// <summary>
+/// Worker pool type targeted by dispatch.
+/// </summary>
+public enum PipelineWorkerType
+{
+    Deterministic,
+    Agentic
+}
+
+/// <summary>
+/// Logical type of a stage in the pipeline graph.
+/// </summary>
+public enum PipelineStageType
+{
+    Standard,
+    FanOut,
+    FanIn
+}
+
+/// <summary>
+/// Constraint set for an individual stage.
+/// </summary>
+public sealed record PipelineStageConstraints
+{
+    public int? MaxParallelism { get; init; }
+    public bool ForceSerialized { get; init; }
+    public bool Critical { get; init; }
+    public bool RequiresPostValidation { get; init; }
+}
+
+/// <summary>
+/// Optional worker routing hints per stage.
+/// </summary>
+public sealed record PipelineWorkerBinding
+{
+    public string? DeterministicPoolId { get; init; }
+    public string? AgenticPoolId { get; init; }
+}
+
+/// <summary>
+/// Declares one stage in a template.
+/// </summary>
+public sealed record PipelineStageDefinition
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public PipelineStageType StageType { get; init; } = PipelineStageType.Standard;
+    public PipelineExecutionMode Mode { get; init; } = PipelineExecutionMode.Deterministic;
+    public PipelineJoinStrategy? JoinStrategy { get; init; }
+    public int? QuorumCount { get; init; }
+    public IReadOnlyList<PipelineWorkerType> FallbackChain { get; init; } = Array.Empty<PipelineWorkerType>();
+    public PipelineStageConstraints Constraints { get; init; } = new();
+    public PipelineWorkerBinding WorkerBinding { get; init; } = new();
+}
+
+/// <summary>
+/// Directed edge between stage identifiers.
+/// </summary>
+public sealed record PipelineEdge(string FromStageId, string ToStageId);
+
+/// <summary>
+/// Immutable template describing a composable pipeline graph.
+/// </summary>
+public sealed record PipelineTemplate
+{
+    public string TemplateId { get; init; } = string.Empty;
+    public string Version { get; init; } = "1.0";
+    public IReadOnlyList<PipelineStageDefinition> Stages { get; init; } = Array.Empty<PipelineStageDefinition>();
+    public IReadOnlyList<PipelineEdge> Edges { get; init; } = Array.Empty<PipelineEdge>();
+}
+
+/// <summary>
+/// Materialized execution node from template decomposition.
+/// </summary>
+public sealed record PipelineExecutionNode
+{
+    public string StageId { get; init; } = string.Empty;
+    public PipelineExecutionMode Mode { get; init; }
+    public PipelineStageType StageType { get; init; }
+    public PipelineJoinStrategy? JoinStrategy { get; init; }
+    public int? QuorumCount { get; init; }
+    public IReadOnlyList<string> Predecessors { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> Successors { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<PipelineWorkerType> FallbackChain { get; init; } = Array.Empty<PipelineWorkerType>();
+}
+
+/// <summary>
+/// Executable graph for scheduling and dispatch.
+/// </summary>
+public sealed record PipelineExecutionGraph
+{
+    public string TemplateId { get; init; } = string.Empty;
+    public IReadOnlyList<PipelineExecutionNode> Nodes { get; init; } = Array.Empty<PipelineExecutionNode>();
+}
+
+/// <summary>
+/// Validation diagnostics for a template.
+/// </summary>
+public sealed record PipelineTemplateValidationResult
+{
+    public bool IsValid { get; init; }
+    public IReadOnlyList<string> Errors { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Runtime state of a pipeline run.
+/// </summary>
+public enum PipelineRunState
+{
+    Pending,
+    Running,
+    Completed,
+    Failed
+}
+
+/// <summary>
+/// Runtime state of a stage execution.
+/// </summary>
+public enum PipelineStageRunState
+{
+    Pending,
+    Running,
+    Completed,
+    Failed
+}
+
+/// <summary>
+/// Stage run state for persistence and diagnostics.
+/// </summary>
+public sealed record PipelineStageRun
+{
+    public string StageId { get; init; } = string.Empty;
+    public PipelineStageRunState State { get; init; } = PipelineStageRunState.Pending;
+    public int Attempt { get; init; }
+    public string? WorkerId { get; init; }
+    public PipelineWorkerType? WorkerType { get; init; }
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Pipeline run aggregate.
+/// </summary>
+public sealed record PipelineRun
+{
+    public string RunId { get; init; } = string.Empty;
+    public string TemplateId { get; init; } = string.Empty;
+    public PipelineRunState State { get; init; } = PipelineRunState.Pending;
+    public DateTimeOffset StartedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? CompletedAt { get; init; }
+    public IReadOnlyList<PipelineStageRun> StageRuns { get; init; } = Array.Empty<PipelineStageRun>();
+}
+
+/// <summary>
+/// Decision emitted by a scaling policy.
+/// </summary>
+public sealed record PipelineScalingDecision
+{
+    public int DeterministicWorkers { get; init; }
+    public int AgenticWorkers { get; init; }
+    public int? DeterministicMaxDegreeOfParallelism { get; init; }
+    public int? AgenticMaxDegreeOfParallelism { get; init; }
+}
+
+/// <summary>
+/// Snapshot for scaling policy input.
+/// </summary>
+public sealed record PipelineScalingSnapshot
+{
+    public int DeterministicQueueDepth { get; init; }
+    public int AgenticQueueDepth { get; init; }
+    public double DeterministicErrorRate { get; init; }
+    public double AgenticErrorRate { get; init; }
+    public int CurrentDeterministicWorkers { get; init; }
+    public int CurrentAgenticWorkers { get; init; }
+}

--- a/src/Nexo.Core.Application/Pipelines/Models/PipelineRuntimeModels.cs
+++ b/src/Nexo.Core.Application/Pipelines/Models/PipelineRuntimeModels.cs
@@ -1,0 +1,39 @@
+namespace Nexo.Core.Application.Pipelines.Models;
+
+/// <summary>
+/// Input request for executing or resuming a pipeline run.
+/// </summary>
+public sealed record PipelineExecutionRequest
+{
+    public string? RunId { get; init; }
+    public string? ResumeRunId { get; init; }
+    public bool ResumeFailedStages { get; init; }
+    public IReadOnlyDictionary<string, string> Inputs { get; init; } = new Dictionary<string, string>();
+    public required PipelineTemplate Template { get; init; }
+}
+
+/// <summary>
+/// Context payload passed to a stage executor.
+/// </summary>
+public sealed record PipelineStageExecutionRequest
+{
+    public required string RunId { get; init; }
+    public required string StageId { get; init; }
+    public required int Attempt { get; init; }
+    public required PipelineWorkerType WorkerType { get; init; }
+    public required PipelineStageDefinition Stage { get; init; }
+    public required PipelineExecutionNode Node { get; init; }
+    public IReadOnlyDictionary<string, string> Inputs { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Normalized output from a stage executor.
+/// </summary>
+public sealed record PipelineStageExecutionResult
+{
+    public bool Succeeded { get; init; }
+    public bool Retryable { get; init; } = true;
+    public string? WorkerId { get; init; }
+    public string? Output { get; init; }
+    public string? Error { get; init; }
+}

--- a/src/Nexo.Core.Application/Pipelines/Ports/IPipelineContracts.cs
+++ b/src/Nexo.Core.Application/Pipelines/Ports/IPipelineContracts.cs
@@ -44,3 +44,25 @@ public interface IPipelineScalingPolicy
 {
     PipelineScalingDecision Evaluate(PipelineScalingSnapshot snapshot);
 }
+
+/// <summary>
+/// Executes one stage against an underlying worker implementation.
+/// </summary>
+public interface IPipelineStageExecutor
+{
+    PipelineWorkerType WorkerType { get; }
+
+    Task<PipelineStageExecutionResult> ExecuteAsync(
+        PipelineStageExecutionRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Orchestrates full lifecycle execution for pipeline templates.
+/// </summary>
+public interface IPipelineOrchestrator
+{
+    Task<PipelineRun> RunAsync(
+        PipelineExecutionRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/Pipelines/Ports/IPipelineContracts.cs
+++ b/src/Nexo.Core.Application/Pipelines/Ports/IPipelineContracts.cs
@@ -1,0 +1,46 @@
+using Nexo.Core.Application.Pipelines.Models;
+
+namespace Nexo.Core.Application.Pipelines.Ports;
+
+/// <summary>
+/// Validates pipeline templates and returns diagnostics.
+/// </summary>
+public interface IPipelineTemplateValidator
+{
+    PipelineTemplateValidationResult Validate(PipelineTemplate template);
+}
+
+/// <summary>
+/// Decomposes a validated template into an execution graph.
+/// </summary>
+public interface IPipelineDecomposer
+{
+    PipelineExecutionGraph Decompose(PipelineTemplate template);
+}
+
+/// <summary>
+/// Evaluates whether a stage can be scheduled based on predecessor state.
+/// </summary>
+public interface IPipelineScheduler
+{
+    IReadOnlyList<string> GetReadyStages(
+        PipelineExecutionGraph graph,
+        IReadOnlyDictionary<string, PipelineStageRunState> states);
+}
+
+/// <summary>
+/// Persists pipeline runs for diagnostics and recovery.
+/// </summary>
+public interface IPipelineRunStore
+{
+    Task SaveAsync(PipelineRun run, CancellationToken cancellationToken = default);
+    Task<PipelineRun?> GetAsync(string runId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Produces scaling decisions for deterministic and agentic worker pools.
+/// </summary>
+public interface IPipelineScalingPolicy
+{
+    PipelineScalingDecision Evaluate(PipelineScalingSnapshot snapshot);
+}

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Nexo.Infrastructure.Execution;
 using Nexo.Infrastructure.Execution.Ephemeral;
 using Nexo.Infrastructure.Execution.LoadPolicy;
 using Nexo.Infrastructure.Maintenance;
+using Nexo.Infrastructure.Pipelines;
 using Nexo.Infrastructure.Persistence.Ephemeral;
 using Nexo.Infrastructure.Persistence;
 using Nexo.Orchestration;
@@ -77,6 +78,7 @@ public static class NexoServiceCollectionExtensions
         services.AddNexoOrchestration();
         services.AddNexoPersistence();
         services.AddAdaptationInfrastructure(options.PatternStorePath);
+        services.AddPipelineCompositionLayer();
         services.AddBackgroundAgents(registerHostedService: options.RegisterBackgroundAgentHostedService);
         services.AddBackgroundAgentsRAG();
         if (!options.DisableObservationPipeline)

--- a/src/Nexo.Infrastructure/Pipelines/AgenticPipelineStageExecutor.cs
+++ b/src/Nexo.Infrastructure/Pipelines/AgenticPipelineStageExecutor.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Executes agentic stages.
+/// </summary>
+public sealed class AgenticPipelineStageExecutor : IPipelineStageExecutor
+{
+    private readonly ILogger<AgenticPipelineStageExecutor> _logger;
+
+    public AgenticPipelineStageExecutor(ILogger<AgenticPipelineStageExecutor> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public PipelineWorkerType WorkerType => PipelineWorkerType.Agentic;
+
+    public Task<PipelineStageExecutionResult> ExecuteAsync(
+        PipelineStageExecutionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        // Test hook to force agentic stage failures.
+        var fail = ShouldFail(request, "agentic");
+        if (fail)
+        {
+            _logger.LogWarning("Agentic stage {StageId} failed by test hook.", request.StageId);
+            return Task.FromResult(new PipelineStageExecutionResult
+            {
+                Succeeded = false,
+                Retryable = true,
+                WorkerId = "agentic-default",
+                Error = "Agentic execution failed (test hook)."
+            });
+        }
+
+        _logger.LogInformation("Agentic stage {StageId} completed.", request.StageId);
+        return Task.FromResult(new PipelineStageExecutionResult
+        {
+            Succeeded = true,
+            Retryable = false,
+            WorkerId = "agentic-default",
+            Output = $"agentic:{request.StageId}:ok"
+        });
+    }
+
+    private static bool ShouldFail(PipelineStageExecutionRequest request, string worker)
+    {
+        if (!request.Inputs.TryGetValue($"fail:{request.StageId}:{worker}", out var shouldFail))
+            return false;
+
+        if (bool.TryParse(shouldFail, out var parsed))
+            return parsed;
+
+        return string.Equals(shouldFail, "1", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/DeterministicPipelineStageExecutor.cs
+++ b/src/Nexo.Infrastructure/Pipelines/DeterministicPipelineStageExecutor.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Executes deterministic stages.
+/// </summary>
+public sealed class DeterministicPipelineStageExecutor : IPipelineStageExecutor
+{
+    private readonly ILogger<DeterministicPipelineStageExecutor> _logger;
+
+    public DeterministicPipelineStageExecutor(ILogger<DeterministicPipelineStageExecutor> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public PipelineWorkerType WorkerType => PipelineWorkerType.Deterministic;
+
+    public Task<PipelineStageExecutionResult> ExecuteAsync(
+        PipelineStageExecutionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        // Test hook to force deterministic stage failures.
+        var fail = ShouldFail(request, "deterministic");
+        if (fail)
+        {
+            _logger.LogWarning("Deterministic stage {StageId} failed by test hook.", request.StageId);
+            return Task.FromResult(new PipelineStageExecutionResult
+            {
+                Succeeded = false,
+                Retryable = true,
+                WorkerId = "deterministic-default",
+                Error = "Deterministic execution failed (test hook)."
+            });
+        }
+
+        _logger.LogInformation("Deterministic stage {StageId} completed.", request.StageId);
+        return Task.FromResult(new PipelineStageExecutionResult
+        {
+            Succeeded = true,
+            Retryable = false,
+            WorkerId = "deterministic-default",
+            Output = $"deterministic:{request.StageId}:ok"
+        });
+    }
+
+    private static bool ShouldFail(PipelineStageExecutionRequest request, string worker)
+    {
+        if (!request.Inputs.TryGetValue($"fail:{request.StageId}:{worker}", out var shouldFail))
+            return false;
+
+        if (bool.TryParse(shouldFail, out var parsed))
+            return parsed;
+
+        return string.Equals(shouldFail, "1", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/InMemoryPipelineRunStore.cs
+++ b/src/Nexo.Infrastructure/Pipelines/InMemoryPipelineRunStore.cs
@@ -1,0 +1,27 @@
+using System.Collections.Concurrent;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Simple in-memory run store for pipeline execution tests and local runtime.
+/// </summary>
+public sealed class InMemoryPipelineRunStore : IPipelineRunStore
+{
+    private readonly ConcurrentDictionary<string, PipelineRun> _runs = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task SaveAsync(PipelineRun run, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _runs[run.RunId] = run;
+        return Task.CompletedTask;
+    }
+
+    public Task<PipelineRun?> GetAsync(string runId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _runs.TryGetValue(runId, out var run);
+        return Task.FromResult(run);
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/LiteDbPipelineRunStore.cs
+++ b/src/Nexo.Infrastructure/Pipelines/LiteDbPipelineRunStore.cs
@@ -1,0 +1,135 @@
+using LiteDB;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Durable LiteDB-backed pipeline run store.
+/// </summary>
+public sealed class LiteDbPipelineRunStore : IPipelineRunStore
+{
+    private const string CollectionName = "pipeline_runs";
+    private readonly string _databasePath;
+    private readonly object _gate = new();
+
+    public LiteDbPipelineRunStore(string databasePath)
+    {
+        if (string.IsNullOrWhiteSpace(databasePath))
+            throw new ArgumentException("Database path is required.", nameof(databasePath));
+        _databasePath = databasePath;
+    }
+
+    public Task SaveAsync(PipelineRun run, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (run == null) throw new ArgumentNullException(nameof(run));
+
+        lock (_gate)
+        {
+            using var db = new LiteDatabase(_databasePath);
+            var col = db.GetCollection<PipelineRunDocument>(CollectionName);
+            col.EnsureIndex(x => x.RunId, unique: true);
+            col.Upsert(ToDocument(run));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<PipelineRun?> GetAsync(string runId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(runId))
+            throw new ArgumentException("Run id is required.", nameof(runId));
+
+        PipelineRun? run = null;
+        lock (_gate)
+        {
+            using var db = new LiteDatabase(_databasePath);
+            var col = db.GetCollection<PipelineRunDocument>(CollectionName);
+            var doc = col.FindById(runId);
+            if (doc != null)
+                run = FromDocument(doc);
+        }
+
+        return Task.FromResult(run);
+    }
+
+    private static PipelineRunDocument ToDocument(PipelineRun run)
+    {
+        return new PipelineRunDocument
+        {
+            RunId = run.RunId,
+            TemplateId = run.TemplateId,
+            State = run.State.ToString(),
+            StartedAt = run.StartedAt,
+            CompletedAt = run.CompletedAt,
+            StageRuns = run.StageRuns.Select(stage => new PipelineStageRunDocument
+            {
+                StageId = stage.StageId,
+                State = stage.State.ToString(),
+                Attempt = stage.Attempt,
+                WorkerId = stage.WorkerId,
+                WorkerType = stage.WorkerType?.ToString(),
+                Output = stage.Output,
+                Error = stage.Error
+            }).ToList()
+        };
+    }
+
+    private static PipelineRun FromDocument(PipelineRunDocument doc)
+    {
+        return new PipelineRun
+        {
+            RunId = doc.RunId,
+            TemplateId = doc.TemplateId,
+            State = ParseEnum<PipelineRunState>(doc.State, PipelineRunState.Pending),
+            StartedAt = doc.StartedAt,
+            CompletedAt = doc.CompletedAt,
+            StageRuns = doc.StageRuns.Select(stage => new PipelineStageRun
+            {
+                StageId = stage.StageId,
+                State = ParseEnum<PipelineStageRunState>(stage.State, PipelineStageRunState.Pending),
+                Attempt = stage.Attempt,
+                WorkerId = stage.WorkerId,
+                WorkerType = string.IsNullOrWhiteSpace(stage.WorkerType)
+                    ? null
+                    : ParseEnum<PipelineWorkerType>(stage.WorkerType, PipelineWorkerType.Deterministic),
+                Output = stage.Output,
+                Error = stage.Error
+            }).ToArray()
+        };
+    }
+
+    private static TEnum ParseEnum<TEnum>(string? value, TEnum fallback) where TEnum : struct
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed)
+            ? parsed
+            : fallback;
+    }
+
+    private sealed class PipelineRunDocument
+    {
+        [BsonId]
+        public string RunId { get; set; } = string.Empty;
+        public string TemplateId { get; set; } = string.Empty;
+        public string State { get; set; } = string.Empty;
+        public DateTimeOffset StartedAt { get; set; }
+        public DateTimeOffset? CompletedAt { get; set; }
+        public List<PipelineStageRunDocument> StageRuns { get; set; } = new();
+    }
+
+    private sealed class PipelineStageRunDocument
+    {
+        public string StageId { get; set; } = string.Empty;
+        public string State { get; set; } = string.Empty;
+        public int Attempt { get; set; }
+        public string? WorkerId { get; set; }
+        public string? WorkerType { get; set; }
+        public string? Output { get; set; }
+        public string? Error { get; set; }
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/PipelineDecomposer.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelineDecomposer.cs
@@ -1,0 +1,58 @@
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Decomposes templates into executable DAG nodes.
+/// </summary>
+public sealed class PipelineDecomposer : IPipelineDecomposer
+{
+    private readonly IPipelineTemplateValidator _validator;
+
+    public PipelineDecomposer(IPipelineTemplateValidator validator)
+    {
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+    }
+
+    public PipelineExecutionGraph Decompose(PipelineTemplate template)
+    {
+        var validation = _validator.Validate(template);
+        if (!validation.IsValid)
+            throw new InvalidOperationException($"Template validation failed: {string.Join("; ", validation.Errors)}");
+
+        var predecessors = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        var successors = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var stage in template.Stages)
+        {
+            predecessors[stage.Id] = new List<string>();
+            successors[stage.Id] = new List<string>();
+        }
+
+        foreach (var edge in template.Edges)
+        {
+            predecessors[edge.ToStageId].Add(edge.FromStageId);
+            successors[edge.FromStageId].Add(edge.ToStageId);
+        }
+
+        var nodes = template.Stages.Select(stage => new PipelineExecutionNode
+        {
+            StageId = stage.Id,
+            Mode = stage.Mode,
+            StageType = stage.StageType,
+            JoinStrategy = stage.JoinStrategy,
+            QuorumCount = stage.QuorumCount,
+            Predecessors = predecessors[stage.Id],
+            Successors = successors[stage.Id],
+            FallbackChain = stage.Mode == PipelineExecutionMode.Hybrid
+                ? stage.FallbackChain
+                : Array.Empty<PipelineWorkerType>()
+        }).ToList();
+
+        return new PipelineExecutionGraph
+        {
+            TemplateId = template.TemplateId,
+            Nodes = nodes
+        };
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/PipelineExecutionOptions.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelineExecutionOptions.cs
@@ -1,0 +1,27 @@
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Runtime controls for pipeline execution behavior.
+/// </summary>
+public sealed class PipelineExecutionOptions
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string SectionName = "Nexo:Pipelines:Execution";
+
+    /// <summary>
+    /// Maximum retry attempts for failed stages.
+    /// </summary>
+    public int MaxRetryAttempts { get; set; } = 2;
+
+    /// <summary>
+    /// Delay in milliseconds before retrying a failed stage.
+    /// </summary>
+    public int RetryDelayMs { get; set; } = 100;
+
+    /// <summary>
+    /// Whether failed stages should be resumed from a prior run.
+    /// </summary>
+    public bool ResumeFailedStages { get; set; } = true;
+}

--- a/src/Nexo.Infrastructure/Pipelines/PipelineOrchestrator.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelineOrchestrator.cs
@@ -1,0 +1,438 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Default orchestrator for template-driven pipeline execution.
+/// </summary>
+public sealed class PipelineOrchestrator : IPipelineOrchestrator
+{
+    private readonly IPipelineTemplateValidator _validator;
+    private readonly IPipelineDecomposer _decomposer;
+    private readonly IPipelineScheduler _scheduler;
+    private readonly IPipelineRunStore _runStore;
+    private readonly IPipelineScalingPolicy _scalingPolicy;
+    private readonly IReadOnlyDictionary<PipelineWorkerType, IPipelineStageExecutor> _executorsByType;
+    private readonly PipelineExecutionOptions _options;
+    private readonly ILogger<PipelineOrchestrator> _logger;
+
+    public PipelineOrchestrator(
+        IPipelineTemplateValidator validator,
+        IPipelineDecomposer decomposer,
+        IPipelineScheduler scheduler,
+        IPipelineRunStore runStore,
+        IPipelineScalingPolicy scalingPolicy,
+        IEnumerable<IPipelineStageExecutor> executors,
+        IOptions<PipelineExecutionOptions> options,
+        ILogger<PipelineOrchestrator> logger)
+    {
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+        _decomposer = decomposer ?? throw new ArgumentNullException(nameof(decomposer));
+        _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+        _runStore = runStore ?? throw new ArgumentNullException(nameof(runStore));
+        _scalingPolicy = scalingPolicy ?? throw new ArgumentNullException(nameof(scalingPolicy));
+        _executorsByType = (executors ?? throw new ArgumentNullException(nameof(executors)))
+            .GroupBy(x => x.WorkerType)
+            .ToDictionary(g => g.Key, g => g.First());
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PipelineRun> RunAsync(
+        PipelineExecutionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var validation = _validator.Validate(request.Template);
+        if (!validation.IsValid)
+            throw new InvalidOperationException($"Pipeline template invalid: {string.Join("; ", validation.Errors)}");
+
+        var graph = _decomposer.Decompose(request.Template);
+        var runId = string.IsNullOrWhiteSpace(request.RunId) ? Guid.NewGuid().ToString("N") : request.RunId!;
+        var allowResume = !string.IsNullOrWhiteSpace(request.ResumeRunId);
+        var resumeFailed = request.ResumeFailedStages || _options.ResumeFailedStages;
+        var stageStates = graph.Nodes.ToDictionary(n => n.StageId, _ => PipelineStageRunState.Pending, StringComparer.Ordinal);
+        var stageAttempts = graph.Nodes.ToDictionary(n => n.StageId, _ => 0, StringComparer.Ordinal);
+        var stageRuns = graph.Nodes.ToDictionary(
+            n => n.StageId,
+            n => new PipelineStageRun
+            {
+                StageId = n.StageId,
+                State = PipelineStageRunState.Pending,
+                Attempt = 0
+            },
+            StringComparer.Ordinal);
+
+        if (allowResume)
+            await TryHydrateFromPriorRunAsync(request, graph, stageStates, stageAttempts, stageRuns, resumeFailed, cancellationToken);
+
+        var stageDefinitionsById = request.Template.Stages
+            .ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
+
+        var run = new PipelineRun
+        {
+            RunId = runId,
+            TemplateId = request.Template.TemplateId,
+            State = PipelineRunState.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+            StageRuns = stageRuns.Values.ToArray()
+        };
+
+        await _runStore.SaveAsync(run, cancellationToken);
+        _logger.LogInformation("Pipeline run {RunId} started for template {TemplateId}.", run.RunId, run.TemplateId);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (stageStates.Values.All(s => s == PipelineStageRunState.Completed))
+            {
+                run = FinalizeRun(run, PipelineRunState.Completed, stageRuns);
+                await _runStore.SaveAsync(run, cancellationToken);
+                _logger.LogInformation("Pipeline run {RunId} completed successfully.", run.RunId);
+                return run;
+            }
+
+            if (IsTerminalWithoutPending(stageStates))
+            {
+                var hasCriticalFailure = stageRuns.Values.Any(stageRun =>
+                    stageRun.State == PipelineStageRunState.Failed &&
+                    stageDefinitionsById.TryGetValue(stageRun.StageId, out var stageDefinition) &&
+                    stageDefinition.Constraints.Critical);
+
+                var terminalState = hasCriticalFailure ? PipelineRunState.Failed : PipelineRunState.Completed;
+                run = FinalizeRun(run, terminalState, stageRuns);
+                await _runStore.SaveAsync(run, cancellationToken);
+                _logger.LogInformation(
+                    "Pipeline run {RunId} reached terminal state {State}.",
+                    run.RunId,
+                    terminalState);
+                return run;
+            }
+
+            var readyStageIds = _scheduler.GetReadyStages(graph, stageStates);
+            if (readyStageIds.Count == 0)
+            {
+                run = FinalizeRun(run, PipelineRunState.Failed, stageRuns);
+                await _runStore.SaveAsync(run, cancellationToken);
+                _logger.LogWarning("Pipeline run {RunId} stalled with no ready stages.", run.RunId);
+                return run;
+            }
+
+            foreach (var stageId in readyStageIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var node = graph.Nodes.Single(n => n.StageId == stageId);
+                var stage = request.Template.Stages.Single(s => s.Id.Equals(stageId, StringComparison.OrdinalIgnoreCase));
+
+                if (!CanStageExecute(node, stageStates))
+                    continue;
+
+                stageStates[stageId] = PipelineStageRunState.Running;
+                run = UpdateRun(run, stageRuns, PipelineRunState.Running);
+                await _runStore.SaveAsync(run, cancellationToken);
+
+                var execution = await ExecuteWithRetryAndFallbackAsync(
+                    runId,
+                    stage,
+                    node,
+                    request.Inputs,
+                    stageAttempts,
+                    cancellationToken);
+
+                stageRuns[stageId] = new PipelineStageRun
+                {
+                    StageId = stageId,
+                    State = execution.Succeeded ? PipelineStageRunState.Completed : PipelineStageRunState.Failed,
+                    Attempt = stageAttempts[stageId],
+                    WorkerId = execution.WorkerId,
+                    WorkerType = execution.WorkerType,
+                    Output = execution.Output,
+                    Error = execution.Error
+                };
+                stageStates[stageId] = stageRuns[stageId].State;
+
+                _logger.LogInformation(
+                    "Pipeline stage {StageId} completed with state {State} on worker {WorkerType}.",
+                    stageId,
+                    stageRuns[stageId].State,
+                    stageRuns[stageId].WorkerType);
+
+                if (stageRuns[stageId].State == PipelineStageRunState.Failed && stage.Constraints.Critical)
+                {
+                    run = FinalizeRun(run, PipelineRunState.Failed, stageRuns);
+                    await _runStore.SaveAsync(run, cancellationToken);
+                    _logger.LogWarning("Critical stage {StageId} failed; run {RunId} is failing fast.", stageId, run.RunId);
+                    return run;
+                }
+            }
+
+            var scaleSnapshot = BuildScalingSnapshot(stageRuns.Values);
+            var scaleDecision = _scalingPolicy.Evaluate(scaleSnapshot);
+            _logger.LogDebug(
+                "Pipeline scaling decision: deterministic={DeterministicWorkers}, agentic={AgenticWorkers}.",
+                scaleDecision.DeterministicWorkers,
+                scaleDecision.AgenticWorkers);
+
+            run = UpdateRun(run, stageRuns, PipelineRunState.Running);
+            await _runStore.SaveAsync(run, cancellationToken);
+        }
+    }
+
+    private async Task TryHydrateFromPriorRunAsync(
+        PipelineExecutionRequest request,
+        PipelineExecutionGraph graph,
+        IDictionary<string, PipelineStageRunState> stageStates,
+        IDictionary<string, int> stageAttempts,
+        IDictionary<string, PipelineStageRun> stageRuns,
+        bool resumeFailed,
+        CancellationToken cancellationToken)
+    {
+        var prior = await _runStore.GetAsync(request.ResumeRunId!, cancellationToken);
+        if (prior == null)
+        {
+            _logger.LogWarning("Resume requested for run {RunId}, but no prior run was found.", request.ResumeRunId);
+            return;
+        }
+
+        foreach (var stage in prior.StageRuns)
+        {
+            if (!stageStates.ContainsKey(stage.StageId))
+                continue;
+
+            var canCarryForward = stage.State == PipelineStageRunState.Completed ||
+                                  (resumeFailed && stage.State == PipelineStageRunState.Failed);
+
+            if (!canCarryForward)
+                continue;
+
+            var carriedState = stage.State == PipelineStageRunState.Failed
+                ? PipelineStageRunState.Pending
+                : stage.State;
+            stageStates[stage.StageId] = carriedState;
+            stageAttempts[stage.StageId] = stage.Attempt;
+            stageRuns[stage.StageId] = stage with { State = carriedState };
+        }
+
+        // Ensure unknown graph stages are reset to pending.
+        foreach (var node in graph.Nodes)
+        {
+            if (!stageRuns.ContainsKey(node.StageId))
+            {
+                stageRuns[node.StageId] = new PipelineStageRun
+                {
+                    StageId = node.StageId,
+                    State = PipelineStageRunState.Pending,
+                    Attempt = 0
+                };
+            }
+        }
+    }
+
+    private bool CanStageExecute(
+        PipelineExecutionNode node,
+        IReadOnlyDictionary<string, PipelineStageRunState> states)
+    {
+        if (node.Predecessors.Count == 0)
+            return true;
+
+        var predecessorStates = new List<PipelineStageRunState>(node.Predecessors.Count);
+        foreach (var predecessor in node.Predecessors)
+        {
+            if (!states.TryGetValue(predecessor, out var predecessorState))
+                return false;
+            predecessorStates.Add(predecessorState);
+        }
+
+        if (node.StageType == PipelineStageType.FanIn)
+        {
+            var completed = predecessorStates.Count(x => x == PipelineStageRunState.Completed);
+            if (node.JoinStrategy == PipelineJoinStrategy.FirstSuccess)
+                return completed >= 1;
+            if (node.JoinStrategy == PipelineJoinStrategy.Quorum)
+                return node.QuorumCount.GetValueOrDefault(0) > 0 && completed >= node.QuorumCount.GetValueOrDefault(0);
+        }
+
+        return predecessorStates.All(x => x == PipelineStageRunState.Completed);
+    }
+
+    private async Task<ExecutionOutcome> ExecuteWithRetryAndFallbackAsync(
+        string runId,
+        PipelineStageDefinition stage,
+        PipelineExecutionNode node,
+        IReadOnlyDictionary<string, string> inputs,
+        IDictionary<string, int> stageAttempts,
+        CancellationToken cancellationToken)
+    {
+        var chain = ResolveWorkerChain(stage);
+        if (chain.Count == 0)
+        {
+            return new ExecutionOutcome
+            {
+                Succeeded = false,
+                Error = $"No worker chain available for stage {stage.Id}."
+            };
+        }
+
+        for (var chainIndex = 0; chainIndex < chain.Count; chainIndex++)
+        {
+            var workerType = chain[chainIndex];
+            if (!_executorsByType.TryGetValue(workerType, out var executor))
+            {
+                continue;
+            }
+
+            var maxAttempts = Math.Max(1, _options.MaxRetryAttempts);
+            for (var localAttempt = 1; localAttempt <= maxAttempts; localAttempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                stageAttempts[stage.Id] = stageAttempts[stage.Id] + 1;
+                var globalAttempt = stageAttempts[stage.Id];
+
+                _logger.LogDebug(
+                    "Executing stage {StageId} attempt {Attempt} on {WorkerType}.",
+                    stage.Id,
+                    globalAttempt,
+                    workerType);
+
+                var result = await executor.ExecuteAsync(new PipelineStageExecutionRequest
+                {
+                    RunId = runId,
+                    StageId = stage.Id,
+                    Attempt = globalAttempt,
+                    WorkerType = workerType,
+                    Stage = stage,
+                    Node = node,
+                    Inputs = inputs
+                }, cancellationToken);
+
+                if (result.Succeeded)
+                {
+                    return new ExecutionOutcome
+                    {
+                        Succeeded = true,
+                        WorkerId = result.WorkerId,
+                        WorkerType = workerType,
+                        Output = result.Output
+                    };
+                }
+
+                var isLastAttempt = localAttempt >= maxAttempts;
+                if (!result.Retryable || isLastAttempt)
+                {
+                    if (chainIndex < chain.Count - 1)
+                    {
+                        _logger.LogInformation(
+                            "Stage {StageId} failed on {WorkerType}; falling back to {FallbackWorkerType}.",
+                            stage.Id,
+                            workerType,
+                            chain[chainIndex + 1]);
+                        break;
+                    }
+
+                    return new ExecutionOutcome
+                    {
+                        Succeeded = false,
+                        WorkerId = result.WorkerId,
+                        WorkerType = workerType,
+                        Error = result.Error ?? $"Stage {stage.Id} failed."
+                    };
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(Math.Max(0, _options.RetryDelayMs)), cancellationToken);
+            }
+        }
+
+        return new ExecutionOutcome
+        {
+            Succeeded = false,
+            Error = $"Stage {stage.Id} exhausted retries and fallback chain."
+        };
+    }
+
+    private IReadOnlyList<PipelineWorkerType> ResolveWorkerChain(PipelineStageDefinition stage)
+    {
+        if (stage.Mode == PipelineExecutionMode.Deterministic)
+            return new[] { PipelineWorkerType.Deterministic };
+        if (stage.Mode == PipelineExecutionMode.Agentic)
+            return new[] { PipelineWorkerType.Agentic };
+
+        if (stage.FallbackChain.Count > 0)
+            return stage.FallbackChain;
+
+        return new[] { PipelineWorkerType.Deterministic, PipelineWorkerType.Agentic };
+    }
+
+    private static PipelineScalingSnapshot BuildScalingSnapshot(IEnumerable<PipelineStageRun> stages)
+    {
+        var list = stages.ToList();
+        var deterministicPending = list.Count(x => x.State == PipelineStageRunState.Pending && x.WorkerType != PipelineWorkerType.Agentic);
+        var agenticPending = list.Count(x => x.State == PipelineStageRunState.Pending && x.WorkerType == PipelineWorkerType.Agentic);
+        var deterministicCompleted = list.Count(x => x.WorkerType != PipelineWorkerType.Agentic && x.State == PipelineStageRunState.Completed);
+        var deterministicFailed = list.Count(x => x.WorkerType != PipelineWorkerType.Agentic && x.State == PipelineStageRunState.Failed);
+        var agenticCompleted = list.Count(x => x.WorkerType == PipelineWorkerType.Agentic && x.State == PipelineStageRunState.Completed);
+        var agenticFailed = list.Count(x => x.WorkerType == PipelineWorkerType.Agentic && x.State == PipelineStageRunState.Failed);
+
+        var deterministicTotal = Math.Max(1, deterministicCompleted + deterministicFailed);
+        var agenticTotal = Math.Max(1, agenticCompleted + agenticFailed);
+
+        return new PipelineScalingSnapshot
+        {
+            DeterministicQueueDepth = deterministicPending,
+            AgenticQueueDepth = agenticPending,
+            DeterministicErrorRate = (double)deterministicFailed / deterministicTotal,
+            AgenticErrorRate = (double)agenticFailed / agenticTotal,
+            CurrentDeterministicWorkers = Math.Max(1, deterministicCompleted + deterministicPending),
+            CurrentAgenticWorkers = Math.Max(1, agenticCompleted + agenticPending)
+        };
+    }
+
+    private static PipelineRun UpdateRun(
+        PipelineRun current,
+        IReadOnlyDictionary<string, PipelineStageRun> stageRuns,
+        PipelineRunState state)
+    {
+        return current with
+        {
+            State = state,
+            StageRuns = stageRuns.Values.OrderBy(x => x.StageId, StringComparer.Ordinal).ToArray()
+        };
+    }
+
+    private static PipelineRun FinalizeRun(
+        PipelineRun current,
+        PipelineRunState state,
+        IReadOnlyDictionary<string, PipelineStageRun> stageRuns)
+    {
+        return current with
+        {
+            State = state,
+            CompletedAt = DateTimeOffset.UtcNow,
+            StageRuns = stageRuns.Values.OrderBy(x => x.StageId, StringComparer.Ordinal).ToArray()
+        };
+    }
+
+    private static bool IsTerminalWithoutPending(IReadOnlyDictionary<string, PipelineStageRunState> stageStates)
+    {
+        foreach (var state in stageStates.Values)
+        {
+            if (state == PipelineStageRunState.Pending || state == PipelineStageRunState.Running)
+                return false;
+        }
+
+        return true;
+    }
+
+    private sealed record ExecutionOutcome
+    {
+        public bool Succeeded { get; init; }
+        public string? WorkerId { get; init; }
+        public PipelineWorkerType? WorkerType { get; init; }
+        public string? Output { get; init; }
+        public string? Error { get; init; }
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/PipelinePersistenceOptions.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelinePersistenceOptions.cs
@@ -1,0 +1,22 @@
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Persistence strategy for pipeline runs.
+/// </summary>
+public sealed class PipelinePersistenceOptions
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string SectionName = "Nexo:Pipelines:Persistence";
+
+    /// <summary>
+    /// Provider name: InMemory or LiteDb.
+    /// </summary>
+    public string Provider { get; set; } = "InMemory";
+
+    /// <summary>
+    /// Path used by durable providers.
+    /// </summary>
+    public string DatabasePath { get; set; } = "nexo-pipeline-runs.db";
+}

--- a/src/Nexo.Infrastructure/Pipelines/PipelineScheduler.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelineScheduler.cs
@@ -1,0 +1,69 @@
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Resolves stages that are ready to execute based on predecessor completion state.
+/// </summary>
+public sealed class PipelineScheduler : IPipelineScheduler
+{
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetReadyStages(
+        PipelineExecutionGraph graph,
+        IReadOnlyDictionary<string, PipelineStageRunState> states)
+    {
+        if (graph == null)
+            throw new ArgumentNullException(nameof(graph));
+        if (states == null)
+            throw new ArgumentNullException(nameof(states));
+
+        var ready = new List<string>();
+        var byId = graph.Nodes.ToDictionary(n => n.StageId, StringComparer.Ordinal);
+
+        foreach (var node in graph.Nodes)
+        {
+            if (!states.TryGetValue(node.StageId, out var current) || current != PipelineStageRunState.Pending)
+                continue;
+
+            if (node.Predecessors.Count == 0)
+            {
+                ready.Add(node.StageId);
+                continue;
+            }
+
+            var predecessorStates = node.Predecessors
+                .Where(p => byId.ContainsKey(p))
+                .Select(p => states.TryGetValue(p, out var s) ? s : PipelineStageRunState.Pending)
+                .ToList();
+
+            if (node.StageType == PipelineStageType.FanIn)
+            {
+                if (IsFanInReady(node, predecessorStates))
+                    ready.Add(node.StageId);
+                continue;
+            }
+
+            if (predecessorStates.All(s => s == PipelineStageRunState.Completed))
+                ready.Add(node.StageId);
+        }
+
+        return ready;
+    }
+
+    private static bool IsFanInReady(PipelineExecutionNode node, IReadOnlyList<PipelineStageRunState> predecessorStates)
+    {
+        var completed = predecessorStates.Count(s => s == PipelineStageRunState.Completed);
+
+        if (node.JoinStrategy == PipelineJoinStrategy.FirstSuccess)
+            return completed >= 1;
+
+        if (node.JoinStrategy == PipelineJoinStrategy.Quorum)
+        {
+            var quorum = node.QuorumCount.GetValueOrDefault(0);
+            return quorum > 0 && completed >= quorum;
+        }
+
+        return predecessorStates.All(s => s == PipelineStageRunState.Completed);
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/PipelineServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelineServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Registers pipeline composition layer services.
+/// </summary>
+public static class PipelineServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds default pipeline composition services.
+    /// </summary>
+    public static IServiceCollection AddPipelineCompositionLayer(this IServiceCollection services)
+    {
+        services.TryAddSingleton<IPipelineTemplateValidator, PipelineTemplateValidator>();
+        services.TryAddSingleton<IPipelineDecomposer, PipelineDecomposer>();
+        services.TryAddSingleton<IPipelineScheduler, PipelineScheduler>();
+        services.TryAddSingleton<IPipelineScalingPolicy, ThresholdScalingPolicy>();
+        services.TryAddSingleton<IPipelineRunStore, InMemoryPipelineRunStore>();
+        return services;
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/PipelineServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelineServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Nexo.Core.Application.Pipelines.Ports;
 
 namespace Nexo.Infrastructure.Pipelines;
@@ -14,11 +15,61 @@ public static class PipelineServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddPipelineCompositionLayer(this IServiceCollection services)
     {
+        services.AddOptions<PipelineExecutionOptions>();
+        services.Configure<PipelineExecutionOptions>(opts =>
+        {
+            if (int.TryParse(Environment.GetEnvironmentVariable("NEXO_PIPELINE_MAX_RETRIES"), out var retries) && retries >= 1)
+                opts.MaxRetryAttempts = retries;
+            if (int.TryParse(Environment.GetEnvironmentVariable("NEXO_PIPELINE_RETRY_DELAY_MS"), out var retryDelayMs) && retryDelayMs >= 0)
+                opts.RetryDelayMs = retryDelayMs;
+            if (bool.TryParse(Environment.GetEnvironmentVariable("NEXO_PIPELINE_RESUME_FAILED"), out var resumeFailed))
+                opts.ResumeFailedStages = resumeFailed;
+        });
+
+        services.AddOptions<PipelinePersistenceOptions>();
+        services.Configure<PipelinePersistenceOptions>(opts =>
+        {
+            var provider = Environment.GetEnvironmentVariable("NEXO_PIPELINE_STORE_PROVIDER");
+            if (!string.IsNullOrWhiteSpace(provider))
+                opts.Provider = provider;
+            var dbPath = Environment.GetEnvironmentVariable("NEXO_PIPELINE_STORE_PATH");
+            if (!string.IsNullOrWhiteSpace(dbPath))
+                opts.DatabasePath = dbPath;
+        });
+
         services.TryAddSingleton<IPipelineTemplateValidator, PipelineTemplateValidator>();
         services.TryAddSingleton<IPipelineDecomposer, PipelineDecomposer>();
         services.TryAddSingleton<IPipelineScheduler, PipelineScheduler>();
         services.TryAddSingleton<IPipelineScalingPolicy, ThresholdScalingPolicy>();
-        services.TryAddSingleton<IPipelineRunStore, InMemoryPipelineRunStore>();
+        services.TryAddSingleton<IPipelineRunStore>(sp =>
+        {
+            var options = sp.GetService<IOptions<PipelinePersistenceOptions>>()?.Value ?? new PipelinePersistenceOptions();
+            if (string.Equals(options.Provider, "LiteDb", StringComparison.OrdinalIgnoreCase))
+                return new LiteDbPipelineRunStore(options.DatabasePath);
+            return new InMemoryPipelineRunStore();
+        });
+        services.AddSingleton<IPipelineStageExecutor, DeterministicPipelineStageExecutor>();
+        services.AddSingleton<IPipelineStageExecutor, AgenticPipelineStageExecutor>();
+        services.TryAddSingleton<IPipelineOrchestrator, PipelineOrchestrator>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds pipeline composition layer with explicit options configuration.
+    /// </summary>
+    public static IServiceCollection AddPipelineCompositionLayer(
+        this IServiceCollection services,
+        Action<PipelineExecutionOptions>? configureExecution,
+        Action<PipelinePersistenceOptions>? configurePersistence)
+    {
+        services.AddPipelineCompositionLayer();
+
+        if (configureExecution != null)
+            services.Configure(configureExecution);
+
+        if (configurePersistence != null)
+            services.Configure(configurePersistence);
+
         return services;
     }
 }

--- a/src/Nexo.Infrastructure/Pipelines/PipelineTemplateValidator.cs
+++ b/src/Nexo.Infrastructure/Pipelines/PipelineTemplateValidator.cs
@@ -1,0 +1,142 @@
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Structural validation for pipeline templates.
+/// </summary>
+public sealed class PipelineTemplateValidator : IPipelineTemplateValidator
+{
+    public PipelineTemplateValidationResult Validate(PipelineTemplate template)
+    {
+        if (template == null)
+            return new PipelineTemplateValidationResult
+            {
+                IsValid = false,
+                Errors = new[] { "Template is required." }
+            };
+
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(template.TemplateId))
+            errors.Add("TemplateId is required.");
+
+        if (template.Stages.Count == 0)
+            errors.Add("At least one stage is required.");
+
+        var stagesById = new Dictionary<string, PipelineStageDefinition>(StringComparer.OrdinalIgnoreCase);
+        foreach (var stage in template.Stages)
+        {
+            if (string.IsNullOrWhiteSpace(stage.Id))
+            {
+                errors.Add("Stage id is required.");
+                continue;
+            }
+
+            if (!stagesById.TryAdd(stage.Id, stage))
+                errors.Add($"Duplicate stage id '{stage.Id}'.");
+
+            if (stage.Mode == PipelineExecutionMode.Hybrid && stage.FallbackChain.Count == 0)
+                errors.Add($"Hybrid stage '{stage.Id}' must define fallback chain.");
+
+            if (stage.StageType == PipelineStageType.FanIn && stage.JoinStrategy is null)
+                errors.Add($"Fan-in stage '{stage.Id}' must define join strategy.");
+
+            if (stage.JoinStrategy == PipelineJoinStrategy.Quorum && (!stage.QuorumCount.HasValue || stage.QuorumCount.Value <= 0))
+                errors.Add($"Quorum fan-in stage '{stage.Id}' must define QuorumCount > 0.");
+
+            if (stage.Constraints.MaxParallelism.HasValue && stage.Constraints.MaxParallelism.Value <= 0)
+                errors.Add($"Stage '{stage.Id}' MaxParallelism must be greater than 0.");
+
+            if (stage.Constraints.Critical && !stage.Constraints.RequiresPostValidation)
+                errors.Add($"Critical stage '{stage.Id}' must require post validation.");
+        }
+
+        var outgoing = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        var incoming = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var stageId in stagesById.Keys)
+        {
+            outgoing[stageId] = new List<string>();
+            incoming[stageId] = 0;
+        }
+
+        foreach (var edge in template.Edges)
+        {
+            if (!stagesById.ContainsKey(edge.FromStageId))
+                errors.Add($"Edge references unknown source stage '{edge.FromStageId}'.");
+            if (!stagesById.ContainsKey(edge.ToStageId))
+                errors.Add($"Edge references unknown target stage '{edge.ToStageId}'.");
+
+            if (stagesById.ContainsKey(edge.FromStageId) && stagesById.ContainsKey(edge.ToStageId))
+            {
+                outgoing[edge.FromStageId].Add(edge.ToStageId);
+                incoming[edge.ToStageId] = incoming[edge.ToStageId] + 1;
+            }
+        }
+
+        if (stagesById.Count > 0)
+        {
+            var roots = incoming.Where(kv => kv.Value == 0).Select(kv => kv.Key).ToList();
+            if (roots.Count == 0)
+                errors.Add("Pipeline must contain at least one root stage.");
+
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var q = new Queue<string>(roots);
+            while (q.Count > 0)
+            {
+                var node = q.Dequeue();
+                if (!visited.Add(node))
+                    continue;
+
+                foreach (var next in outgoing[node])
+                    q.Enqueue(next);
+            }
+
+            foreach (var stageId in stagesById.Keys)
+            {
+                if (!visited.Contains(stageId))
+                    errors.Add($"Orphan or unreachable stage '{stageId}'.");
+            }
+
+            if (HasCycle(stagesById.Keys, outgoing))
+                errors.Add("Pipeline graph contains at least one cycle.");
+        }
+
+        return new PipelineTemplateValidationResult
+        {
+            IsValid = errors.Count == 0,
+            Errors = errors
+        };
+    }
+
+    private static bool HasCycle(IEnumerable<string> nodes, IReadOnlyDictionary<string, List<string>> outgoing)
+    {
+        var color = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var node in nodes)
+            color[node] = 0;
+
+        foreach (var node in nodes)
+        {
+            if (color[node] == 0 && Visit(node, outgoing, color))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool Visit(string node, IReadOnlyDictionary<string, List<string>> outgoing, IDictionary<string, int> color)
+    {
+        color[node] = 1;
+        foreach (var next in outgoing[node])
+        {
+            if (color[next] == 1)
+                return true;
+            if (color[next] == 0 && Visit(next, outgoing, color))
+                return true;
+        }
+
+        color[node] = 2;
+        return false;
+    }
+}

--- a/src/Nexo.Infrastructure/Pipelines/ThresholdScalingPolicy.cs
+++ b/src/Nexo.Infrastructure/Pipelines/ThresholdScalingPolicy.cs
@@ -1,0 +1,59 @@
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+
+namespace Nexo.Infrastructure.Pipelines;
+
+/// <summary>
+/// Simple threshold-based scaling policy with bounded worker counts.
+/// </summary>
+public sealed class ThresholdScalingPolicy : IPipelineScalingPolicy
+{
+    private readonly int _deterministicMin;
+    private readonly int _deterministicMax;
+    private readonly int _agenticMin;
+    private readonly int _agenticMax;
+    private readonly int _queueScaleUpThreshold;
+    private readonly double _errorRateThrottleThreshold;
+
+    public ThresholdScalingPolicy(
+        int deterministicMin = 1,
+        int deterministicMax = 8,
+        int agenticMin = 1,
+        int agenticMax = 4,
+        int queueScaleUpThreshold = 10,
+        double errorRateThrottleThreshold = 0.5)
+    {
+        _deterministicMin = deterministicMin;
+        _deterministicMax = deterministicMax;
+        _agenticMin = agenticMin;
+        _agenticMax = agenticMax;
+        _queueScaleUpThreshold = queueScaleUpThreshold;
+        _errorRateThrottleThreshold = errorRateThrottleThreshold;
+    }
+
+    public PipelineScalingDecision Evaluate(PipelineScalingSnapshot snapshot)
+    {
+        var deterministic = snapshot.CurrentDeterministicWorkers;
+        var agentic = snapshot.CurrentAgenticWorkers;
+
+        if (snapshot.DeterministicQueueDepth >= _queueScaleUpThreshold)
+            deterministic = Math.Min(_deterministicMax, deterministic + 1);
+        else if (snapshot.DeterministicQueueDepth == 0)
+            deterministic = Math.Max(_deterministicMin, deterministic - 1);
+
+        if (snapshot.AgenticErrorRate >= _errorRateThrottleThreshold)
+            agentic = Math.Max(_agenticMin, agentic - 1);
+        else if (snapshot.AgenticQueueDepth >= _queueScaleUpThreshold)
+            agentic = Math.Min(_agenticMax, agentic + 1);
+        else if (snapshot.AgenticQueueDepth == 0)
+            agentic = Math.Max(_agenticMin, agentic - 1);
+
+        return new PipelineScalingDecision
+        {
+            DeterministicWorkers = deterministic,
+            AgenticWorkers = agentic,
+            DeterministicMaxDegreeOfParallelism = deterministic,
+            AgenticMaxDegreeOfParallelism = agentic
+        };
+    }
+}

--- a/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
+++ b/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.CLI\Nexo.CLI.csproj" />
+    <ProjectReference Include="..\Nexo.Infrastructure\Nexo.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Nexo.Tests.CLI/Tests/Commands/PipelineCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/PipelineCommandTests.cs
@@ -1,0 +1,274 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nexo.CLI;
+using Nexo.CLI.Commands;
+using Nexo.CLI.Formatting;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Infrastructure.Pipelines;
+
+namespace Nexo.Tests.CLI.Tests.Commands;
+
+public sealed class PipelineCommandTests : UnitTestBase
+{
+    private string? _tempDir;
+
+    public override Task SetupAsync(CancellationToken cancellationToken = default)
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"nexo-pipeline-cmd-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        return Task.CompletedTask;
+    }
+
+    public override Task CleanupAsync(CancellationToken cancellationToken = default)
+    {
+        if (!string.IsNullOrWhiteSpace(_tempDir) && Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+        return Task.CompletedTask;
+    }
+
+    public override async Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await TestValidateSuccess();
+            await TestValidateFailure();
+            await TestRunSuccess();
+            await TestRunFailure();
+            await TestRunWithResumeAndInputs();
+
+            return new TestResult
+            {
+                Name = nameof(PipelineCommandTests),
+                Category = "CLI",
+                Passed = true,
+                Message = "All PipelineCommand tests passed"
+            };
+        }
+        catch (AssertionException ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(PipelineCommandTests),
+                Category = "CLI",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            };
+        }
+        catch (Exception ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(PipelineCommandTests),
+                Category = "CLI",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            };
+        }
+    }
+
+    private Task TestValidateSuccess()
+    {
+        var templatePath = WriteTemplate(new PipelineTemplate
+        {
+            TemplateId = "validate-ok",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "stage-a", Name = "Stage A", Mode = PipelineExecutionMode.Deterministic }
+            }
+        }, "validate-ok.json");
+
+        var validator = new PipelineTemplateValidator();
+        var orchestrator = new Mock<IPipelineOrchestrator>(MockBehavior.Strict);
+        var renderer = new Mock<IConsoleRenderer>();
+        var logger = new Mock<ILogger<PipelineCommand>>();
+
+        var command = new PipelineCommand(validator, orchestrator.Object, renderer.Object, logger.Object);
+        var exitCode = command.Validate(templatePath, json: false, verbose: false);
+
+        AssertEqual((int)ExitCode.Ok, exitCode);
+        renderer.Verify(x => x.RenderSuccess(It.Is<string>(msg => msg.Contains("is valid"))), Times.Once);
+        return Task.CompletedTask;
+    }
+
+    private Task TestValidateFailure()
+    {
+        var templatePath = WriteTemplate(new PipelineTemplate
+        {
+            TemplateId = "validate-fail",
+            Stages = Array.Empty<PipelineStageDefinition>()
+        }, "validate-fail.json");
+
+        var validator = new PipelineTemplateValidator();
+        var orchestrator = new Mock<IPipelineOrchestrator>(MockBehavior.Strict);
+        var renderer = new Mock<IConsoleRenderer>();
+        var logger = new Mock<ILogger<PipelineCommand>>();
+
+        var command = new PipelineCommand(validator, orchestrator.Object, renderer.Object, logger.Object);
+        var exitCode = command.Validate(templatePath, json: false, verbose: false);
+
+        AssertEqual((int)ExitCode.ValidationFailed, exitCode);
+        renderer.Verify(x => x.RenderError(It.Is<string>(msg => msg.Contains("invalid", StringComparison.OrdinalIgnoreCase))), Times.AtLeastOnce);
+        return Task.CompletedTask;
+    }
+
+    private async Task TestRunSuccess()
+    {
+        var templatePath = WriteTemplate(new PipelineTemplate
+        {
+            TemplateId = "run-ok",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "stage-a", Name = "Stage A", Mode = PipelineExecutionMode.Deterministic }
+            }
+        }, "run-ok.json");
+
+        var validator = new PipelineTemplateValidator();
+        var orchestrator = new Mock<IPipelineOrchestrator>();
+        var renderer = new Mock<IConsoleRenderer>();
+        var logger = new Mock<ILogger<PipelineCommand>>();
+
+        orchestrator
+            .Setup(x => x.RunAsync(It.IsAny<PipelineExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PipelineRun
+            {
+                RunId = "run-1",
+                TemplateId = "run-ok",
+                State = PipelineRunState.Completed,
+                StageRuns = new[]
+                {
+                    new PipelineStageRun
+                    {
+                        StageId = "stage-a",
+                        State = PipelineStageRunState.Completed,
+                        Attempt = 1,
+                        WorkerType = PipelineWorkerType.Deterministic
+                    }
+                }
+            });
+
+        var command = new PipelineCommand(validator, orchestrator.Object, renderer.Object, logger.Object);
+        var exitCode = await command.RunAsync(
+            templatePath,
+            json: false,
+            verbose: false,
+            runId: "run-1",
+            resumeRunId: null,
+            resumeFailedStages: false,
+            inputs: new Dictionary<string, string>());
+
+        AssertEqual((int)ExitCode.Ok, exitCode);
+        renderer.Verify(x => x.RenderSuccess(It.Is<string>(msg => msg.Contains("Pipeline run completed", StringComparison.OrdinalIgnoreCase))), Times.AtLeastOnce);
+    }
+
+    private async Task TestRunFailure()
+    {
+        var templatePath = WriteTemplate(new PipelineTemplate
+        {
+            TemplateId = "run-failed",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "stage-a", Name = "Stage A", Mode = PipelineExecutionMode.Deterministic }
+            }
+        }, "run-failed.json");
+
+        var validator = new PipelineTemplateValidator();
+        var orchestrator = new Mock<IPipelineOrchestrator>();
+        var renderer = new Mock<IConsoleRenderer>();
+        var logger = new Mock<ILogger<PipelineCommand>>();
+
+        orchestrator
+            .Setup(x => x.RunAsync(It.IsAny<PipelineExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PipelineRun
+            {
+                RunId = "run-2",
+                TemplateId = "run-failed",
+                State = PipelineRunState.Failed,
+                StageRuns = new[]
+                {
+                    new PipelineStageRun
+                    {
+                        StageId = "stage-a",
+                        State = PipelineStageRunState.Failed,
+                        Attempt = 1,
+                        WorkerType = PipelineWorkerType.Deterministic,
+                        Error = "boom"
+                    }
+                }
+            });
+
+        var command = new PipelineCommand(validator, orchestrator.Object, renderer.Object, logger.Object);
+        var exitCode = await command.RunAsync(
+            templatePath,
+            json: false,
+            verbose: false,
+            runId: "run-2",
+            resumeRunId: null,
+            resumeFailedStages: false,
+            inputs: new Dictionary<string, string>());
+
+        AssertEqual((int)ExitCode.ValidationFailed, exitCode);
+        renderer.Verify(x => x.RenderError(It.Is<string>(msg => msg.Contains("ended with state", StringComparison.OrdinalIgnoreCase))), Times.Once);
+    }
+
+    private async Task TestRunWithResumeAndInputs()
+    {
+        var templatePath = WriteTemplate(new PipelineTemplate
+        {
+            TemplateId = "run-resume",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "stage-a", Name = "Stage A", Mode = PipelineExecutionMode.Deterministic }
+            }
+        }, "run-resume.json");
+
+        var validator = new PipelineTemplateValidator();
+        var orchestrator = new Mock<IPipelineOrchestrator>();
+        var renderer = new Mock<IConsoleRenderer>();
+        var logger = new Mock<ILogger<PipelineCommand>>();
+
+        PipelineExecutionRequest? captured = null;
+        orchestrator
+            .Setup(x => x.RunAsync(It.IsAny<PipelineExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PipelineExecutionRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(new PipelineRun
+            {
+                RunId = "run-3",
+                TemplateId = "run-resume",
+                State = PipelineRunState.Completed,
+                StageRuns = Array.Empty<PipelineStageRun>()
+            });
+
+        var command = new PipelineCommand(validator, orchestrator.Object, renderer.Object, logger.Object);
+        var exitCode = await command.RunAsync(
+            templatePath,
+            json: true,
+            verbose: false,
+            runId: "run-3",
+            resumeRunId: "prior-1",
+            resumeFailedStages: true,
+            inputs: new Dictionary<string, string> { ["k"] = "v" });
+
+        AssertEqual((int)ExitCode.Ok, exitCode);
+        AssertNotNull(captured);
+        AssertEqual("run-3", captured!.RunId);
+        AssertEqual("prior-1", captured.ResumeRunId);
+        AssertTrue(captured.ResumeFailedStages);
+        AssertEqual("v", captured.Inputs["k"]);
+        renderer.Verify(x => x.RenderJson(It.IsAny<object>()), Times.Once);
+    }
+
+    private string WriteTemplate(PipelineTemplate template, string filename)
+    {
+        var path = Path.Combine(_tempDir!, filename);
+        var json = System.Text.Json.JsonSerializer.Serialize(template, new System.Text.Json.JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+        File.WriteAllText(path, json);
+        return path;
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/InMemoryPipelineRunStoreTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/InMemoryPipelineRunStoreTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class InMemoryPipelineRunStoreTests
+{
+    [Fact]
+    public async Task SaveAsync_ThenGetAsync_ReturnsSavedRun()
+    {
+        var sut = new InMemoryPipelineRunStore();
+        var run = new PipelineRun
+        {
+            RunId = "run-1",
+            TemplateId = "tpl-1",
+            State = PipelineRunState.Running,
+            StageRuns = new[]
+            {
+                new PipelineStageRun
+                {
+                    StageId = "stage-1",
+                    State = PipelineStageRunState.Completed,
+                    Attempt = 1,
+                    WorkerType = PipelineWorkerType.Deterministic
+                }
+            }
+        };
+
+        await sut.SaveAsync(run);
+        var stored = await sut.GetAsync("run-1");
+
+        stored.Should().NotBeNull();
+        stored!.TemplateId.Should().Be("tpl-1");
+        stored.StageRuns.Should().ContainSingle(s => s.StageId == "stage-1");
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenMissingRun_ReturnsNull()
+    {
+        var sut = new InMemoryPipelineRunStore();
+
+        var stored = await sut.GetAsync("missing");
+
+        stored.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithCancelledToken_Throws()
+    {
+        var sut = new InMemoryPipelineRunStore();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await sut.SaveAsync(new PipelineRun { RunId = "run-x", TemplateId = "tpl-x" }, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/LiteDbPipelineRunStoreTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/LiteDbPipelineRunStoreTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class LiteDbPipelineRunStoreTests
+{
+    [Fact]
+    public async Task SaveAsync_ThenGetAsync_PersistsRunDurably()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nexo-pipeline-store-{Guid.NewGuid():N}.db");
+        try
+        {
+            var sut = new LiteDbPipelineRunStore(path);
+            var run = new PipelineRun
+            {
+                RunId = "durable-run-1",
+                TemplateId = "template-durable",
+                State = PipelineRunState.Completed,
+                CompletedAt = DateTimeOffset.UtcNow,
+                StageRuns = new[]
+                {
+                    new PipelineStageRun
+                    {
+                        StageId = "stage-a",
+                        State = PipelineStageRunState.Completed,
+                        Attempt = 1,
+                        WorkerType = PipelineWorkerType.Deterministic,
+                        WorkerId = "deterministic-default",
+                        Output = "ok"
+                    }
+                }
+            };
+
+            await sut.SaveAsync(run);
+
+            var sut2 = new LiteDbPipelineRunStore(path);
+            var loaded = await sut2.GetAsync("durable-run-1");
+
+            loaded.Should().NotBeNull();
+            loaded!.TemplateId.Should().Be("template-durable");
+            loaded.State.Should().Be(PipelineRunState.Completed);
+            loaded.StageRuns.Should().ContainSingle(s => s.StageId == "stage-a" && s.Output == "ok");
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineDecomposerTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineDecomposerTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class PipelineDecomposerTests
+{
+    [Fact]
+    public void Decompose_WhenTemplateIsInvalid_ThrowsWithValidationErrors()
+    {
+        var validator = new PipelineTemplateValidator();
+        var sut = new PipelineDecomposer(validator);
+        var template = new PipelineTemplate
+        {
+            TemplateId = "invalid",
+            Stages = Array.Empty<PipelineStageDefinition>(),
+            Edges = Array.Empty<PipelineEdge>()
+        };
+
+        Action act = () => sut.Decompose(template);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Template validation failed*At least one stage is required*");
+    }
+
+    [Fact]
+    public void Decompose_WhenTemplateIsValid_ProducesExecutionGraphWithConnectivity()
+    {
+        var validator = new PipelineTemplateValidator();
+        var sut = new PipelineDecomposer(validator);
+        var template = new PipelineTemplate
+        {
+            TemplateId = "compose-ok",
+            Stages = new[]
+            {
+                new PipelineStageDefinition
+                {
+                    Id = "ingest",
+                    Name = "Ingest",
+                    Mode = PipelineExecutionMode.Deterministic
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "fanout-a",
+                    Name = "Fanout A",
+                    StageType = PipelineStageType.FanOut,
+                    Mode = PipelineExecutionMode.Agentic
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "fanin",
+                    Name = "FanIn",
+                    StageType = PipelineStageType.FanIn,
+                    Mode = PipelineExecutionMode.Hybrid,
+                    JoinStrategy = PipelineJoinStrategy.Quorum,
+                    QuorumCount = 1,
+                    FallbackChain = new[] { PipelineWorkerType.Deterministic, PipelineWorkerType.Agentic }
+                }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("ingest", "fanout-a"),
+                new PipelineEdge("fanout-a", "fanin")
+            }
+        };
+
+        var graph = sut.Decompose(template);
+
+        graph.TemplateId.Should().Be("compose-ok");
+        graph.Nodes.Should().HaveCount(3);
+
+        var ingest = graph.Nodes.Single(n => n.StageId == "ingest");
+        ingest.Predecessors.Should().BeEmpty();
+        ingest.Successors.Should().ContainSingle("fanout-a");
+        ingest.FallbackChain.Should().BeEmpty();
+
+        var fanin = graph.Nodes.Single(n => n.StageId == "fanin");
+        fanin.Predecessors.Should().ContainSingle("fanout-a");
+        fanin.Successors.Should().BeEmpty();
+        fanin.JoinStrategy.Should().Be(PipelineJoinStrategy.Quorum);
+        fanin.QuorumCount.Should().Be(1);
+        fanin.FallbackChain.Should().ContainInOrder(PipelineWorkerType.Deterministic, PipelineWorkerType.Agentic);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineOrchestratorTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineOrchestratorTests.cs
@@ -1,0 +1,310 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class PipelineOrchestratorTests
+{
+    [Fact]
+    public async Task RunAsync_HappyPath_CompletesRun()
+    {
+        var orchestrator = BuildOrchestrator(
+            out var runStore,
+            executionOptions: new PipelineExecutionOptions
+            {
+                MaxRetryAttempts = 2,
+                RetryDelayMs = 1
+            });
+
+        var template = new PipelineTemplate
+        {
+            TemplateId = "happy-path",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "ingest", Name = "Ingest", Mode = PipelineExecutionMode.Deterministic },
+                new PipelineStageDefinition { Id = "enrich", Name = "Enrich", Mode = PipelineExecutionMode.Agentic },
+                new PipelineStageDefinition
+                {
+                    Id = "merge",
+                    Name = "Merge",
+                    StageType = PipelineStageType.FanIn,
+                    JoinStrategy = PipelineJoinStrategy.All,
+                    Mode = PipelineExecutionMode.Hybrid,
+                    FallbackChain = new[] { PipelineWorkerType.Deterministic, PipelineWorkerType.Agentic }
+                }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("ingest", "enrich"),
+                new PipelineEdge("enrich", "merge")
+            }
+        };
+
+        var run = await orchestrator.RunAsync(new PipelineExecutionRequest
+        {
+            RunId = "run-happy",
+            Template = template
+        });
+
+        run.State.Should().Be(PipelineRunState.Completed);
+        run.StageRuns.Should().OnlyContain(x => x.State == PipelineStageRunState.Completed);
+
+        var saved = await runStore.GetAsync("run-happy");
+        saved.Should().NotBeNull();
+        saved!.State.Should().Be(PipelineRunState.Completed);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenDeterministicFails_HybridFallsBackToAgentic()
+    {
+        var orchestrator = BuildOrchestrator(
+            out _,
+            executionOptions: new PipelineExecutionOptions
+            {
+                MaxRetryAttempts = 1,
+                RetryDelayMs = 1
+            });
+
+        var template = new PipelineTemplate
+        {
+            TemplateId = "fallback",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "root", Name = "Root", Mode = PipelineExecutionMode.Deterministic },
+                new PipelineStageDefinition
+                {
+                    Id = "hybrid-stage",
+                    Name = "Hybrid",
+                    Mode = PipelineExecutionMode.Hybrid,
+                    FallbackChain = new[] { PipelineWorkerType.Deterministic, PipelineWorkerType.Agentic }
+                }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("root", "hybrid-stage")
+            }
+        };
+
+        var run = await orchestrator.RunAsync(new PipelineExecutionRequest
+        {
+            RunId = "run-fallback",
+            Template = template,
+            Inputs = new Dictionary<string, string>
+            {
+                ["fail:hybrid-stage:deterministic"] = "true"
+            }
+        });
+
+        run.State.Should().Be(PipelineRunState.Completed);
+        var hybrid = run.StageRuns.Single(x => x.StageId == "hybrid-stage");
+        hybrid.State.Should().Be(PipelineStageRunState.Completed);
+        hybrid.WorkerType.Should().Be(PipelineWorkerType.Agentic);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCriticalStageFails_FailsFast()
+    {
+        var orchestrator = BuildOrchestrator(
+            out _,
+            executionOptions: new PipelineExecutionOptions
+            {
+                MaxRetryAttempts = 1,
+                RetryDelayMs = 1
+            });
+
+        var template = new PipelineTemplate
+        {
+            TemplateId = "critical-fail-fast",
+            Stages = new[]
+            {
+                new PipelineStageDefinition
+                {
+                    Id = "critical",
+                    Name = "Critical",
+                    Mode = PipelineExecutionMode.Deterministic,
+                    Constraints = new PipelineStageConstraints
+                    {
+                        Critical = true,
+                        RequiresPostValidation = true
+                    }
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "downstream",
+                    Name = "Downstream",
+                    Mode = PipelineExecutionMode.Agentic
+                }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("critical", "downstream")
+            }
+        };
+
+        var run = await orchestrator.RunAsync(new PipelineExecutionRequest
+        {
+            RunId = "run-critical",
+            Template = template,
+            Inputs = new Dictionary<string, string>
+            {
+                ["fail:critical:deterministic"] = "true"
+            }
+        });
+
+        run.State.Should().Be(PipelineRunState.Failed);
+        var critical = run.StageRuns.Single(x => x.StageId == "critical");
+        critical.State.Should().Be(PipelineStageRunState.Failed);
+        var downstream = run.StageRuns.Single(x => x.StageId == "downstream");
+        downstream.State.Should().Be(PipelineStageRunState.Pending);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithResumeRunId_CarriesForwardCompletedStages()
+    {
+        var orchestrator = BuildOrchestrator(
+            out var runStore,
+            executionOptions: new PipelineExecutionOptions
+            {
+                MaxRetryAttempts = 1,
+                RetryDelayMs = 1
+            });
+
+        var template = new PipelineTemplate
+        {
+            TemplateId = "resume-template",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "a", Name = "A", Mode = PipelineExecutionMode.Deterministic },
+                new PipelineStageDefinition { Id = "b", Name = "B", Mode = PipelineExecutionMode.Agentic },
+                new PipelineStageDefinition { Id = "c", Name = "C", Mode = PipelineExecutionMode.Deterministic }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("a", "b"),
+                new PipelineEdge("b", "c")
+            }
+        };
+
+        await runStore.SaveAsync(new PipelineRun
+        {
+            RunId = "prior-run",
+            TemplateId = "resume-template",
+            State = PipelineRunState.Failed,
+            StageRuns = new[]
+            {
+                new PipelineStageRun
+                {
+                    StageId = "a",
+                    State = PipelineStageRunState.Completed,
+                    Attempt = 1,
+                    WorkerType = PipelineWorkerType.Deterministic
+                },
+                new PipelineStageRun
+                {
+                    StageId = "b",
+                    State = PipelineStageRunState.Failed,
+                    Attempt = 1,
+                    WorkerType = PipelineWorkerType.Agentic,
+                    Error = "prior failure"
+                },
+                new PipelineStageRun
+                {
+                    StageId = "c",
+                    State = PipelineStageRunState.Pending,
+                    Attempt = 0
+                }
+            }
+        });
+
+        var run = await orchestrator.RunAsync(new PipelineExecutionRequest
+        {
+            RunId = "resumed-run",
+            ResumeRunId = "prior-run",
+            ResumeFailedStages = true,
+            Template = template
+        });
+
+        run.State.Should().Be(PipelineRunState.Completed);
+        run.StageRuns.Should().OnlyContain(x => x.State == PipelineStageRunState.Completed);
+        run.StageRuns.Single(x => x.StageId == "a").Attempt.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenFanInFirstSuccess_ProceedsAfterSingleCompletedPredecessor()
+    {
+        var orchestrator = BuildOrchestrator(
+            out _,
+            executionOptions: new PipelineExecutionOptions
+            {
+                MaxRetryAttempts = 1,
+                RetryDelayMs = 1
+            });
+
+        var template = new PipelineTemplate
+        {
+            TemplateId = "fanin-first-success",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "a", Name = "A", Mode = PipelineExecutionMode.Deterministic },
+                new PipelineStageDefinition { Id = "b", Name = "B", Mode = PipelineExecutionMode.Deterministic },
+                new PipelineStageDefinition
+                {
+                    Id = "join",
+                    Name = "Join",
+                    StageType = PipelineStageType.FanIn,
+                    JoinStrategy = PipelineJoinStrategy.FirstSuccess,
+                    Mode = PipelineExecutionMode.Deterministic
+                }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("a", "join"),
+                new PipelineEdge("b", "join")
+            }
+        };
+
+        var run = await orchestrator.RunAsync(new PipelineExecutionRequest
+        {
+            RunId = "run-fanin-first",
+            Template = template,
+            Inputs = new Dictionary<string, string>
+            {
+                ["fail:b:deterministic"] = "true"
+            }
+        });
+
+        run.State.Should().Be(PipelineRunState.Completed);
+        run.StageRuns.Single(x => x.StageId == "join").State.Should().Be(PipelineStageRunState.Completed);
+    }
+
+    private static PipelineOrchestrator BuildOrchestrator(
+        out IPipelineRunStore runStore,
+        PipelineExecutionOptions? executionOptions = null)
+    {
+        runStore = new InMemoryPipelineRunStore();
+        var validator = new PipelineTemplateValidator();
+        var decomposer = new PipelineDecomposer(validator);
+        var scheduler = new PipelineScheduler();
+        var scaling = new ThresholdScalingPolicy();
+        var executors = new IPipelineStageExecutor[]
+        {
+            new DeterministicPipelineStageExecutor(NullLogger<DeterministicPipelineStageExecutor>.Instance),
+            new AgenticPipelineStageExecutor(NullLogger<AgenticPipelineStageExecutor>.Instance)
+        };
+        var options = Options.Create(executionOptions ?? new PipelineExecutionOptions());
+        return new PipelineOrchestrator(
+            validator,
+            decomposer,
+            scheduler,
+            runStore,
+            scaling,
+            executors,
+            options,
+            NullLogger<PipelineOrchestrator>.Instance);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineSchedulerTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineSchedulerTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class PipelineSchedulerTests
+{
+    private static PipelineExecutionGraph BuildGraph()
+    {
+        return new PipelineExecutionGraph
+        {
+            TemplateId = "scheduler-graph",
+            Nodes = new[]
+            {
+                new PipelineExecutionNode
+                {
+                    StageId = "root",
+                    StageType = PipelineStageType.Standard,
+                    Predecessors = Array.Empty<string>(),
+                    Successors = new[] { "fanin-first", "fanin-quorum", "fanin-all" }
+                },
+                new PipelineExecutionNode
+                {
+                    StageId = "peer",
+                    StageType = PipelineStageType.Standard,
+                    Predecessors = Array.Empty<string>(),
+                    Successors = new[] { "fanin-first", "fanin-quorum", "fanin-all" }
+                },
+                new PipelineExecutionNode
+                {
+                    StageId = "fanin-first",
+                    StageType = PipelineStageType.FanIn,
+                    JoinStrategy = PipelineJoinStrategy.FirstSuccess,
+                    Predecessors = new[] { "root", "peer" },
+                    Successors = Array.Empty<string>()
+                },
+                new PipelineExecutionNode
+                {
+                    StageId = "fanin-quorum",
+                    StageType = PipelineStageType.FanIn,
+                    JoinStrategy = PipelineJoinStrategy.Quorum,
+                    QuorumCount = 2,
+                    Predecessors = new[] { "root", "peer" },
+                    Successors = Array.Empty<string>()
+                },
+                new PipelineExecutionNode
+                {
+                    StageId = "fanin-all",
+                    StageType = PipelineStageType.FanIn,
+                    JoinStrategy = PipelineJoinStrategy.All,
+                    Predecessors = new[] { "root", "peer" },
+                    Successors = Array.Empty<string>()
+                },
+                new PipelineExecutionNode
+                {
+                    StageId = "standard-downstream",
+                    StageType = PipelineStageType.Standard,
+                    Predecessors = new[] { "fanin-all" },
+                    Successors = Array.Empty<string>()
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public void GetReadyStages_WhenRootStagesPending_ReturnsRoots()
+    {
+        var sut = new PipelineScheduler();
+        var graph = BuildGraph();
+        var states = graph.Nodes.ToDictionary(n => n.StageId, _ => PipelineStageRunState.Pending);
+
+        var ready = sut.GetReadyStages(graph, states);
+
+        ready.Should().Contain(new[] { "root", "peer" });
+        ready.Should().NotContain("fanin-first");
+    }
+
+    [Fact]
+    public void GetReadyStages_WhenFirstSuccessSatisfied_ReleasesFirstSuccessNode()
+    {
+        var sut = new PipelineScheduler();
+        var graph = BuildGraph();
+        var states = graph.Nodes.ToDictionary(n => n.StageId, _ => PipelineStageRunState.Pending);
+        states["root"] = PipelineStageRunState.Completed;
+
+        var ready = sut.GetReadyStages(graph, states);
+
+        ready.Should().Contain("fanin-first");
+        ready.Should().NotContain("fanin-quorum");
+        ready.Should().NotContain("fanin-all");
+    }
+
+    [Fact]
+    public void GetReadyStages_WhenQuorumSatisfied_ReleasesQuorumNode()
+    {
+        var sut = new PipelineScheduler();
+        var graph = BuildGraph();
+        var states = graph.Nodes.ToDictionary(n => n.StageId, _ => PipelineStageRunState.Pending);
+        states["root"] = PipelineStageRunState.Completed;
+        states["peer"] = PipelineStageRunState.Completed;
+
+        var ready = sut.GetReadyStages(graph, states);
+
+        ready.Should().Contain("fanin-quorum");
+        ready.Should().Contain("fanin-all");
+    }
+
+    [Fact]
+    public void GetReadyStages_WhenFanInAllCompleted_ReleasesStandardDownstream()
+    {
+        var sut = new PipelineScheduler();
+        var graph = BuildGraph();
+        var states = graph.Nodes.ToDictionary(n => n.StageId, _ => PipelineStageRunState.Pending);
+        states["fanin-all"] = PipelineStageRunState.Completed;
+
+        var ready = sut.GetReadyStages(graph, states);
+
+        ready.Should().Contain("standard-downstream");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineServiceCollectionExtensionsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineServiceCollectionExtensionsTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.Core.Application.Pipelines.Ports;
+using Nexo.Hosting;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class PipelineServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddPipelineCompositionLayer_RegistersAllPipelineContracts()
+    {
+        var services = new ServiceCollection();
+        services.AddPipelineCompositionLayer();
+        var provider = services.BuildServiceProvider();
+
+        provider.GetService<IPipelineTemplateValidator>().Should().BeOfType<PipelineTemplateValidator>();
+        provider.GetService<IPipelineDecomposer>().Should().BeOfType<PipelineDecomposer>();
+        provider.GetService<IPipelineScheduler>().Should().BeOfType<PipelineScheduler>();
+        provider.GetService<IPipelineScalingPolicy>().Should().BeOfType<ThresholdScalingPolicy>();
+        provider.GetService<IPipelineRunStore>().Should().BeOfType<InMemoryPipelineRunStore>();
+    }
+
+    [Fact]
+    public void AddNexo_RegistersPipelineCompositionLayerByDefault()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNexo();
+        var provider = services.BuildServiceProvider();
+
+        provider.GetService<IPipelineTemplateValidator>().Should().NotBeNull();
+        provider.GetService<IPipelineDecomposer>().Should().NotBeNull();
+        provider.GetService<IPipelineScheduler>().Should().NotBeNull();
+        provider.GetService<IPipelineScalingPolicy>().Should().NotBeNull();
+        provider.GetService<IPipelineRunStore>().Should().NotBeNull();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineServiceCollectionExtensionsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Nexo.Core.Application.Pipelines.Ports;
 using Nexo.Hosting;
 using Nexo.Infrastructure.Pipelines;
@@ -13,6 +14,7 @@ public sealed class PipelineServiceCollectionExtensionsTests
     public void AddPipelineCompositionLayer_RegistersAllPipelineContracts()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddPipelineCompositionLayer();
         var provider = services.BuildServiceProvider();
 
@@ -21,6 +23,8 @@ public sealed class PipelineServiceCollectionExtensionsTests
         provider.GetService<IPipelineScheduler>().Should().BeOfType<PipelineScheduler>();
         provider.GetService<IPipelineScalingPolicy>().Should().BeOfType<ThresholdScalingPolicy>();
         provider.GetService<IPipelineRunStore>().Should().BeOfType<InMemoryPipelineRunStore>();
+        provider.GetServices<IPipelineStageExecutor>().Should().HaveCount(2);
+        provider.GetService<IPipelineOrchestrator>().Should().BeOfType<PipelineOrchestrator>();
     }
 
     [Fact]
@@ -36,5 +40,32 @@ public sealed class PipelineServiceCollectionExtensionsTests
         provider.GetService<IPipelineScheduler>().Should().NotBeNull();
         provider.GetService<IPipelineScalingPolicy>().Should().NotBeNull();
         provider.GetService<IPipelineRunStore>().Should().NotBeNull();
+        provider.GetService<IPipelineOrchestrator>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddPipelineCompositionLayer_WithLiteDbPersistence_RegistersLiteDbRunStore()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"nexo-pipelines-{Guid.NewGuid():N}.db");
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddPipelineCompositionLayer(
+                configureExecution: null,
+                configurePersistence: options =>
+                {
+                    options.Provider = "LiteDb";
+                    options.DatabasePath = tempPath;
+                });
+
+            var provider = services.BuildServiceProvider();
+            provider.GetService<IPipelineRunStore>().Should().BeOfType<LiteDbPipelineRunStore>();
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
     }
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineTemplateValidatorTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/PipelineTemplateValidatorTests.cs
@@ -1,0 +1,198 @@
+using FluentAssertions;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class PipelineTemplateValidatorTests
+{
+    private readonly PipelineTemplateValidator _sut = new();
+
+    [Fact]
+    public void Validate_WhenTemplateIsNull_ReturnsInvalidResult()
+    {
+        var result = _sut.Validate(null!);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Contain("Template is required");
+    }
+
+    [Fact]
+    public void Validate_WhenTemplateHasStructuralViolations_ReturnsAllRelevantErrors()
+    {
+        var template = new PipelineTemplate
+        {
+            TemplateId = "bad-structure",
+            Stages = new[]
+            {
+                new PipelineStageDefinition
+                {
+                    Id = "dup",
+                    Name = "Duplicate 1"
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "dup",
+                    Name = "Duplicate 2"
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "hybrid-no-fallback",
+                    Name = "Hybrid No Fallback",
+                    Mode = PipelineExecutionMode.Hybrid
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "fanin-missing-join",
+                    Name = "FanIn Missing Join",
+                    StageType = PipelineStageType.FanIn
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "quorum-invalid",
+                    Name = "Quorum Invalid",
+                    StageType = PipelineStageType.FanIn,
+                    JoinStrategy = PipelineJoinStrategy.Quorum,
+                    QuorumCount = 0
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "critical-no-post-validation",
+                    Name = "Critical No Post Validation",
+                    Constraints = new PipelineStageConstraints
+                    {
+                        Critical = true,
+                        RequiresPostValidation = false
+                    }
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "max-parallelism-invalid",
+                    Name = "Max Parallelism Invalid",
+                    Constraints = new PipelineStageConstraints
+                    {
+                        MaxParallelism = 0
+                    }
+                }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("dup", "unknown-target"),
+                new PipelineEdge("unknown-source", "dup")
+            }
+        };
+
+        var result = _sut.Validate(template);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error => error.Contains("Duplicate stage id"));
+        result.Errors.Should().Contain(error => error.Contains("must define fallback chain"));
+        result.Errors.Should().Contain(error => error.Contains("must define join strategy"));
+        result.Errors.Should().Contain(error => error.Contains("must define QuorumCount > 0"));
+        result.Errors.Should().Contain(error => error.Contains("must require post validation"));
+        result.Errors.Should().Contain(error => error.Contains("MaxParallelism must be greater than 0"));
+        result.Errors.Should().Contain(error => error.Contains("unknown source stage"));
+        result.Errors.Should().Contain(error => error.Contains("unknown target stage"));
+    }
+
+    [Fact]
+    public void Validate_WhenGraphContainsCycle_ReturnsCycleError()
+    {
+        var template = new PipelineTemplate
+        {
+            TemplateId = "cycle",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "a", Name = "A" },
+                new PipelineStageDefinition { Id = "b", Name = "B" },
+                new PipelineStageDefinition { Id = "c", Name = "C" }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("a", "b"),
+                new PipelineEdge("b", "c"),
+                new PipelineEdge("c", "a")
+            }
+        };
+
+        var result = _sut.Validate(template);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error => error.Contains("contains at least one cycle"));
+    }
+
+    [Fact]
+    public void Validate_WhenGraphHasUnreachableStage_ReturnsUnreachableError()
+    {
+        var template = new PipelineTemplate
+        {
+            TemplateId = "unreachable",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "root", Name = "Root" },
+                new PipelineStageDefinition { Id = "child", Name = "Child" },
+                new PipelineStageDefinition { Id = "isolated", Name = "Isolated" }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("root", "child"),
+                new PipelineEdge("isolated", "isolated")
+            }
+        };
+
+        var result = _sut.Validate(template);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error => error.Contains("Orphan or unreachable stage 'isolated'"));
+    }
+
+    [Fact]
+    public void Validate_WhenTemplateIsWellFormed_ReturnsValid()
+    {
+        var template = new PipelineTemplate
+        {
+            TemplateId = "valid-template",
+            Stages = new[]
+            {
+                new PipelineStageDefinition
+                {
+                    Id = "ingest",
+                    Name = "Ingest",
+                    Mode = PipelineExecutionMode.Deterministic
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "enrich",
+                    Name = "Enrich",
+                    Mode = PipelineExecutionMode.Hybrid,
+                    FallbackChain = new[] { PipelineWorkerType.Deterministic, PipelineWorkerType.Agentic }
+                },
+                new PipelineStageDefinition
+                {
+                    Id = "merge",
+                    Name = "Merge",
+                    StageType = PipelineStageType.FanIn,
+                    JoinStrategy = PipelineJoinStrategy.Quorum,
+                    QuorumCount = 1,
+                    Constraints = new PipelineStageConstraints
+                    {
+                        Critical = true,
+                        RequiresPostValidation = true,
+                        MaxParallelism = 2
+                    }
+                }
+            },
+            Edges = new[]
+            {
+                new PipelineEdge("ingest", "enrich"),
+                new PipelineEdge("enrich", "merge")
+            }
+        };
+
+        var result = _sut.Validate(template);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Pipelines/ThresholdScalingPolicyTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Pipelines/ThresholdScalingPolicyTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Infrastructure.Pipelines;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Pipelines;
+
+public sealed class ThresholdScalingPolicyTests
+{
+    [Fact]
+    public void Evaluate_WhenDeterministicQueueDepthHigh_ScalesDeterministicUpWithinMax()
+    {
+        var sut = new ThresholdScalingPolicy(
+            deterministicMin: 1,
+            deterministicMax: 3,
+            agenticMin: 1,
+            agenticMax: 3,
+            queueScaleUpThreshold: 10,
+            errorRateThrottleThreshold: 0.5);
+
+        var decision = sut.Evaluate(new PipelineScalingSnapshot
+        {
+            DeterministicQueueDepth = 25,
+            AgenticQueueDepth = 0,
+            DeterministicErrorRate = 0.0,
+            AgenticErrorRate = 0.0,
+            CurrentDeterministicWorkers = 2,
+            CurrentAgenticWorkers = 2
+        });
+
+        decision.DeterministicWorkers.Should().Be(3);
+        decision.DeterministicMaxDegreeOfParallelism.Should().Be(3);
+    }
+
+    [Fact]
+    public void Evaluate_WhenDeterministicQueueEmpty_ScalesDeterministicDownToMin()
+    {
+        var sut = new ThresholdScalingPolicy(
+            deterministicMin: 2,
+            deterministicMax: 6,
+            agenticMin: 1,
+            agenticMax: 4,
+            queueScaleUpThreshold: 10,
+            errorRateThrottleThreshold: 0.5);
+
+        var decision = sut.Evaluate(new PipelineScalingSnapshot
+        {
+            DeterministicQueueDepth = 0,
+            AgenticQueueDepth = 5,
+            DeterministicErrorRate = 0.0,
+            AgenticErrorRate = 0.0,
+            CurrentDeterministicWorkers = 3,
+            CurrentAgenticWorkers = 2
+        });
+
+        decision.DeterministicWorkers.Should().Be(2);
+    }
+
+    [Fact]
+    public void Evaluate_WhenAgenticErrorRateHigh_ThrottlesAgenticWorkers()
+    {
+        var sut = new ThresholdScalingPolicy(
+            deterministicMin: 1,
+            deterministicMax: 8,
+            agenticMin: 1,
+            agenticMax: 4,
+            queueScaleUpThreshold: 10,
+            errorRateThrottleThreshold: 0.25);
+
+        var decision = sut.Evaluate(new PipelineScalingSnapshot
+        {
+            DeterministicQueueDepth = 1,
+            AgenticQueueDepth = 100,
+            DeterministicErrorRate = 0.0,
+            AgenticErrorRate = 0.30,
+            CurrentDeterministicWorkers = 2,
+            CurrentAgenticWorkers = 3
+        });
+
+        decision.AgenticWorkers.Should().Be(2, "high error rate should throttle agentic workers first");
+        decision.AgenticMaxDegreeOfParallelism.Should().Be(2);
+    }
+
+    [Fact]
+    public void Evaluate_WhenAgenticQueueHighAndHealthy_ScalesAgenticUpWithinMax()
+    {
+        var sut = new ThresholdScalingPolicy(
+            deterministicMin: 1,
+            deterministicMax: 8,
+            agenticMin: 1,
+            agenticMax: 3,
+            queueScaleUpThreshold: 10,
+            errorRateThrottleThreshold: 0.5);
+
+        var decision = sut.Evaluate(new PipelineScalingSnapshot
+        {
+            DeterministicQueueDepth = 1,
+            AgenticQueueDepth = 10,
+            DeterministicErrorRate = 0.0,
+            AgenticErrorRate = 0.0,
+            CurrentDeterministicWorkers = 2,
+            CurrentAgenticWorkers = 2
+        });
+
+        decision.AgenticWorkers.Should().Be(3);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Added full pipeline runtime orchestration (`IPipelineOrchestrator`) with retry, fallback-chain execution, fan-in semantics support, resume hydration, fail-fast for critical stages, and scaling decision hooks.
- Added stage executor abstractions and default implementations for deterministic and agentic workers.
- Added durable run persistence via `LiteDbPipelineRunStore`, plus execution/persistence options and provider selection in pipeline DI registration.
- Added CLI command surface: `nexo pipeline validate` and `nexo pipeline run` with JSON and human output, run IDs, resume support, and `--input key=value` parsing.
- Added Production Readiness Gate v1 as repository documentation and a dedicated GitHub Actions workflow to execute that gate in CI.
- Expanded tests to cover orchestration runtime behaviors, LiteDB durability, enhanced DI registrations, and new CLI pipeline command behavior.

## Testing
- `dotnet build src/Nexo.Core.Application/Nexo.Core.Application.csproj -f netstandard2.0`
- `dotnet build src/Nexo.Infrastructure/Nexo.Infrastructure.csproj`
- `dotnet build src/Nexo.CLI/Nexo.CLI.csproj`
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter "FullyQualifiedName~Pipelines"`
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net9.0 --filter "FullyQualifiedName~Pipelines"`
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter "FullyQualifiedName~HostingE2ESmokeTests.AddNexo_RegistersObservationPipeline_ByDefault|FullyQualifiedName~Pipelines.PipelineServiceCollectionExtensionsTests.AddNexo_RegistersPipelineCompositionLayerByDefault"`
- `dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline validate --template /tmp/pipeline_gate_demo.json` (via documented/automated gate flow)
- `dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-success --format-json` (via documented/automated gate flow)
- `dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-fallback --input "fail:hybrid:deterministic=true" --format-json` (via documented/automated gate flow)
- `NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-source --input "fail:ingest:deterministic=true" --format-json` (via documented/automated gate flow)
- `NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-target --resume-run-id gate-resume-source --resume-failed-stages --format-json` (via documented/automated gate flow)

## Notes
- Gate spec: `docs/ProductionReadinessGate-v1.md`.
- CI workflow: `.github/workflows/production-readiness-gate-v1.yml`.
- Workflow publishes `trx` and gate command logs as artifacts for auditability.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a86d3f7-46a0-42dd-a004-19067499b0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a86d3f7-46a0-42dd-a004-19067499b0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

