### PR TITLE
Harden installer brute-force CI determinism and packaging path

### DIFF
--- a/.github/workflows/native-installer-packages.yml
+++ b/.github/workflows/native-installer-packages.yml
@@ -1,0 +1,77 @@
+name: Native Installer Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label embedded in installer README files"
+        required: false
+        default: "dev"
+
+permissions:
+  contents: read
+
+jobs:
+  build-native-installers:
+    name: Build ${{ matrix.label }} native installer bundle
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x64
+            rid: linux-x64
+            platform: linux
+            archive_glob: "*.tar.gz"
+          - os: macos-latest
+            label: macos-x64
+            rid: osx-x64
+            platform: macos
+            archive_glob: "*.tar.gz"
+          - os: windows-latest
+            label: windows-x64
+            rid: win-x64
+            platform: windows
+            archive_glob: "*.zip"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Restore
+        run: dotnet restore src/Nexo.CLI/Nexo.CLI.csproj
+
+      - name: Package native installer bundle (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out/native-installer
+          bash scripts/install/package-native-bundle.sh \
+            --rid "${{ matrix.rid }}" \
+            --platform "${{ matrix.platform }}" \
+            --version "${{ github.event.inputs.version || 'dev' }}" \
+            --output-dir out/native-installer
+
+      - name: Package native installer bundle (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path out/native-installer -Force | Out-Null
+          powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install\package-native-bundle.ps1 `
+            -Rid "${{ matrix.rid }}" `
+            -Version "${{ github.event.inputs.version || 'dev' }}" `
+            -OutputDir "out/native-installer"
+
+      - name: Upload native installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexo-native-installer-${{ matrix.label }}
+          path: out/native-installer/${{ matrix.archive_glob }}
+          if-no-files-found: error

--- a/docs/OneClickInstall.md
+++ b/docs/OneClickInstall.md
@@ -60,7 +60,7 @@ For distribution-ready native installer bundles, use the GitHub Actions workflow
 - Workflow: `.github/workflows/native-installer-packages.yml`
 - Trigger: **Actions** -> **Native Installer Packages** -> **Run workflow** (optional `version` input)
 
-This one-button run builds self-contained CLI installer bundles for:
+This one-button run builds self-contained CLI app-directory installer bundles for:
 
 - Linux (`linux-x64`)
 - macOS (`osx-x64`)
@@ -76,7 +76,7 @@ Each run uploads one artifact per platform:
 
 Each bundle includes:
 
-1. Self-contained CLI binary (`bin/nexo` or `bin/nexo.exe`).
+1. Self-contained CLI runtime directory (`bin/` with `Nexo.CLI` entrypoint).
 2. Platform-native install launcher (`install.sh`, `install.command`, or `install.ps1`).
 3. A bundle README with install and verification commands.
 
@@ -84,7 +84,7 @@ Each bundle includes:
 
 The bundle installers:
 
-1. Copy the CLI to `$HOME/.local/bin` (`nexo` or `nexo.exe`).
+1. Copy the CLI runtime to `$HOME/.local/share/nexo` and install a launcher at `$HOME/.local/bin/nexo` (or `nexo.ps1` on Windows).
 2. Keep installation user-scoped (no admin/root required).
 3. Print PATH guidance if `$HOME/.local/bin` is not on PATH.
 

--- a/docs/OneClickInstall.md
+++ b/docs/OneClickInstall.md
@@ -76,7 +76,7 @@ Each run uploads one artifact per platform:
 
 Each bundle includes:
 
-1. Self-contained CLI runtime directory (`bin/` with `Nexo.CLI` entrypoint).
+1. Self-contained CLI runtime directory (`app/` with `Nexo.CLI` entrypoint).
 2. Platform-native install launcher (`install.sh`, `install.command`, or `install.ps1`).
 3. A bundle README with install and verification commands.
 
@@ -84,7 +84,7 @@ Each bundle includes:
 
 The bundle installers:
 
-1. Copy the CLI runtime to `$HOME/.local/share/nexo` and install a launcher at `$HOME/.local/bin/nexo` (or `nexo.ps1` on Windows).
+1. Copy the CLI runtime to a user-scoped app path and install a launcher at `$HOME/.local/bin/nexo` (or `nexo.ps1` on Windows).
 2. Keep installation user-scoped (no admin/root required).
 3. Print PATH guidance if `$HOME/.local/bin` is not on PATH.
 

--- a/docs/OneClickInstall.md
+++ b/docs/OneClickInstall.md
@@ -84,9 +84,10 @@ Each bundle includes:
 
 The bundle installers:
 
-1. Copy the CLI runtime to a user-scoped app path and install a launcher at `$HOME/.local/bin/nexo` (or `nexo.ps1` on Windows).
+1. Copy the CLI runtime to a user-scoped app path and install launchers under `$HOME/.local/bin`.
 2. Keep installation user-scoped (no admin/root required).
-3. Print PATH guidance if `$HOME/.local/bin` is not on PATH.
+3. Auto-update shell profile PATH on Linux/macOS when needed (non-destructive append).
+4. Run a post-install smoke check (`nexo --version`) and exit non-zero on failure.
 
 ## Linux / macOS
 

--- a/docs/OneClickInstall.md
+++ b/docs/OneClickInstall.md
@@ -53,6 +53,41 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install\container-
 6. Optionally validates mount path with `--workspace` and runs mounted smoke checks.
 7. If `--workspace` is set and the Nexo repo is mounted, runs SDK restore smoke on `src/Nexo.CLI/Nexo.CLI.csproj`.
 
+## Packaged native installer artifacts (single-button release build)
+
+For distribution-ready native installer bundles, use the GitHub Actions workflow:
+
+- Workflow: `.github/workflows/native-installer-packages.yml`
+- Trigger: **Actions** -> **Native Installer Packages** -> **Run workflow** (optional `version` input)
+
+This one-button run builds self-contained CLI installer bundles for:
+
+- Linux (`linux-x64`)
+- macOS (`osx-x64`)
+- Windows (`win-x64`)
+
+### Output artifacts
+
+Each run uploads one artifact per platform:
+
+- `nexo-native-installer-linux-x64` (`.tar.gz`)
+- `nexo-native-installer-macos-x64` (`.tar.gz`)
+- `nexo-native-installer-windows-x64` (`.zip`)
+
+Each bundle includes:
+
+1. Self-contained CLI binary (`bin/nexo` or `bin/nexo.exe`).
+2. Platform-native install launcher (`install.sh`, `install.command`, or `install.ps1`).
+3. A bundle README with install and verification commands.
+
+### End-user install behavior
+
+The bundle installers:
+
+1. Copy the CLI to `$HOME/.local/bin` (`nexo` or `nexo.exe`).
+2. Keep installation user-scoped (no admin/root required).
+3. Print PATH guidance if `$HOME/.local/bin` is not on PATH.
+
 ## Linux / macOS
 
 Unified entrypoint (auto-detects OS):

--- a/scripts/install/native-installer/install.command
+++ b/scripts/install/native-installer/install.command
@@ -2,6 +2,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AUTO_CLOSE=false
+
+for arg in "$@"; do
+  case "${arg}" in
+    --no-pause)
+      AUTO_CLOSE=true
+      ;;
+  esac
+done
 
 echo "============================================="
 echo " Nexo Native Installer (macOS)"
@@ -17,4 +26,6 @@ fi
 
 echo ""
 echo "Install complete."
-read -r -p "Press Enter to close this window..."
+if [[ "${AUTO_CLOSE}" != "true" ]]; then
+  read -r -p "Press Enter to close this window..."
+fi

--- a/scripts/install/native-installer/install.command
+++ b/scripts/install/native-installer/install.command
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "============================================="
+echo " Nexo Native Installer (macOS)"
+echo "============================================="
+echo ""
+
+if ! bash "${SCRIPT_DIR}/install.sh"; then
+  echo ""
+  echo "Install failed."
+  read -r -p "Press Enter to close this window..."
+  exit 1
+fi
+
+echo ""
+echo "Install complete."
+read -r -p "Press Enter to close this window..."

--- a/scripts/install/native-installer/install.ps1
+++ b/scripts/install/native-installer/install.ps1
@@ -6,14 +6,16 @@ $ErrorActionPreference = "Stop"
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $installBase = if ([string]::IsNullOrWhiteSpace($env:NEXO_INSTALL_BASE)) {
-    Join-Path $HOME ".local\bin"
+    Join-Path $HOME ".local\share\nexo"
 }
 else {
     $env:NEXO_INSTALL_BASE
 }
-$appSourceDir = Join-Path $scriptDir "bin\nexo-app"
-$appTargetDir = Join-Path $installBase "nexo-app"
-$targetPath = Join-Path $installBase "nexo.cmd"
+$binDir = Join-Path $HOME ".local\bin"
+$appSourceDir = Join-Path $scriptDir "app"
+$appTargetDir = Join-Path $installBase "app"
+$targetCmdPath = Join-Path $binDir "nexo.cmd"
+$targetPs1Path = Join-Path $binDir "nexo.ps1"
 $targetExe = Join-Path $appTargetDir "Nexo.CLI.exe"
 
 if (-not (Test-Path $appSourceDir)) {
@@ -21,24 +23,31 @@ if (-not (Test-Path $appSourceDir)) {
 }
 
 New-Item -ItemType Directory -Path $installBase -Force | Out-Null
+New-Item -ItemType Directory -Path $binDir -Force | Out-Null
 if (Test-Path $appTargetDir) {
     Remove-Item -Path $appTargetDir -Recurse -Force
 }
 Copy-Item $appSourceDir $appTargetDir -Recurse -Force
-"@echo off`r`n`"$targetExe`" %*" | Set-Content -Path $targetPath -NoNewline
+$cmdContent = "@echo off`r`n`"$targetExe`" %*"
+$ps1Content = "& `"$targetExe`" @args"
+$cmdContent | Set-Content -Path $targetCmdPath -NoNewline
+$ps1Content | Set-Content -Path $targetPs1Path -NoNewline
 
-Write-Host "Installed nexo launcher to $targetPath"
+Write-Host "Installed nexo app to $appTargetDir"
+Write-Host "Installed launchers:"
+Write-Host "  $targetCmdPath"
+Write-Host "  $targetPs1Path"
 
 $pathParts = @()
 if (-not [string]::IsNullOrWhiteSpace($env:PATH)) {
     $pathParts = $env:PATH.Split(';')
 }
 
-if (-not ($pathParts -contains $installBase)) {
+if (-not ($pathParts -contains $binDir)) {
     Write-Host ""
-    Write-Host "PATH update recommended: add $installBase"
+    Write-Host "PATH update recommended: add $binDir"
     Write-Host "Example (current user):"
-    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$installBase', 'User')"
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$binDir', 'User')"
 }
 
 Write-Host ""

--- a/scripts/install/native-installer/install.ps1
+++ b/scripts/install/native-installer/install.ps1
@@ -1,0 +1,40 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$installBase = if ([string]::IsNullOrWhiteSpace($env:NEXO_INSTALL_BASE)) {
+    Join-Path $HOME ".local\bin"
+}
+else {
+    $env:NEXO_INSTALL_BASE
+}
+$targetPath = Join-Path $installBase "nexo.exe"
+$sourcePath = Join-Path $scriptDir "bin\nexo.exe"
+
+if (-not (Test-Path $sourcePath)) {
+    throw "Missing bundled binary at $sourcePath"
+}
+
+New-Item -ItemType Directory -Path $installBase -Force | Out-Null
+Copy-Item $sourcePath $targetPath -Force
+
+Write-Host "Installed nexo to $targetPath"
+
+$pathParts = @()
+if (-not [string]::IsNullOrWhiteSpace($env:PATH)) {
+    $pathParts = $env:PATH.Split(';')
+}
+
+if (-not ($pathParts -contains $installBase)) {
+    Write-Host ""
+    Write-Host "PATH update recommended: add $installBase"
+    Write-Host "Example (current user):"
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$installBase', 'User')"
+}
+
+Write-Host ""
+Write-Host "Verify with:"
+Write-Host "  $targetPath --help"

--- a/scripts/install/native-installer/install.ps1
+++ b/scripts/install/native-installer/install.ps1
@@ -11,17 +11,23 @@ $installBase = if ([string]::IsNullOrWhiteSpace($env:NEXO_INSTALL_BASE)) {
 else {
     $env:NEXO_INSTALL_BASE
 }
-$targetPath = Join-Path $installBase "nexo.exe"
-$sourcePath = Join-Path $scriptDir "bin\nexo.exe"
+$appSourceDir = Join-Path $scriptDir "bin\nexo-app"
+$appTargetDir = Join-Path $installBase "nexo-app"
+$targetPath = Join-Path $installBase "nexo.cmd"
+$targetExe = Join-Path $appTargetDir "Nexo.CLI.exe"
 
-if (-not (Test-Path $sourcePath)) {
-    throw "Missing bundled binary at $sourcePath"
+if (-not (Test-Path $appSourceDir)) {
+    throw "Missing bundled app directory at $appSourceDir"
 }
 
 New-Item -ItemType Directory -Path $installBase -Force | Out-Null
-Copy-Item $sourcePath $targetPath -Force
+if (Test-Path $appTargetDir) {
+    Remove-Item -Path $appTargetDir -Recurse -Force
+}
+Copy-Item $appSourceDir $appTargetDir -Recurse -Force
+"@echo off`r`n`"$targetExe`" %*" | Set-Content -Path $targetPath -NoNewline
 
-Write-Host "Installed nexo to $targetPath"
+Write-Host "Installed nexo launcher to $targetPath"
 
 $pathParts = @()
 if (-not [string]::IsNullOrWhiteSpace($env:PATH)) {
@@ -37,4 +43,4 @@ if (-not ($pathParts -contains $installBase)) {
 
 Write-Host ""
 Write-Host "Verify with:"
-Write-Host "  $targetPath --help"
+Write-Host "  nexo --help"

--- a/scripts/install/native-installer/install.ps1
+++ b/scripts/install/native-installer/install.ps1
@@ -17,6 +17,7 @@ $appTargetDir = Join-Path $installBase "app"
 $targetCmdPath = Join-Path $binDir "nexo.cmd"
 $targetPs1Path = Join-Path $binDir "nexo.ps1"
 $targetExe = Join-Path $appTargetDir "Nexo.CLI.exe"
+$pathUpdated = $false
 
 if (-not (Test-Path $appSourceDir)) {
     throw "Missing bundled app directory at $appSourceDir"
@@ -45,11 +46,32 @@ if (-not [string]::IsNullOrWhiteSpace($env:PATH)) {
 
 if (-not ($pathParts -contains $binDir)) {
     Write-Host ""
-    Write-Host "PATH update recommended: add $binDir"
-    Write-Host "Example (current user):"
-    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$binDir', 'User')"
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ([string]::IsNullOrWhiteSpace($userPath)) {
+        [Environment]::SetEnvironmentVariable('Path', $binDir, 'User')
+    }
+    elseif ($userPath.Split(';') -notcontains $binDir) {
+        [Environment]::SetEnvironmentVariable('Path', "$userPath;$binDir", 'User')
+    }
+
+    $env:PATH = "$binDir;$env:PATH"
+    $pathUpdated = $true
+    Write-Host "Added $binDir to the user PATH."
 }
 
 Write-Host ""
 Write-Host "Verify with:"
 Write-Host "  nexo --help"
+
+Write-Host ""
+Write-Host "Running post-install smoke check..."
+& $targetExe --help | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Post-install validation failed. Command exited with code $LASTEXITCODE"
+}
+Write-Host "Post-install smoke check passed."
+
+if ($pathUpdated) {
+    Write-Host ""
+    Write-Host "Open a new terminal to use 'nexo' from PATH everywhere."
+}

--- a/scripts/install/native-installer/install.sh
+++ b/scripts/install/native-installer/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_BASE="${NEXO_INSTALL_BASE:-${HOME}/.local/bin}"
+TARGET_PATH="${INSTALL_BASE}/nexo"
+SOURCE_PATH="${SCRIPT_DIR}/bin/nexo"
+
+if [[ ! -f "${SOURCE_PATH}" ]]; then
+  echo "Missing bundled binary at ${SOURCE_PATH}" >&2
+  exit 1
+fi
+
+mkdir -p "${INSTALL_BASE}"
+cp "${SOURCE_PATH}" "${TARGET_PATH}"
+chmod +x "${TARGET_PATH}"
+
+echo "Installed nexo to ${TARGET_PATH}"
+
+case ":${PATH}:" in
+  *":${INSTALL_BASE}:"*)
+    ;;
+  *)
+    echo ""
+    echo "PATH update recommended: add ${INSTALL_BASE}"
+    echo "Example:"
+    echo "  echo 'export PATH=\"${INSTALL_BASE}:\$PATH\"' >> \"${HOME}/.bashrc\""
+    ;;
+esac
+
+echo ""
+echo "Verify with:"
+echo "  ${TARGET_PATH} --help"

--- a/scripts/install/native-installer/install.sh
+++ b/scripts/install/native-installer/install.sh
@@ -7,15 +7,46 @@ INSTALL_APP_DIR="${NEXO_INSTALL_APP:-${HOME}/.local/lib/nexo}"
 TARGET_BIN_PATH="${INSTALL_BIN_DIR}/nexo"
 SOURCE_APP_DIR="${SCRIPT_DIR}/app"
 TARGET_APP_BINARY="${INSTALL_APP_DIR}/Nexo.CLI"
+PATH_EXPORT_LINE="export PATH=\"${INSTALL_BIN_DIR}:\$PATH\""
+INSTALL_MARKER="# Added by Nexo native installer"
 
 if [[ ! -d "${SOURCE_APP_DIR}" ]]; then
   echo "Missing bundled app directory at ${SOURCE_APP_DIR}" >&2
   exit 1
 fi
 
+append_path_if_needed() {
+  local profile_path="$1"
+  local marker_present=false
+  local export_present=false
+
+  if [[ -f "${profile_path}" ]]; then
+    while IFS= read -r line; do
+      [[ "${line}" == "${INSTALL_MARKER}" ]] && marker_present=true
+      [[ "${line}" == "${PATH_EXPORT_LINE}" ]] && export_present=true
+    done < "${profile_path}"
+  fi
+
+  if [[ "${export_present}" == "true" ]]; then
+    return
+  fi
+
+  {
+    echo ""
+    if [[ "${marker_present}" != "true" ]]; then
+      echo "${INSTALL_MARKER}"
+    fi
+    echo "${PATH_EXPORT_LINE}"
+  } >> "${profile_path}"
+}
+
 mkdir -p "$(dirname "${INSTALL_APP_DIR}")"
+tmp_install_dir="${INSTALL_APP_DIR}.tmp.$$"
+rm -rf "${tmp_install_dir}"
+cp -R "${SOURCE_APP_DIR}" "${tmp_install_dir}"
+chmod +x "${tmp_install_dir}/Nexo.CLI"
 rm -rf "${INSTALL_APP_DIR}"
-cp -R "${SOURCE_APP_DIR}" "${INSTALL_APP_DIR}"
+mv "${tmp_install_dir}" "${INSTALL_APP_DIR}"
 
 mkdir -p "${INSTALL_BIN_DIR}"
 cat > "${TARGET_BIN_PATH}" <<EOF
@@ -32,13 +63,28 @@ case ":${PATH}:" in
   *":${INSTALL_BIN_DIR}:"*)
     ;;
   *)
+    target_profile=""
+    for candidate in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
+      if [[ -f "${candidate}" ]]; then
+        target_profile="${candidate}"
+        break
+      fi
+    done
+    if [[ -z "${target_profile}" ]]; then
+      target_profile="${HOME}/.profile"
+    fi
+    append_path_if_needed "${target_profile}"
     echo ""
-    echo "PATH update recommended: add ${INSTALL_BIN_DIR}"
-    echo "Example:"
-    echo "  echo 'export PATH=\"${INSTALL_BIN_DIR}:\$PATH\"' >> \"${HOME}/.bashrc\""
+    echo "Added ${INSTALL_BIN_DIR} to PATH in ${target_profile}"
+    echo "Restart your terminal (or run: source \"${target_profile}\") to use 'nexo' directly."
     ;;
 esac
 
+if ! "${TARGET_BIN_PATH}" --version >/dev/null 2>&1; then
+  echo "Install verification failed: unable to run ${TARGET_BIN_PATH} --version" >&2
+  exit 1
+fi
+
 echo ""
-echo "Verify with:"
-echo "  ${TARGET_BIN_PATH} --help"
+echo "Verification passed:"
+echo "  ${TARGET_BIN_PATH} --version"

--- a/scripts/install/native-installer/install.sh
+++ b/scripts/install/native-installer/install.sh
@@ -2,34 +2,43 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INSTALL_BASE="${NEXO_INSTALL_BASE:-${HOME}/.local/share/nexo}"
-BIN_DIR="${INSTALL_BASE}/bin"
-TARGET_PATH="${BIN_DIR}/nexo"
-SOURCE_BIN_DIR="${SCRIPT_DIR}/bin"
-SOURCE_PATH="${SOURCE_BIN_DIR}/nexo"
+INSTALL_BIN_DIR="${NEXO_INSTALL_BIN:-${HOME}/.local/bin}"
+INSTALL_APP_DIR="${NEXO_INSTALL_APP:-${HOME}/.local/lib/nexo}"
+TARGET_BIN_PATH="${INSTALL_BIN_DIR}/nexo"
+SOURCE_APP_DIR="${SCRIPT_DIR}/app"
+TARGET_APP_BINARY="${INSTALL_APP_DIR}/Nexo.CLI"
 
-if [[ ! -d "${SOURCE_BIN_DIR}" ]]; then
-  echo "Missing bundled app directory at ${SOURCE_BIN_DIR}" >&2
+if [[ ! -d "${SOURCE_APP_DIR}" ]]; then
+  echo "Missing bundled app directory at ${SOURCE_APP_DIR}" >&2
   exit 1
 fi
 
-mkdir -p "${BIN_DIR}"
-cp -R "${SOURCE_BIN_DIR}/." "${BIN_DIR}/"
-chmod +x "${TARGET_PATH}"
+mkdir -p "$(dirname "${INSTALL_APP_DIR}")"
+rm -rf "${INSTALL_APP_DIR}"
+cp -R "${SOURCE_APP_DIR}" "${INSTALL_APP_DIR}"
 
-echo "Installed nexo to ${BIN_DIR}"
+mkdir -p "${INSTALL_BIN_DIR}"
+cat > "${TARGET_BIN_PATH}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${TARGET_APP_BINARY}" "\$@"
+EOF
+chmod +x "${TARGET_BIN_PATH}"
+
+echo "Installed nexo launcher to ${TARGET_BIN_PATH}"
+echo "Installed app to ${INSTALL_APP_DIR}"
 
 case ":${PATH}:" in
-  *":${BIN_DIR}:"*)
+  *":${INSTALL_BIN_DIR}:"*)
     ;;
   *)
     echo ""
-    echo "PATH update recommended: add ${BIN_DIR}"
+    echo "PATH update recommended: add ${INSTALL_BIN_DIR}"
     echo "Example:"
-    echo "  echo 'export PATH=\"${BIN_DIR}:\$PATH\"' >> \"${HOME}/.bashrc\""
+    echo "  echo 'export PATH=\"${INSTALL_BIN_DIR}:\$PATH\"' >> \"${HOME}/.bashrc\""
     ;;
 esac
 
 echo ""
 echo "Verify with:"
-echo "  ${TARGET_PATH} --help"
+echo "  ${TARGET_BIN_PATH} --help"

--- a/scripts/install/native-installer/install.sh
+++ b/scripts/install/native-installer/install.sh
@@ -2,29 +2,31 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INSTALL_BASE="${NEXO_INSTALL_BASE:-${HOME}/.local/bin}"
-TARGET_PATH="${INSTALL_BASE}/nexo"
-SOURCE_PATH="${SCRIPT_DIR}/bin/nexo"
+INSTALL_BASE="${NEXO_INSTALL_BASE:-${HOME}/.local/share/nexo}"
+BIN_DIR="${INSTALL_BASE}/bin"
+TARGET_PATH="${BIN_DIR}/nexo"
+SOURCE_BIN_DIR="${SCRIPT_DIR}/bin"
+SOURCE_PATH="${SOURCE_BIN_DIR}/nexo"
 
-if [[ ! -f "${SOURCE_PATH}" ]]; then
-  echo "Missing bundled binary at ${SOURCE_PATH}" >&2
+if [[ ! -d "${SOURCE_BIN_DIR}" ]]; then
+  echo "Missing bundled app directory at ${SOURCE_BIN_DIR}" >&2
   exit 1
 fi
 
-mkdir -p "${INSTALL_BASE}"
-cp "${SOURCE_PATH}" "${TARGET_PATH}"
+mkdir -p "${BIN_DIR}"
+cp -R "${SOURCE_BIN_DIR}/." "${BIN_DIR}/"
 chmod +x "${TARGET_PATH}"
 
-echo "Installed nexo to ${TARGET_PATH}"
+echo "Installed nexo to ${BIN_DIR}"
 
 case ":${PATH}:" in
-  *":${INSTALL_BASE}:"*)
+  *":${BIN_DIR}:"*)
     ;;
   *)
     echo ""
-    echo "PATH update recommended: add ${INSTALL_BASE}"
+    echo "PATH update recommended: add ${BIN_DIR}"
     echo "Example:"
-    echo "  echo 'export PATH=\"${INSTALL_BASE}:\$PATH\"' >> \"${HOME}/.bashrc\""
+    echo "  echo 'export PATH=\"${BIN_DIR}:\$PATH\"' >> \"${HOME}/.bashrc\""
     ;;
 esac
 

--- a/scripts/install/native-installer/install.sh
+++ b/scripts/install/native-installer/install.sh
@@ -9,6 +9,7 @@ SOURCE_APP_DIR="${SCRIPT_DIR}/app"
 TARGET_APP_BINARY="${INSTALL_APP_DIR}/Nexo.CLI"
 PATH_EXPORT_LINE="export PATH=\"${INSTALL_BIN_DIR}:\$PATH\""
 INSTALL_MARKER="# Added by Nexo native installer"
+PATH_LINE_ADDED=false
 
 if [[ ! -d "${SOURCE_APP_DIR}" ]]; then
   echo "Missing bundled app directory at ${SOURCE_APP_DIR}" >&2
@@ -28,6 +29,7 @@ append_path_if_needed() {
   fi
 
   if [[ "${export_present}" == "true" ]]; then
+    PATH_LINE_ADDED=false
     return
   fi
 
@@ -38,6 +40,7 @@ append_path_if_needed() {
     fi
     echo "${PATH_EXPORT_LINE}"
   } >> "${profile_path}"
+  PATH_LINE_ADDED=true
 }
 
 mkdir -p "$(dirname "${INSTALL_APP_DIR}")"
@@ -75,8 +78,12 @@ case ":${PATH}:" in
     fi
     append_path_if_needed "${target_profile}"
     echo ""
-    echo "Added ${INSTALL_BIN_DIR} to PATH in ${target_profile}"
-    echo "Restart your terminal (or run: source \"${target_profile}\") to use 'nexo' directly."
+    if [[ "${PATH_LINE_ADDED}" == "true" ]]; then
+      echo "Added ${INSTALL_BIN_DIR} to PATH in ${target_profile}"
+      echo "Restart your terminal (or run: source \"${target_profile}\") to use 'nexo' directly."
+    else
+      echo "PATH already configured for ${INSTALL_BIN_DIR} in ${target_profile}"
+    fi
     ;;
 esac
 

--- a/scripts/install/package-native-bundle.ps1
+++ b/scripts/install/package-native-bundle.ps1
@@ -67,11 +67,14 @@ This bundle contains a self-contained Nexo CLI app directory and an install wrap
 powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
+The installer runs a post-install `nexo --help` smoke check and exits non-zero if setup is not usable.
+
 ## What install does
 
 1. Copies the `app` directory to `$HOME\.local\share\nexo\app`.
 2. Creates/updates launchers at `$HOME\.local\bin\nexo.ps1` and `$HOME\.local\bin\nexo.cmd`.
-3. Prints PATH guidance if `$HOME\.local\bin` is not currently on PATH.
+3. Updates the current-user PATH to include `$HOME\.local\bin` when missing.
+4. Prints final verification command and launch paths.
 
 ## Verify
 

--- a/scripts/install/package-native-bundle.ps1
+++ b/scripts/install/package-native-bundle.ps1
@@ -34,8 +34,6 @@ try {
         -r $Rid `
         --self-contained true `
         -p:IncludeTestProjectReferences=false `
-        -p:PublishSingleFile=true `
-        -p:IncludeNativeLibrariesForSelfExtract=true `
         -o $publishDir
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed with exit code $LASTEXITCODE"
@@ -48,10 +46,10 @@ try {
 
     $bundleName = "nexo-native-installer-windows-$Rid"
     $bundleDir = Join-Path $workDir $bundleName
-    $binDir = Join-Path $bundleDir "bin"
-    New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+    $appDir = Join-Path $bundleDir "app"
+    New-Item -ItemType Directory -Path $appDir -Force | Out-Null
 
-    Copy-Item $sourceBinary (Join-Path $binDir "nexo.exe")
+    Copy-Item (Join-Path $publishDir "*") $appDir -Recurse -Force
     Copy-Item (Join-Path $templateDir "install.ps1") (Join-Path $bundleDir "install.ps1")
 
     $readmePath = Join-Path $bundleDir "README.md"
@@ -60,7 +58,7 @@ try {
 
 Version: $Version
 
-This bundle contains a self-contained `nexo.exe` CLI binary and an install wrapper.
+This bundle contains a self-contained Nexo CLI app directory and an install wrapper.
 
 ## Install
 
@@ -70,9 +68,10 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
 
 ## What install does
 
-1. Copies `bin\nexo.exe` to `$HOME\.local\bin\nexo.exe`.
-2. Adds execute/access bits as needed by Windows file ACL defaults.
-3. Prints PATH guidance if `$HOME\.local\bin` is not currently on PATH.
+1. Copies the `app` directory to `$HOME\.local\share\nexo`.
+2. Creates/updates a launcher at `$HOME\.local\bin\nexo.ps1`.
+3. Creates/updates a launcher at `$HOME\.local\bin\nexo.cmd`.
+4. Prints PATH guidance if `$HOME\.local\bin` is not currently on PATH.
 
 ## Verify
 

--- a/scripts/install/package-native-bundle.ps1
+++ b/scripts/install/package-native-bundle.ps1
@@ -69,10 +69,9 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
 
 ## What install does
 
-1. Copies the `app` directory to `$HOME\.local\share\nexo`.
-2. Creates/updates a launcher at `$HOME\.local\bin\nexo.ps1`.
-3. Creates/updates a launcher at `$HOME\.local\bin\nexo.cmd`.
-4. Prints PATH guidance if `$HOME\.local\bin` is not currently on PATH.
+1. Copies the `app` directory to `$HOME\.local\share\nexo\app`.
+2. Creates/updates launchers at `$HOME\.local\bin\nexo.ps1` and `$HOME\.local\bin\nexo.cmd`.
+3. Prints PATH guidance if `$HOME\.local\bin` is not currently on PATH.
 
 ## Verify
 

--- a/scripts/install/package-native-bundle.ps1
+++ b/scripts/install/package-native-bundle.ps1
@@ -34,6 +34,7 @@ try {
         -r $Rid `
         --self-contained true `
         -p:IncludeTestProjectReferences=false `
+        -p:ErrorOnDuplicatePublishOutputFiles=false `
         -o $publishDir
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed with exit code $LASTEXITCODE"

--- a/scripts/install/package-native-bundle.ps1
+++ b/scripts/install/package-native-bundle.ps1
@@ -33,6 +33,7 @@ try {
         -c Release `
         -r $Rid `
         --self-contained true `
+        -p:IncludeTestProjectReferences=false `
         -p:PublishSingleFile=true `
         -p:IncludeNativeLibrariesForSelfExtract=true `
         -o $publishDir

--- a/scripts/install/package-native-bundle.ps1
+++ b/scripts/install/package-native-bundle.ps1
@@ -1,0 +1,95 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Rid,
+    [Parameter(Mandatory = $true)][string]$OutputDir,
+    [string]$Version = "dev"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..\..")
+$templateDir = Join-Path $scriptDir "native-installer"
+
+if (-not (Test-Path $templateDir)) {
+    throw "Missing template directory: $templateDir"
+}
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw "dotnet is required to package installer bundles."
+}
+
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+$publishDir = Join-Path ([System.IO.Path]::GetTempPath()) ("nexo-publish-" + [Guid]::NewGuid().ToString("N"))
+$workDir = Join-Path ([System.IO.Path]::GetTempPath()) ("nexo-bundle-" + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
+New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+
+try {
+    Write-Host "Publishing self-contained CLI for $Rid..."
+    & dotnet publish (Join-Path $repoRoot "src\Nexo.CLI\Nexo.CLI.csproj") `
+        -c Release `
+        -r $Rid `
+        --self-contained true `
+        -p:PublishSingleFile=true `
+        -p:IncludeNativeLibrariesForSelfExtract=true `
+        -o $publishDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed with exit code $LASTEXITCODE"
+    }
+
+    $sourceBinary = Join-Path $publishDir "Nexo.CLI.exe"
+    if (-not (Test-Path $sourceBinary)) {
+        throw "Expected publish output not found: $sourceBinary"
+    }
+
+    $bundleName = "nexo-native-installer-windows-$Rid"
+    $bundleDir = Join-Path $workDir $bundleName
+    $binDir = Join-Path $bundleDir "bin"
+    New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+    Copy-Item $sourceBinary (Join-Path $binDir "nexo.exe")
+    Copy-Item (Join-Path $templateDir "install.ps1") (Join-Path $bundleDir "install.ps1")
+
+    $readmePath = Join-Path $bundleDir "README.md"
+    @"
+# Nexo Native Installer (windows / $Rid)
+
+Version: $Version
+
+This bundle contains a self-contained `nexo.exe` CLI binary and an install wrapper.
+
+## Install
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+## What install does
+
+1. Copies `bin\nexo.exe` to `$HOME\.local\bin\nexo.exe`.
+2. Adds execute/access bits as needed by Windows file ACL defaults.
+3. Prints PATH guidance if `$HOME\.local\bin` is not currently on PATH.
+
+## Verify
+
+```powershell
+nexo --help
+```
+"@ | Set-Content -Path $readmePath -NoNewline
+
+    $artifactName = "$bundleName-$Version.zip"
+    $artifactPath = Join-Path $OutputDir $artifactName
+    if (Test-Path $artifactPath) {
+        Remove-Item $artifactPath -Force
+    }
+
+    Compress-Archive -Path (Join-Path $bundleDir "*") -DestinationPath $artifactPath
+    Write-Host "Created: $artifactPath"
+}
+finally {
+    Remove-Item -Path $publishDir -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $workDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install/package-native-bundle.sh
+++ b/scripts/install/package-native-bundle.sh
@@ -93,8 +93,6 @@ dotnet publish "${REPO_ROOT}/src/Nexo.CLI/Nexo.CLI.csproj" \
   -r "${RID}" \
   --self-contained true \
   -p:IncludeTestProjectReferences=false \
-  -p:PublishSingleFile=true \
-  -p:IncludeNativeLibrariesForSelfExtract=true \
   -o "${publish_dir}"
 
 source_binary="${publish_dir}/Nexo.CLI"
@@ -105,10 +103,10 @@ fi
 
 bundle_name="nexo-native-installer-${PLATFORM}-${RID}"
 bundle_dir="${work_dir}/${bundle_name}"
-mkdir -p "${bundle_dir}/bin"
+mkdir -p "${bundle_dir}"
 
-cp "${source_binary}" "${bundle_dir}/bin/nexo"
-chmod +x "${bundle_dir}/bin/nexo"
+cp -R "${publish_dir}" "${bundle_dir}/app"
+chmod +x "${bundle_dir}/app/Nexo.CLI"
 
 cp "${TEMPLATE_DIR}/install.sh" "${bundle_dir}/install.sh"
 chmod +x "${bundle_dir}/install.sh"
@@ -123,7 +121,7 @@ cat > "${bundle_dir}/README.md" <<EOF
 
 Version: ${VERSION}
 
-This bundle contains a self-contained \`nexo\` CLI binary and an install wrapper.
+This bundle contains a self-contained \`nexo\` CLI app directory and an install wrapper.
 
 ## Install
 
@@ -142,8 +140,9 @@ This bundle contains a self-contained \`nexo\` CLI binary and an install wrapper
 ## What install does
 
 1. Copies \`bin/nexo\` to \`\$HOME/.local/bin/nexo\`.
-2. Marks it executable.
-3. Prints PATH guidance if \`\$HOME/.local/bin\` is not currently on PATH.
+2. Copies runtime dependencies to \`\$HOME/.local/lib/nexo\`.
+3. Marks \`nexo\` executable.
+4. Prints PATH guidance if \`\$HOME/.local/bin\` is not currently on PATH.
 
 ## Verify
 

--- a/scripts/install/package-native-bundle.sh
+++ b/scripts/install/package-native-bundle.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TEMPLATE_DIR="${SCRIPT_DIR}/native-installer"
+
+RID=""
+PLATFORM=""
+VERSION="dev"
+OUTPUT_DIR=""
+
+usage() {
+  echo "Usage: scripts/install/package-native-bundle.sh --rid <rid> --platform <linux|macos> --output-dir <dir> [--version <version>]"
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  if [[ -z "${value}" || "${value}" == --* ]]; then
+    echo "Missing value for ${flag}" >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rid)
+      require_value "$1" "${2:-}"
+      RID="$2"
+      shift
+      ;;
+    --platform)
+      require_value "$1" "${2:-}"
+      PLATFORM="$2"
+      shift
+      ;;
+    --output-dir)
+      require_value "$1" "${2:-}"
+      OUTPUT_DIR="$2"
+      shift
+      ;;
+    --version)
+      require_value "$1" "${2:-}"
+      VERSION="$2"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "${RID}" || -z "${PLATFORM}" || -z "${OUTPUT_DIR}" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ "${PLATFORM}" != "linux" && "${PLATFORM}" != "macos" ]]; then
+  echo "Unsupported platform: ${PLATFORM}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${TEMPLATE_DIR}" ]]; then
+  echo "Missing template directory: ${TEMPLATE_DIR}" >&2
+  exit 1
+fi
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "dotnet is required to package installer bundles." >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+publish_dir="$(mktemp -d)"
+work_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${publish_dir}" "${work_dir}"
+}
+trap cleanup EXIT
+
+echo "Publishing self-contained CLI for ${RID}..."
+dotnet publish "${REPO_ROOT}/src/Nexo.CLI/Nexo.CLI.csproj" \
+  -c Release \
+  -r "${RID}" \
+  --self-contained true \
+  -p:PublishSingleFile=true \
+  -p:IncludeNativeLibrariesForSelfExtract=true \
+  -o "${publish_dir}"
+
+source_binary="${publish_dir}/Nexo.CLI"
+if [[ ! -f "${source_binary}" ]]; then
+  echo "Expected publish output not found: ${source_binary}" >&2
+  exit 1
+fi
+
+bundle_name="nexo-native-installer-${PLATFORM}-${RID}"
+bundle_dir="${work_dir}/${bundle_name}"
+mkdir -p "${bundle_dir}/bin"
+
+cp "${source_binary}" "${bundle_dir}/bin/nexo"
+chmod +x "${bundle_dir}/bin/nexo"
+
+cp "${TEMPLATE_DIR}/install.sh" "${bundle_dir}/install.sh"
+chmod +x "${bundle_dir}/install.sh"
+
+if [[ "${PLATFORM}" == "macos" ]]; then
+  cp "${TEMPLATE_DIR}/install.command" "${bundle_dir}/install.command"
+  chmod +x "${bundle_dir}/install.command"
+fi
+
+cat > "${bundle_dir}/README.md" <<EOF
+# Nexo Native Installer (${PLATFORM} / ${RID})
+
+Version: ${VERSION}
+
+This bundle contains a self-contained \`nexo\` CLI binary and an install wrapper.
+
+## Install
+
+- Linux/macOS terminal:
+
+\`\`\`bash
+./install.sh
+\`\`\`
+
+- macOS Finder (double-click):
+
+\`\`\`bash
+./install.command
+\`\`\`
+
+## What install does
+
+1. Copies \`bin/nexo\` to \`\$HOME/.local/bin/nexo\`.
+2. Marks it executable.
+3. Prints PATH guidance if \`\$HOME/.local/bin\` is not currently on PATH.
+
+## Verify
+
+\`\`\`bash
+nexo --help
+\`\`\`
+EOF
+
+artifact_name="${bundle_name}-${VERSION}.tar.gz"
+artifact_path="${OUTPUT_DIR}/${artifact_name}"
+
+tar -C "${work_dir}" -czf "${artifact_path}" "${bundle_name}"
+echo "Created: ${artifact_path}"

--- a/scripts/install/package-native-bundle.sh
+++ b/scripts/install/package-native-bundle.sh
@@ -93,6 +93,7 @@ dotnet publish "${REPO_ROOT}/src/Nexo.CLI/Nexo.CLI.csproj" \
   -r "${RID}" \
   --self-contained true \
   -p:IncludeTestProjectReferences=false \
+  -p:ErrorOnDuplicatePublishOutputFiles=false \
   -o "${publish_dir}"
 
 source_binary="${publish_dir}/Nexo.CLI"

--- a/scripts/install/package-native-bundle.sh
+++ b/scripts/install/package-native-bundle.sh
@@ -92,6 +92,7 @@ dotnet publish "${REPO_ROOT}/src/Nexo.CLI/Nexo.CLI.csproj" \
   -c Release \
   -r "${RID}" \
   --self-contained true \
+  -p:IncludeTestProjectReferences=false \
   -p:PublishSingleFile=true \
   -p:IncludeNativeLibrariesForSelfExtract=true \
   -o "${publish_dir}"

--- a/scripts/install/package-native-bundle.sh
+++ b/scripts/install/package-native-bundle.sh
@@ -140,10 +140,10 @@ This bundle contains a self-contained \`nexo\` CLI app directory and an install 
 
 ## What install does
 
-1. Copies \`bin/nexo\` to \`\$HOME/.local/bin/nexo\`.
-2. Copies runtime dependencies to \`\$HOME/.local/lib/nexo\`.
-3. Marks \`nexo\` executable.
-4. Prints PATH guidance if \`\$HOME/.local/bin\` is not currently on PATH.
+1. Copies runtime dependencies to \`\$HOME/.local/lib/nexo\`.
+2. Installs launcher at \`\$HOME/.local/bin/nexo\`.
+3. Adds \`\$HOME/.local/bin\` to your shell profile when needed.
+4. Runs a post-install smoke test (\`nexo --version\`).
 
 ## Verify
 

--- a/src/Nexo.CLI/Nexo.CLI.csproj
+++ b/src/Nexo.CLI/Nexo.CLI.csproj
@@ -52,6 +52,9 @@
     <ProjectReference Include="../Nexo.Orchestration/Nexo.Orchestration.csproj" />
     <ProjectReference Include="../Nexo.BackgroundAgents/Nexo.BackgroundAgents.csproj" />
     <ProjectReference Include="../Nexo.Policies.Dev/Nexo.Policies.Dev.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IncludeTestProjectReferences)' != 'false'">
     <!-- Test projects for runtime discovery (excluding CLI to avoid circular dependency) -->
     <ProjectReference Include="../Nexo.Tests.Domain/Nexo.Tests.Domain.csproj" />
     <ProjectReference Include="../Nexo.Tests.Application/Nexo.Tests.Application.csproj" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Hardened `scripts/install/bruteforce-matrix.sh` for deterministic CI behavior by forcing a controlled no-`sudo`/non-interactive environment in the expected-failure case.
- Added explicit brute-force summary output file generation (`.artifacts/install_bruteforce_summary.log`).
- Fixed installer gate artifact upload paths in `.github/workflows/installer-bruteforce-gate.yml` to match the script output directory (`./.artifacts/...`).
- Aligned `README.md` onboarding wording with current auto-bootstrap installer behavior.
- Updated `make package-cli` to use native-bundle packaging scripts instead of stale single-file publish commands.
- Made the Windows packaging step in `make package-cli` resilient by using `pwsh` when available, `powershell` as fallback, and a clear skip message when neither exists.

## Validation run in this branch
- `bash scripts/install/bruteforce-matrix.sh` -> 16/16 cases passed.
- `dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal` -> succeeded.
- `make package-cli` -> produced Linux/macOS native installer bundles and skipped Windows bundle in this Linux environment with explicit messaging.

## Notes
- No UI changes in this PR; validation is terminal-driven only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e5bb7b5-e498-4420-ab51-1fd056b89fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e5bb7b5-e498-4420-ab51-1fd056b89fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

