### PR TITLE
Implement Node Capability Runtime (NCR) foundation and integrations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,6 +84,7 @@
   <!-- Web/API Packages -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="7.4.0" />
@@ -119,7 +120,7 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
     <PackageVersion Include="Dapper" Version="2.1.28" />
     <PackageVersion Include="Npgsql" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.5" />

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -42,6 +42,18 @@ Nexo configures via environment variables and optional `~/.nexo/config.json`. Th
 | `OLLAMA_VISION_MODEL` | Vision model | `richardyoung/smolvlm2-2.2b-instruct` |
 | `OLLAMA_TIMEOUT_SECONDS` | Request timeout | `300` |
 
+### Node Capability Runtime (NCR) Ollama
+
+Desktop NCR uses its own options-bound Ollama endpoint for model serving.
+
+| Key / Variable | Description | Default |
+|----------------|-------------|---------|
+| `Nexo:NodeCapabilityRuntime:Ollama:BaseUrl` (`Nexo__NodeCapabilityRuntime__Ollama__BaseUrl`) | NCR Ollama backend base URL used by desktop policy registrations | `http://127.0.0.1:11434` |
+
+Behavior notes:
+- On startup, NCR runs a health probe against the configured Ollama backend and logs a degraded warning if unreachable.
+- A degraded startup does not crash the host; agentic tasks may escalate until Ollama becomes reachable.
+
 ## Video (SmolVLM2)
 
 | Variable | Description | Default |

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -61,6 +61,20 @@ Remote brick catalogs now use an in-memory stale capability snapshot fallback:
 - Fresh `/api/capabilities` responses are cached per remote base URL.
 - If a later capability fetch fails, the last known manifest is reused and marked stale internally.
 - Consumers should treat stale manifests as routing hints (not hard guarantees), and retry capability refresh periodically.
+- `Nexo:Execution:RemoteCapabilities:MaxStaleAge` (`Nexo__Execution__RemoteCapabilities__MaxStaleAge`) bounds stale fallback age (default `00:10:00`). If stale data exceeds this age, fallback is rejected.
+
+### NCR Telemetry SLO Suggestions (v1)
+
+Suggested starting SLOs/alerts using `ncr.*` metrics:
+- `ncr.model_resolution.target.Escalate`: alert if escalation ratio > 20% over 15 minutes for user-facing workloads.
+- `ncr.model_load.error` and `ncr.ollama.*.error`: alert on sustained non-zero error rate over 5 minutes.
+- `ncr.ollama.chat.duration`: track p95/p99; alert if p95 exceeds your interactive budget for 10+ minutes.
+- `ncr.profile.constraint_change`: watch for bursty spikes that correlate with thermal/memory pressure and escalation increases.
+
+Operational guidance:
+- Treat stale capability fallback as degraded mode; prefer conservative routing and periodic refresh attempts.
+- Keep `NEXO_ENDPOINT_HEALTH_DEGRADED_LOG_THRESHOLD` > 1 in noisy environments to reduce transient probe warning noise.
+- Set `NEXO_OBSERVATION_FAIL_OPEN=1` for production-style hosts that must continue serving even if observation store permissions are restricted.
 
 ## Video (SmolVLM2)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -53,6 +53,14 @@ Desktop NCR uses its own options-bound Ollama endpoint for model serving.
 Behavior notes:
 - On startup, NCR runs a health probe against the configured Ollama backend and logs a degraded warning if unreachable.
 - A degraded startup does not crash the host; agentic tasks may escalate until Ollama becomes reachable.
+- NCR records metrics for model resolution, model load, and Ollama endpoint latencies/error rates via `IMetricsCollector` keys under `ncr.*`.
+
+### NCR Capability Freshness
+
+Remote brick catalogs now use an in-memory stale capability snapshot fallback:
+- Fresh `/api/capabilities` responses are cached per remote base URL.
+- If a later capability fetch fails, the last known manifest is reused and marked stale internally.
+- Consumers should treat stale manifests as routing hints (not hard guarantees), and retry capability refresh periodically.
 
 ## Video (SmolVLM2)
 

--- a/docs/NcrReleaseSLOs.md
+++ b/docs/NcrReleaseSLOs.md
@@ -1,0 +1,59 @@
+# NCR Release SLOs and Alerts (v1)
+
+This document defines the minimum telemetry-backed SLOs for first NCR release.
+
+## Scope
+
+Applies to:
+- NCR model resolution (`ncr.model_resolution.*`)
+- NCR model lifecycle load (`ncr.model_load.*`)
+- NCR execution outcomes (`ncr.outcome.*`)
+- Ollama backend integration (`ncr.ollama.*`)
+- Agentic escalation signals (`ncr.execution.escalated.*`)
+
+## SLO targets (first release)
+
+Evaluate over 1h rolling windows in production-like environments.
+
+1. Model resolution latency
+- Metric: `ncr.model_resolution.duration`
+- Target: p95 <= 150ms
+- Alert: p95 > 300ms for 15m
+
+2. Model load reliability
+- Metrics: `ncr.model_load.success`, `ncr.model_load.error`
+- Target: error ratio <= 2%
+- Alert: error ratio > 5% for 10m
+
+3. Inference reliability
+- Metrics: `ncr.ollama.chat.success`, `ncr.ollama.chat.failure`, `ncr.ollama.chat.error`
+- Target: failure+error ratio <= 2%
+- Alert: failure+error ratio > 5% for 10m
+
+4. Inference latency
+- Metric: `ncr.ollama.chat.duration`
+- Target: p95 <= 8s for interactive workloads
+- Alert: p95 > 12s for 15m
+
+5. Escalation pressure
+- Metric family: `ncr.execution.escalated.*`
+- Target: escalation ratio <= 10% of agentic attempts
+- Alert: escalation ratio > 20% for 15m
+
+6. Stale capability dependence
+- Signal: `CapabilitiesFetchResult.IsStale == true` (from remote catalog fetches)
+- Target: stale responses <= 10% of capability fetches
+- Alert: stale responses > 25% for 15m
+
+## Operational interpretation
+
+- High `ncr.execution.escalated.EscalatedPolicyBlocked` often means local constraints or policy mismatch.
+- High `ncr.execution.escalated.EscalatedInsufficientMemory` suggests memory pressure or model sizing mismatch.
+- Simultaneous rises in `ncr.ollama.ps.error` and `ncr.model_load.error` usually indicate backend health degradation.
+
+## Release gate recommendation
+
+Before first release sign-off:
+- Run a 30-minute soak with representative workflows.
+- Confirm all SLO targets are met for the full soak window.
+- No unresolved Critical alerts at sign-off time.

--- a/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -2,7 +2,10 @@ using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Nexo.BrickContracts.Capabilities;
 using Nexo.Core.Application.Agent.UseCases.RunAgent;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
 using Nexo.Core.Application.Validation.UseCases.RunValidation;
 using Nexo.Infrastructure.Testing.ExecutionPlatform;
 using Nexo.Orchestration.Coordination;
@@ -58,6 +61,11 @@ public static class NexoEndpoints
             .Produces<ExecutionRunResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+        group.MapGet("/capabilities", GetCapabilitiesAsync)
+            .WithName("GetCapabilities")
+            .WithSummary("Get node capability manifest for brick routing")
+            .Produces<NodeCapabilityManifestDto>(StatusCodes.Status200OK);
 
         return app;
     }
@@ -179,6 +187,53 @@ public static class NexoEndpoints
         {
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
+    }
+
+    private static async Task<IResult> GetCapabilitiesAsync(
+        [FromServices] INodeCapabilityRuntime runtime,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask;
+        var manifest = runtime.GetCapabilityManifest();
+        return Results.Ok(ToDto(manifest));
+    }
+
+    private static NodeCapabilityManifestDto ToDto(NodeCapabilityManifest manifest)
+    {
+        return new NodeCapabilityManifestDto
+        {
+            NodeId = manifest.NodeId,
+            Tier = manifest.Tier switch
+            {
+                NodeTier.Core => NodeTierDto.Core,
+                NodeTier.Standard => NodeTierDto.Standard,
+                NodeTier.Micro => NodeTierDto.Micro,
+                _ => NodeTierDto.Nano
+            },
+            Platform = manifest.Platform switch
+            {
+                PlatformType.Windows => PlatformTypeDto.Windows,
+                PlatformType.macOS => PlatformTypeDto.macOS,
+                PlatformType.Linux => PlatformTypeDto.Linux,
+                PlatformType.iOS => PlatformTypeDto.iOS,
+                PlatformType.Android => PlatformTypeDto.Android,
+                _ => PlatformTypeDto.Unknown
+            },
+            HotModelIds = manifest.HotModelIds,
+            AvailableModelIds = manifest.AvailableModelIds,
+            SupportedCapabilities = manifest.SupportedCapabilities.Select(cap => cap switch
+            {
+                TaskCapability.CodeGeneration => TaskCapabilityDto.CodeGeneration,
+                TaskCapability.Embeddings => TaskCapabilityDto.Embeddings,
+                TaskCapability.Vision => TaskCapabilityDto.Vision,
+                TaskCapability.Reasoning => TaskCapabilityDto.Reasoning,
+                TaskCapability.Classification => TaskCapabilityDto.Classification,
+                _ => TaskCapabilityDto.TextGeneration
+            }).ToArray(),
+            AcceptingRemoteWork = manifest.AcceptingRemoteWork,
+            GeneratedAt = manifest.GeneratedAt
+        };
     }
 }
 

--- a/src/Nexo.BackgroundAgents/Observation/NoOpPatternStore.cs
+++ b/src/Nexo.BackgroundAgents/Observation/NoOpPatternStore.cs
@@ -1,0 +1,19 @@
+using Nexo.Core.Application.Observation.Models;
+using Nexo.Core.Application.Observation.Ports;
+
+namespace Nexo.BackgroundAgents.Observation;
+
+/// <summary>
+/// No-op pattern store used when observation persistence cannot be initialized.
+/// </summary>
+public sealed class NoOpPatternStore : IPatternStore
+{
+    public Task AddAsync(ObservedPattern pattern, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<IReadOnlyList<ObservedPattern>> QueryAsync(PatternStoreQueryParams query, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ObservedPattern>>([]);
+
+    public Task PersistAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/src/Nexo.BackgroundAgents/Observation/ObservationPipelineOptions.cs
+++ b/src/Nexo.BackgroundAgents/Observation/ObservationPipelineOptions.cs
@@ -25,4 +25,9 @@ public sealed class ObservationPipelineOptions
 
     /// <summary>Minimum edits to same path to emit repeated-edits pattern.</summary>
     public int RepeatedEditThreshold { get; set; } = 3;
+
+    /// <summary>
+    /// When true, observation pipeline logs store errors and degrades instead of rethrowing.
+    /// </summary>
+    public bool FailOpenOnStoreErrors { get; set; }
 }

--- a/src/Nexo.BackgroundAgents/Observation/ObservationPipelineService.cs
+++ b/src/Nexo.BackgroundAgents/Observation/ObservationPipelineService.cs
@@ -91,6 +91,15 @@ public sealed class ObservationPipelineService : BackgroundService
         }
         catch (Exception ex)
         {
+            if (ex is UnauthorizedAccessException || ex is IOException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Observation pipeline degraded due to storage/permission issue. " +
+                    "Service will stay active and continue retrying with next events.");
+                return;
+            }
+
             _logger.LogError(ex, "Observation pipeline failed: {Error}", ex.Message);
             throw;
         }

--- a/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
+++ b/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nexo.BackgroundAgents.Configuration;
@@ -26,6 +27,8 @@ namespace Nexo.BackgroundAgents;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
+    private const string ObservationDegradedModeEnv = "NEXO_OBSERVATION_DEGRADED_MODE";
+
     /// <summary>
     /// Adds background agent services including scheduler, registry, and policy integration.
     /// Requires orchestration (AgentFactory, LifecycleManager for BackgroundAgentService) and configuration to be registered.
@@ -149,6 +152,10 @@ public static class ServiceCollectionExtensions
     /// <param name="registerHostedService">If true, registers ObservationPipelineService (default true).</param>
     public static IServiceCollection AddObservationPipeline(this IServiceCollection services, Action<ObservationPipelineOptions>? configure = null, bool registerHostedService = true)
     {
+        var degradedModeEnabled = string.Equals(
+            Environment.GetEnvironmentVariable(ObservationDegradedModeEnv),
+            "1",
+            StringComparison.OrdinalIgnoreCase);
         services.Configure<ObservationPipelineOptions>(opts =>
         {
             configure?.Invoke(opts);
@@ -158,7 +165,19 @@ public static class ServiceCollectionExtensions
             var opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ObservationPipelineOptions>>().Value;
             var repoRoot = opts.RepoRoot ?? Directory.GetCurrentDirectory();
             var storePath = Path.Combine(repoRoot, opts.StorePath);
-            return new LiteDbPatternStore(storePath);
+            if (!degradedModeEnabled)
+            {
+                return new LiteDbPatternStore(storePath);
+            }
+
+            try
+            {
+                return new LiteDbPatternStore(storePath);
+            }
+            catch
+            {
+                return new NoOpPatternStore();
+            }
         });
         services.AddSingleton<Nexo.Core.Application.Observation.Ports.IPatternProcessedStore>(sp =>
         {

--- a/src/Nexo.Brick.Contracts/BrickCatalogEntryDto.cs
+++ b/src/Nexo.Brick.Contracts/BrickCatalogEntryDto.cs
@@ -1,3 +1,5 @@
+using Nexo.BrickContracts.Capabilities;
+
 namespace Nexo.BrickContracts;
 
 /// <summary>
@@ -5,7 +7,7 @@ namespace Nexo.BrickContracts;
 /// </summary>
 public class BrickCatalogEntryDto
 {
-    public string WireFormatVersion { get; set; } = "2025-01";
+    public string WireFormatVersion { get; set; } = global::Nexo.BrickContracts.WireFormatVersion.Current;
     public string Id { get; set; } = default!;
     public string Name { get; set; } = default!;
     public string Version { get; set; } = "1.0.0";
@@ -22,4 +24,7 @@ public class BrickCatalogEntryDto
 
     /// <summary>Network-wide usage statistics (populated by central catalog when available).</summary>
     public BrickUsageStatsDto? UsageStats { get; set; }
+
+    /// <summary>Optional capability manifest for the host publishing this brick.</summary>
+    public NodeCapabilityManifestDto? HostCapabilities { get; set; }
 }

--- a/src/Nexo.Brick.Contracts/BrickCatalogResponseDto.cs
+++ b/src/Nexo.Brick.Contracts/BrickCatalogResponseDto.cs
@@ -5,7 +5,7 @@ namespace Nexo.BrickContracts;
 /// </summary>
 public class BrickCatalogResponseDto
 {
-    public string WireFormatVersion { get; set; } = "2025-01";
+    public string WireFormatVersion { get; set; } = Nexo.BrickContracts.WireFormatVersion.Current;
     public IReadOnlyList<BrickCatalogEntryDto> Bricks { get; set; } = [];
     public string? ContinuationToken { get; set; }
 }

--- a/src/Nexo.Brick.Contracts/BrickExecuteRequestDto.cs
+++ b/src/Nexo.Brick.Contracts/BrickExecuteRequestDto.cs
@@ -5,7 +5,7 @@ namespace Nexo.BrickContracts;
 /// </summary>
 public class BrickExecuteRequestDto
 {
-    public string WireFormatVersion { get; set; } = "2025-01";
+    public string WireFormatVersion { get; set; } = Nexo.BrickContracts.WireFormatVersion.Current;
     public string BrickId { get; set; } = default!;
     /// <summary>"Deterministic" or "Agentic".</summary>
     public string Implementation { get; set; } = "Deterministic";

--- a/src/Nexo.Brick.Contracts/BrickExecuteResponseDto.cs
+++ b/src/Nexo.Brick.Contracts/BrickExecuteResponseDto.cs
@@ -5,7 +5,7 @@ namespace Nexo.BrickContracts;
 /// </summary>
 public class BrickExecuteResponseDto
 {
-    public string WireFormatVersion { get; set; } = "2025-01";
+    public string WireFormatVersion { get; set; } = Nexo.BrickContracts.WireFormatVersion.Current;
     public bool Success { get; set; }
     public string? Summary { get; set; }
     /// <summary>Output key-value; binary values use {"__type":"bytes","base64":"..."}.</summary>

--- a/src/Nexo.Brick.Contracts/BrickUsageReportDto.cs
+++ b/src/Nexo.Brick.Contracts/BrickUsageReportDto.cs
@@ -5,7 +5,7 @@ namespace Nexo.BrickContracts;
 /// </summary>
 public class BrickUsageReportDto
 {
-    public string WireFormatVersion { get; set; } = "2025-01";
+    public string WireFormatVersion { get; set; } = Nexo.BrickContracts.WireFormatVersion.Current;
     public string NodeId { get; set; } = default!;
     public List<BrickUsageRecordDto> Records { get; set; } = new();
 }

--- a/src/Nexo.Brick.Contracts/Capabilities/NodeCapabilityManifestDto.cs
+++ b/src/Nexo.Brick.Contracts/Capabilities/NodeCapabilityManifestDto.cs
@@ -1,0 +1,44 @@
+namespace Nexo.BrickContracts.Capabilities;
+
+public enum NodeTierDto
+{
+    Nano,
+    Micro,
+    Standard,
+    Core
+}
+
+public enum PlatformTypeDto
+{
+    Windows,
+    macOS,
+    Linux,
+    iOS,
+    Android,
+    Unknown
+}
+
+public enum TaskCapabilityDto
+{
+    TextGeneration,
+    CodeGeneration,
+    Embeddings,
+    Vision,
+    Reasoning,
+    Classification
+}
+
+/// <summary>
+/// Capability manifest published by each node to assist routing decisions.
+/// </summary>
+public sealed class NodeCapabilityManifestDto
+{
+    public string NodeId { get; set; } = string.Empty;
+    public NodeTierDto Tier { get; set; } = NodeTierDto.Nano;
+    public PlatformTypeDto Platform { get; set; } = PlatformTypeDto.Unknown;
+    public string[] HotModelIds { get; set; } = [];
+    public string[] AvailableModelIds { get; set; } = [];
+    public TaskCapabilityDto[] SupportedCapabilities { get; set; } = [];
+    public bool AcceptingRemoteWork { get; set; }
+    public DateTimeOffset GeneratedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/src/Nexo.Brick.Contracts/WireFormatVersion.cs
+++ b/src/Nexo.Brick.Contracts/WireFormatVersion.cs
@@ -6,7 +6,7 @@ namespace Nexo.BrickContracts;
 public static class WireFormatVersion
 {
     /// <summary>
-    /// Current version (e.g. "2025-01"). Include in catalog and execute payloads.
+    /// Current version (e.g. "2025-02"). Include in catalog and execute payloads.
     /// </summary>
-    public const string Current = "2025-01";
+    public const string Current = "2025-02";
 }

--- a/src/Nexo.Core.Application/Execution/Ports/IAgenticBrickEngine.cs
+++ b/src/Nexo.Core.Application/Execution/Ports/IAgenticBrickEngine.cs
@@ -1,0 +1,38 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.Core.Application.Execution.Ports;
+
+/// <summary>
+/// Bridge between agentic brick execution and NCR model selection.
+/// </summary>
+public interface IAgenticBrickEngine
+{
+    /// <summary>
+    /// Resolves which model/provider should back this brick execution.
+    /// </summary>
+    Task<ModelResolution> ResolveModelForBrickAsync(
+        Brick brick,
+        IExecutionContext context,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Records execution outcome as a scoring feedback signal.
+    /// </summary>
+    Task RecordExecutionOutcomeAsync(
+        ModelResolution resolution,
+        BrickExecutionOutcome outcome,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Simplified outcome signal used by model scoring feedback.
+/// </summary>
+public sealed record BrickExecutionOutcome
+{
+    public bool Succeeded { get; init; }
+    public bool TimedOut { get; init; }
+    public TimeSpan Duration { get; init; }
+    public string? ErrorCode { get; init; }
+}

--- a/src/Nexo.Core.Application/NodeCapabilityRuntime/Models/NodeCapabilityRuntimeModels.cs
+++ b/src/Nexo.Core.Application/NodeCapabilityRuntime/Models/NodeCapabilityRuntimeModels.cs
@@ -1,0 +1,218 @@
+namespace Nexo.Core.Application.NodeCapabilityRuntime.Models;
+
+/// <summary>
+/// Capability tier of the current node.
+/// </summary>
+public enum NodeTier
+{
+    Nano,
+    Micro,
+    Standard,
+    Core
+}
+
+/// <summary>
+/// Host platform of the current runtime.
+/// </summary>
+public enum PlatformType
+{
+    Windows,
+    macOS,
+    Linux,
+    iOS,
+    Android,
+    Unknown
+}
+
+/// <summary>
+/// Task capability types used for model suitability and routing.
+/// </summary>
+public enum TaskCapability
+{
+    TextGeneration,
+    CodeGeneration,
+    Embeddings,
+    Vision,
+    Reasoning,
+    Classification
+}
+
+public enum QualityRequirement
+{
+    Low,
+    Medium,
+    High,
+    Maximum
+}
+
+public enum LatencyRequirement
+{
+    RealTime,
+    Interactive,
+    Background,
+    Overnight
+}
+
+public enum PrivacyBoundary
+{
+    Standard,
+    LocalOnly
+}
+
+public enum ModelState
+{
+    Hot,
+    Warm,
+    Cold
+}
+
+public enum BackendType
+{
+    Ollama,
+    LlamaCppMobile,
+    OnnxRuntime
+}
+
+public enum InferenceTarget
+{
+    Local,
+    Escalate
+}
+
+public enum ResolutionReason
+{
+    BestLocalFit,
+    EscalatedInsufficientMemory,
+    EscalatedQualityRequirement,
+    EscalatedPolicyBlocked,
+    ForcedLocal
+}
+
+public enum AppState
+{
+    Foreground,
+    Background,
+    BackgroundRestricted,
+    Suspended
+}
+
+public enum ThermalState
+{
+    Nominal,
+    Fair,
+    Serious,
+    Critical,
+    Severe
+}
+
+public sealed record NetworkLatencyProfile
+{
+    public bool IsWifi { get; init; }
+    public bool IsMetered { get; init; }
+    public int AverageLatencyMs { get; init; }
+}
+
+public sealed record StorageProfile
+{
+    public long AvailableBytes { get; init; }
+    public long TotalBytes { get; init; }
+}
+
+public sealed record NodeProfile
+{
+    public long AvailableVRAMBytes { get; init; }
+    public long TotalVRAMBytes { get; init; }
+    public long AvailableRAMBytes { get; init; }
+    public long TotalRAMBytes { get; init; }
+    public float GPUUtilizationPercent { get; init; }
+    public float CPUUtilizationPercent { get; init; }
+    public bool IsOnBattery { get; init; }
+    public bool IsCharging { get; init; }
+    public float BatteryLevelPercent { get; init; } = 100f;
+    public bool IsUserActive { get; init; }
+    public AppState AppState { get; init; } = AppState.Foreground;
+    public ThermalState ThermalState { get; init; } = ThermalState.Nominal;
+    public bool HasBackgroundTaskPermission { get; init; }
+    public bool IsBatteryOptimizationEnabled { get; init; }
+    public NetworkLatencyProfile NetworkLatency { get; init; } = new();
+    public StorageProfile Storage { get; init; } = new();
+    public NodeTier Tier { get; init; } = NodeTier.Nano;
+    public PlatformType Platform { get; init; } = PlatformType.Unknown;
+    public DateTimeOffset CapturedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record TaskContext
+{
+    public TaskCapability RequiredCapability { get; init; }
+    public QualityRequirement Quality { get; init; } = QualityRequirement.Medium;
+    public LatencyRequirement Latency { get; init; } = LatencyRequirement.Background;
+    public PrivacyBoundary Privacy { get; init; } = PrivacyBoundary.Standard;
+    public bool IsUserFacing { get; init; }
+    public bool IsDelegationTask { get; init; }
+    public string? RequestedProvider { get; init; }
+}
+
+public sealed record ModelDescriptor
+{
+    public string Id { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string? Provider { get; init; }
+    public string? ProviderModelId { get; init; }
+    public ModelState State { get; init; } = ModelState.Cold;
+    public float QualityScore { get; init; }
+    public float SpeedScore { get; init; }
+    public long WeightSizeBytes { get; init; }
+    public long MinVRAMRequiredBytes { get; init; }
+    public long MinRAMRequiredBytes { get; init; }
+    public bool RequiresRemote { get; init; }
+    public IReadOnlySet<TaskCapability> Capabilities { get; init; } = new HashSet<TaskCapability>();
+    public IReadOnlySet<PlatformType> SupportedPlatforms { get; init; } = new HashSet<PlatformType>();
+}
+
+public sealed record ModelResolution
+{
+    public ModelDescriptor Model { get; init; } = new();
+    public InferenceTarget Target { get; init; }
+    public ResolutionReason Reason { get; init; }
+}
+
+public sealed record NodeCapabilityManifest
+{
+    public string NodeId { get; init; } = string.Empty;
+    public NodeTier Tier { get; init; }
+    public PlatformType Platform { get; init; } = PlatformType.Unknown;
+    public string[] HotModelIds { get; init; } = [];
+    public string[] AvailableModelIds { get; init; } = [];
+    public TaskCapability[] SupportedCapabilities { get; init; } = [];
+    public bool AcceptingRemoteWork { get; init; }
+    public DateTimeOffset GeneratedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record ConstraintUpdate
+{
+    public NodeProfile Previous { get; init; } = new();
+    public NodeProfile Current { get; init; } = new();
+    public string Reason { get; init; } = "ProfileUpdated";
+}
+
+public sealed record PullProgress
+{
+    public string ModelId { get; init; } = string.Empty;
+    public long BytesDownloaded { get; init; }
+    public long TotalBytes { get; init; }
+}
+
+public sealed record InferenceRequest
+{
+    public string ModelId { get; init; } = string.Empty;
+    public string Prompt { get; init; } = string.Empty;
+    public string? SystemPrompt { get; init; }
+    public IReadOnlyDictionary<string, object> Parameters { get; init; } = new Dictionary<string, object>();
+}
+
+public sealed record InferenceResult
+{
+    public string Output { get; init; } = string.Empty;
+    public int TokenCount { get; init; }
+    public TimeSpan Duration { get; init; }
+}

--- a/src/Nexo.Core.Application/NodeCapabilityRuntime/Models/NodeCapabilityRuntimeModels.cs
+++ b/src/Nexo.Core.Application/NodeCapabilityRuntime/Models/NodeCapabilityRuntimeModels.cs
@@ -165,8 +165,8 @@ public sealed record ModelDescriptor
     public long MinVRAMRequiredBytes { get; init; }
     public long MinRAMRequiredBytes { get; init; }
     public bool RequiresRemote { get; init; }
-    public IReadOnlySet<TaskCapability> Capabilities { get; init; } = new HashSet<TaskCapability>();
-    public IReadOnlySet<PlatformType> SupportedPlatforms { get; init; } = new HashSet<PlatformType>();
+    public IReadOnlyCollection<TaskCapability> Capabilities { get; init; } = new HashSet<TaskCapability>();
+    public IReadOnlyCollection<PlatformType> SupportedPlatforms { get; init; } = new HashSet<PlatformType>();
 }
 
 public sealed record ModelResolution

--- a/src/Nexo.Core.Application/NodeCapabilityRuntime/Ports/INodeCapabilityRuntime.cs
+++ b/src/Nexo.Core.Application/NodeCapabilityRuntime/Ports/INodeCapabilityRuntime.cs
@@ -1,0 +1,70 @@
+using Nexo.Core.Application.Execution.Ports;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+
+namespace Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+public interface INodeCapabilityRuntime
+{
+    NodeProfile CurrentProfile { get; }
+
+    Task<ModelResolution> SelectModelAsync(TaskContext context, CancellationToken ct = default);
+
+    Task EnsureModelReadyAsync(ModelDescriptor model, CancellationToken ct = default);
+
+    Task<NodeTier> GetTierAsync();
+
+    IObservable<ConstraintUpdate> ConstraintChanges { get; }
+
+    IReadOnlyList<ModelDescriptor> AvailableModels { get; }
+
+    NodeCapabilityManifest GetCapabilityManifest();
+
+    Task RecordOutcomeAsync(
+        ModelResolution resolution,
+        BrickExecutionOutcome outcome,
+        CancellationToken ct = default);
+}
+
+public interface IPlatformPolicy
+{
+    PlatformType Platform { get; }
+
+    bool CanRunInferenceNow(NodeProfile profile);
+    bool CanLoadModel(ModelDescriptor model, NodeProfile profile);
+    bool CanPullModel(NodeProfile profile);
+    bool CanAdvertiseRemoteWork(NodeProfile profile);
+
+    long MaxModelCacheBytes { get; }
+    long MaxSingleModelBytes { get; }
+    int MaxConcurrentInferenceRequests { get; }
+
+    TimeSpan HotModelTTL { get; }
+    TimeSpan ColdEvictionAge { get; }
+    bool ShouldUnloadAfterInference(NodeProfile profile);
+    bool CanRunIdleMaintenance(NodeProfile profile);
+}
+
+public interface IHardwareProfiler
+{
+    Task<NodeProfile> CaptureAsync(CancellationToken ct = default);
+}
+
+public interface IModelServingBackend
+{
+    BackendType BackendType { get; }
+    Task<bool> IsAvailableAsync(CancellationToken ct = default);
+    Task<InferenceResult> RunInferenceAsync(InferenceRequest request, CancellationToken ct = default);
+    Task LoadModelAsync(string modelId, CancellationToken ct = default);
+    Task UnloadModelAsync(string modelId, CancellationToken ct = default);
+    Task PullModelAsync(string modelId, IProgress<PullProgress>? progress = null, CancellationToken ct = default);
+    Task<IReadOnlyList<string>> ListLoadedModelsAsync(CancellationToken ct = default);
+}
+
+public interface IModelLifecycleManager
+{
+    Task<bool> EnsureLoadedAsync(ModelDescriptor model, CancellationToken ct = default);
+    Task UnloadAsync(ModelDescriptor model);
+    Task PullAsync(ModelDescriptor model, IProgress<PullProgress>? progress = null, CancellationToken ct = default);
+    Task EvictAsync(ModelDescriptor model);
+    Task RunIdleMaintenanceAsync(CancellationToken ct = default);
+}

--- a/src/Nexo.Core.Domain/Execution/Events/ExecutionEvents.cs
+++ b/src/Nexo.Core.Domain/Execution/Events/ExecutionEvents.cs
@@ -186,6 +186,38 @@ public class StepErrorEvent : ExecutionEvent
     }
 }
 
+/// <summary>
+/// Emitted when an agentic step is escalated by NCR instead of running locally.
+/// </summary>
+public class AgenticEscalatedEvent : ExecutionEvent
+{
+    /// <summary>ID of the step that was escalated.</summary>
+    public string StepId { get; init; } = default!;
+    /// <summary>ID of the brick whose execution was escalated.</summary>
+    public string BrickId { get; init; } = default!;
+    /// <summary>NCR escalation reason.</summary>
+    public string Reason { get; init; } = default!;
+    /// <summary>Optional model id considered by NCR.</summary>
+    public string? ModelId { get; init; }
+    /// <summary>Optional provider considered by NCR.</summary>
+    public string? Provider { get; init; }
+
+    public AgenticEscalatedEvent(
+        string stepId,
+        string brickId,
+        string reason,
+        string? modelId = null,
+        string? provider = null)
+        : base("agentic_escalated", DateTime.UtcNow)
+    {
+        StepId = stepId;
+        BrickId = brickId;
+        Reason = reason;
+        ModelId = modelId;
+        Provider = provider;
+    }
+}
+
 // Cache events
 /// <summary>
 /// Emitted when a step result is served from cache.

--- a/src/Nexo.Hosting/NexoHostingOptions.cs
+++ b/src/Nexo.Hosting/NexoHostingOptions.cs
@@ -35,6 +35,12 @@ public sealed class NexoHostingOptions
     public bool DisableObservationPipeline { get; set; }
 
     /// <summary>
+    /// When true, observation pipeline store errors are fail-open (logged and skipped) instead of stopping the host.
+    /// Default: null (resolved from NEXO_OBSERVATION_FAIL_OPEN env var, then false).
+    /// </summary>
+    public bool? ObservationFailOpen { get; set; }
+
+    /// <summary>
     /// Base URL for the Nexo API when used as a remote client (e.g. for mobile thin client).
     /// </summary>
     public string? ApiBaseUrl { get; set; }

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -16,6 +17,7 @@ using Nexo.Infrastructure.Execution;
 using Nexo.Infrastructure.Execution.Ephemeral;
 using Nexo.Infrastructure.Execution.LoadPolicy;
 using Nexo.Infrastructure.Maintenance;
+using Nexo.Infrastructure.NodeCapabilityRuntime;
 using Nexo.Infrastructure.Pipelines;
 using Nexo.Infrastructure.Persistence.Ephemeral;
 using Nexo.Infrastructure.Persistence;
@@ -53,6 +55,22 @@ public static class NexoServiceCollectionExtensions
         configure?.Invoke(options);
 
         services.AddHttpClient();
+        var configuration = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .Build();
+        services.AddNodeCapabilityRuntimeCore(configuration);
+        if (OperatingSystem.IsWindows())
+            services.AddNodeCapabilityRuntimeWindows(configuration);
+        else if (OperatingSystem.IsMacOS())
+            services.AddNodeCapabilityRuntimeMacOS(configuration);
+        else if (OperatingSystem.IsLinux())
+            services.AddNodeCapabilityRuntimeLinux(configuration);
+        else if (OperatingSystem.IsIOS())
+            services.AddNodeCapabilityRuntimeiOS(configuration);
+        else if (OperatingSystem.IsAndroid())
+            services.AddNodeCapabilityRuntimeAndroid(configuration);
+        else
+            services.AddNodeCapabilityRuntimeLinux(configuration);
 
         services.AddMediatR(cfg =>
         {
@@ -193,6 +211,7 @@ public static class NexoServiceCollectionExtensions
                 sp.GetRequiredService<Nexo.Infrastructure.Execution.ISemanticCache>(),
                 sp.GetRequiredService<ILoopKernel>(),
                 sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Nexo.Infrastructure.Execution.BehaviorExecutor>>(),
+                sp.GetService<Nexo.Core.Application.Execution.Ports.IAgenticBrickEngine>(),
                 sp.GetService<Nexo.Core.Application.Execution.Ports.IStepExecutionMode>()));
         services.TryAddSingleton<Nexo.Core.Domain.Execution.IAgentRegistry>(sp =>
         {

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -212,7 +212,8 @@ public static class NexoServiceCollectionExtensions
                 sp.GetRequiredService<ILoopKernel>(),
                 sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Nexo.Infrastructure.Execution.BehaviorExecutor>>(),
                 sp.GetService<Nexo.Core.Application.Execution.Ports.IAgenticBrickEngine>(),
-                sp.GetService<Nexo.Core.Application.Execution.Ports.IStepExecutionMode>()));
+                sp.GetService<Nexo.Core.Application.Execution.Ports.IStepExecutionMode>(),
+                sp.GetService<IMetricsCollector>()));
         services.TryAddSingleton<Nexo.Core.Domain.Execution.IAgentRegistry>(sp =>
         {
             var sdkOptions = sp.GetService<Nexo.Hosting.Sdk.NexoSdkOptions>();

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -58,6 +58,8 @@ public static class NexoServiceCollectionExtensions
         var configuration = new ConfigurationBuilder()
             .AddEnvironmentVariables()
             .Build();
+        services.AddOptions<Nexo.Infrastructure.Execution.RemoteCapabilitiesOptions>()
+            .Bind(configuration.GetSection("Nexo:RemoteCapabilities"));
         services.AddNodeCapabilityRuntimeCore(configuration);
         if (OperatingSystem.IsWindows())
             services.AddNodeCapabilityRuntimeWindows(configuration);
@@ -113,10 +115,12 @@ public static class NexoServiceCollectionExtensions
         if (!options.DisableObservationPipeline)
         {
             var repoRoot = RepoPathResolver.FindRepoRoot();
+            var observationFailOpen = options.ObservationFailOpen ?? ParseBooleanEnvironmentVariable("NEXO_OBSERVATION_FAIL_OPEN");
             services.AddObservationPipeline(opts =>
             {
                 opts.RepoRoot = repoRoot;
                 opts.StorePath = options.PatternStorePath ?? "nexo-patterns.db";
+                opts.FailOpenOnStoreErrors = observationFailOpen;
             }, registerHostedService: options.RegisterBackgroundAgentHostedService);
         }
         services.TryAddSingleton<Nexo.BackgroundAgents.WebSearch.IWebSearchProvider, Nexo.BackgroundAgents.WebSearch.MockWebSearchProvider>();
@@ -296,5 +300,17 @@ public static class NexoServiceCollectionExtensions
         });
 
         return services;
+    }
+
+    private static bool ParseBooleanEnvironmentVariable(string key)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Nexo.Infrastructure/Execution/Agentic/NcrAgenticBrickEngine.cs
+++ b/src/Nexo.Infrastructure/Execution/Agentic/NcrAgenticBrickEngine.cs
@@ -1,0 +1,101 @@
+using Nexo.Core.Application.Execution.Ports;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.Infrastructure.Execution.Agentic;
+
+/// <summary>
+/// Adapter connecting agentic brick execution to the node capability runtime.
+/// </summary>
+public sealed class NcrAgenticBrickEngine : IAgenticBrickEngine
+{
+    private readonly INodeCapabilityRuntime _ncr;
+
+    public NcrAgenticBrickEngine(INodeCapabilityRuntime ncr)
+    {
+        _ncr = ncr ?? throw new ArgumentNullException(nameof(ncr));
+    }
+
+    public async Task<ModelResolution> ResolveModelForBrickAsync(
+        Brick brick,
+        IExecutionContext context,
+        CancellationToken ct = default)
+    {
+        var taskContext = MapBrickToTaskContext(brick, context);
+        var resolution = await _ncr.SelectModelAsync(taskContext, ct).ConfigureAwait(false);
+        if (resolution.Target == InferenceTarget.Local && !string.IsNullOrWhiteSpace(resolution.Model.Id))
+        {
+            await _ncr.EnsureModelReadyAsync(resolution.Model, ct).ConfigureAwait(false);
+        }
+
+        return resolution;
+    }
+
+    public Task RecordExecutionOutcomeAsync(
+        ModelResolution resolution,
+        BrickExecutionOutcome outcome,
+        CancellationToken ct = default)
+        => _ncr.RecordOutcomeAsync(resolution, outcome, ct);
+
+    internal static TaskContext MapBrickToTaskContext(Brick brick, IExecutionContext context)
+    {
+        if (brick is null) throw new ArgumentNullException(nameof(brick));
+        if (context is null) throw new ArgumentNullException(nameof(context));
+
+        var requiredCapability = MapCapability(brick.Category, brick.Implementations.HasAgentic);
+        var isUserFacing = context.Variables.TryGetValue("nexo:user_facing", out var userFacingObj) &&
+                           userFacingObj is bool userFacing &&
+                           userFacing;
+        var quality = ParseEnumVariable(context.Variables, "nexo:quality", QualityRequirement.Medium);
+        var latency = isUserFacing ? LatencyRequirement.Interactive : LatencyRequirement.Background;
+        var privacy = (context.IsAirGapped || context.AuditMode)
+            ? PrivacyBoundary.LocalOnly
+            : ParseEnumVariable(context.Variables, "nexo:privacy", PrivacyBoundary.Standard);
+
+        return new TaskContext
+        {
+            RequiredCapability = requiredCapability,
+            Quality = quality,
+            Latency = latency,
+            Privacy = privacy,
+            IsUserFacing = isUserFacing,
+            IsDelegationTask = context.Variables.ContainsKey("nexo:delegation"),
+            RequestedProvider = string.IsNullOrWhiteSpace(context.Provider) ? null : context.Provider
+        };
+    }
+
+    private static TEnum ParseEnumVariable<TEnum>(
+        IReadOnlyDictionary<string, object> variables,
+        string key,
+        TEnum fallback)
+        where TEnum : struct, Enum
+    {
+        if (!variables.TryGetValue(key, out var value))
+        {
+            return fallback;
+        }
+
+        if (value is string text && Enum.TryParse(text, ignoreCase: true, out TEnum parsed))
+        {
+            return parsed;
+        }
+
+        return fallback;
+    }
+
+    private static TaskCapability MapCapability(BrickCategory category, bool hasAgentic)
+    {
+        return category switch
+        {
+            BrickCategory.Generation => hasAgentic ? TaskCapability.TextGeneration : TaskCapability.Classification,
+            BrickCategory.Analysis => TaskCapability.Reasoning,
+            BrickCategory.Security => TaskCapability.CodeGeneration,
+            BrickCategory.Transform => TaskCapability.TextGeneration,
+            BrickCategory.Control => TaskCapability.Classification,
+            BrickCategory.Output => TaskCapability.TextGeneration,
+            _ => TaskCapability.TextGeneration
+        };
+    }
+}

--- a/src/Nexo.Infrastructure/Execution/BehaviorExecutor.cs
+++ b/src/Nexo.Infrastructure/Execution/BehaviorExecutor.cs
@@ -22,6 +22,7 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
 {
     private readonly Nexo.Core.Domain.Execution.IBrickRegistry _brickRegistry;
     private readonly IProviderFactory _providerFactory;
+    private readonly IAgenticBrickEngine? _agenticBrickEngine;
     private readonly ISemanticCache _semanticCache;
     private readonly ILoopKernel _loops;
     private readonly ILogger<BehaviorExecutor> _logger;
@@ -35,6 +36,7 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
     /// <param name="semanticCache">Semantic cache for brick outputs.</param>
     /// <param name="loops">Loop kernel for step iteration.</param>
     /// <param name="logger">Logger for diagnostics.</param>
+    /// <param name="agenticBrickEngine">Optional NCR-backed model resolution for agentic execution.</param>
     /// <param name="stepExecutionMode">Optional runtime mode override for steps.</param>
     public BehaviorExecutor(
         Nexo.Core.Domain.Execution.IBrickRegistry brickRegistry,
@@ -42,10 +44,12 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
         ISemanticCache semanticCache,
         ILoopKernel loops,
         ILogger<BehaviorExecutor> logger,
+        IAgenticBrickEngine? agenticBrickEngine = null,
         IStepExecutionMode? stepExecutionMode = null)
     {
         _brickRegistry = brickRegistry;
         _providerFactory = providerFactory;
+        _agenticBrickEngine = agenticBrickEngine;
         _semanticCache = semanticCache;
         _loops = loops;
         _logger = logger;
@@ -174,16 +178,65 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
                         }
                         else
                         {
+                            var executionStart = DateTimeOffset.UtcNow;
+                            Nexo.Core.Application.NodeCapabilityRuntime.Models.ModelResolution? resolution = null;
                             try
                             {
-                                output = await brick.ExecuteAsync(brickInput, implementation, context, ct2);
+                                if (implementation == ImplementationType.Agentic && _agenticBrickEngine is not null)
+                                {
+                                    resolution = await _agenticBrickEngine.ResolveModelForBrickAsync(brick, context, ct2);
+                                    if (resolution.Target == Nexo.Core.Application.NodeCapabilityRuntime.Models.InferenceTarget.Escalate)
+                                    {
+                                        throw new InvalidOperationException($"Agentic execution escalated: {resolution.Reason}");
+                                    }
+
+                                    var provider = resolution.Model.Provider ?? resolution.Model.ProviderModelId ?? context.Provider;
+                                    if (!string.IsNullOrWhiteSpace(provider))
+                                    {
+                                        var stepContext = new OverrideProviderExecutionContext(context, provider);
+                                        output = await brick.ExecuteAsync(brickInput, implementation, stepContext, ct2);
+                                    }
+                                    else
+                                    {
+                                        output = await brick.ExecuteAsync(brickInput, implementation, context, ct2);
+                                    }
+                                }
+                                else
+                                {
+                                    output = await brick.ExecuteAsync(brickInput, implementation, context, ct2);
+                                }
                                 await _semanticCache.SetAsync(cacheKey, output, ct2);
+
+                                if (resolution is not null && _agenticBrickEngine is not null)
+                                {
+                                    await _agenticBrickEngine.RecordExecutionOutcomeAsync(
+                                        resolution,
+                                        new BrickExecutionOutcome
+                                        {
+                                            Succeeded = true,
+                                            Duration = DateTimeOffset.UtcNow - executionStart
+                                        },
+                                        ct2);
+                                }
                             }
                             catch (Exception ex)
                             {
                                 output = null;
                                 error = ex.Message;
                                 _logger.LogError(ex, "Error executing step {StepId} with {Implementation}", step.Id, implementation);
+                                if (resolution is not null && _agenticBrickEngine is not null)
+                                {
+                                    await _agenticBrickEngine.RecordExecutionOutcomeAsync(
+                                        resolution,
+                                        new BrickExecutionOutcome
+                                        {
+                                            Succeeded = false,
+                                            TimedOut = ex is TimeoutException,
+                                            Duration = DateTimeOffset.UtcNow - executionStart,
+                                            ErrorCode = ex.GetType().Name
+                                        },
+                                        ct2);
+                                }
                             }
                         }
 

--- a/src/Nexo.Infrastructure/Execution/BehaviorExecutor.cs
+++ b/src/Nexo.Infrastructure/Execution/BehaviorExecutor.cs
@@ -27,6 +27,7 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
     private readonly ILoopKernel _loops;
     private readonly ILogger<BehaviorExecutor> _logger;
     private readonly IStepExecutionMode? _stepExecutionMode;
+    private readonly IMetricsCollector? _metricsCollector;
     
     /// <summary>
     /// Creates a new behavior executor.
@@ -38,6 +39,7 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
     /// <param name="logger">Logger for diagnostics.</param>
     /// <param name="agenticBrickEngine">Optional NCR-backed model resolution for agentic execution.</param>
     /// <param name="stepExecutionMode">Optional runtime mode override for steps.</param>
+    /// <param name="metricsCollector">Optional telemetry collector for execution metrics.</param>
     public BehaviorExecutor(
         Nexo.Core.Domain.Execution.IBrickRegistry brickRegistry,
         IProviderFactory providerFactory,
@@ -45,7 +47,8 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
         ILoopKernel loops,
         ILogger<BehaviorExecutor> logger,
         IAgenticBrickEngine? agenticBrickEngine = null,
-        IStepExecutionMode? stepExecutionMode = null)
+        IStepExecutionMode? stepExecutionMode = null,
+        IMetricsCollector? metricsCollector = null)
     {
         _brickRegistry = brickRegistry;
         _providerFactory = providerFactory;
@@ -54,6 +57,7 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
         _loops = loops;
         _logger = logger;
         _stepExecutionMode = stepExecutionMode;
+        _metricsCollector = metricsCollector;
     }
     
     /// <inheritdoc />
@@ -187,27 +191,49 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
                                     resolution = await _agenticBrickEngine.ResolveModelForBrickAsync(brick, context, ct2);
                                     if (resolution.Target == Nexo.Core.Application.NodeCapabilityRuntime.Models.InferenceTarget.Escalate)
                                     {
-                                        throw new InvalidOperationException($"Agentic execution escalated: {resolution.Reason}");
-                                    }
-
-                                    var provider = resolution.Model.Provider ?? resolution.Model.ProviderModelId ?? context.Provider;
-                                    if (!string.IsNullOrWhiteSpace(provider))
-                                    {
-                                        var stepContext = new OverrideProviderExecutionContext(context, provider);
-                                        output = await brick.ExecuteAsync(brickInput, implementation, stepContext, ct2);
+                                        var modelId = string.IsNullOrWhiteSpace(resolution.Model.Id)
+                                            ? null
+                                            : resolution.Model.Id;
+                                        var provider = resolution.Model.Provider ?? resolution.Model.ProviderModelId ?? context.Provider;
+                                        error = $"Agentic execution escalated: {resolution.Reason}";
+                                        _metricsCollector?.IncrementCounter($"ncr.execution.escalated.{resolution.Reason}");
+                                        await writer.WriteAsync(
+                                            new AgenticEscalatedEvent(step.Id, brick.Id, resolution.Reason.ToString(), modelId, provider),
+                                            ct2);
+                                        await _agenticBrickEngine.RecordExecutionOutcomeAsync(
+                                            resolution,
+                                            new BrickExecutionOutcome
+                                            {
+                                                Succeeded = false,
+                                                Duration = DateTimeOffset.UtcNow - executionStart,
+                                                ErrorCode = "Escalated"
+                                            },
+                                            ct2);
                                     }
                                     else
                                     {
-                                        output = await brick.ExecuteAsync(brickInput, implementation, context, ct2);
+                                        var provider = resolution.Model.Provider ?? resolution.Model.ProviderModelId ?? context.Provider;
+                                        if (!string.IsNullOrWhiteSpace(provider))
+                                        {
+                                            var stepContext = new OverrideProviderExecutionContext(context, provider);
+                                            output = await brick.ExecuteAsync(brickInput, implementation, stepContext, ct2);
+                                        }
+                                        else
+                                        {
+                                            output = await brick.ExecuteAsync(brickInput, implementation, context, ct2);
+                                        }
                                     }
                                 }
                                 else
                                 {
                                     output = await brick.ExecuteAsync(brickInput, implementation, context, ct2);
                                 }
-                                await _semanticCache.SetAsync(cacheKey, output, ct2);
+                                if (output is not null)
+                                {
+                                    await _semanticCache.SetAsync(cacheKey, output, ct2);
+                                }
 
-                                if (resolution is not null && _agenticBrickEngine is not null)
+                                if (resolution is not null && _agenticBrickEngine is not null && output is not null)
                                 {
                                     await _agenticBrickEngine.RecordExecutionOutcomeAsync(
                                         resolution,
@@ -244,6 +270,7 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
 
                         if (output != null)
                         {
+                            _metricsCollector?.RecordExecutionTime("ncr.execution.step.duration", stopwatch.Elapsed);
                             MapOutputs(step.OutputMapping, output, context);
                             await writer.WriteAsync(new StepCompletedEvent(
                                 step.Id,
@@ -257,6 +284,7 @@ public class BehaviorExecutor : Nexo.Core.Domain.Execution.IBehaviorExecutor
                         }
 
                         await writer.WriteAsync(new StepErrorEvent(step.Id, error ?? "Step failed", stopwatch.ElapsedMilliseconds), ct2);
+                        _metricsCollector?.IncrementCounter("ncr.execution.step.error");
 
                         if (!options.SwapOnFailure)
                         {

--- a/src/Nexo.Infrastructure/Execution/CompositeBrickRegistry.cs
+++ b/src/Nexo.Infrastructure/Execution/CompositeBrickRegistry.cs
@@ -41,6 +41,7 @@ public sealed class CompositeBrickRegistry : IBrickRegistry
                 if (entry != null)
                 {
                     var executeBaseUrl = entry.HostBaseUrl ?? catalog.BaseUrl.TrimEnd('/');
+                    entry.HostCapabilities ??= catalog.GetCapabilitiesWithStalenessAsync().GetAwaiter().GetResult().Capabilities;
                     return new RemoteBrick(entry, _httpClient, executeBaseUrl, null);
                 }
             }
@@ -66,9 +67,11 @@ public sealed class CompositeBrickRegistry : IBrickRegistry
             {
                 var entries = catalog.GetAllAsync().GetAwaiter().GetResult();
                 var baseUrl = catalog.BaseUrl.TrimEnd('/');
+                var hostCapabilities = catalog.GetCapabilitiesWithStalenessAsync().GetAwaiter().GetResult().Capabilities;
                 foreach (var entry in entries)
                 {
                     if (set.ContainsKey(entry.Id)) continue;
+                    entry.HostCapabilities ??= hostCapabilities;
                     set[entry.Id] = new RemoteBrick(entry, _httpClient, entry.HostBaseUrl ?? baseUrl, null);
                 }
             }

--- a/src/Nexo.Infrastructure/Execution/CompositeBrickRegistry.cs
+++ b/src/Nexo.Infrastructure/Execution/CompositeBrickRegistry.cs
@@ -41,7 +41,15 @@ public sealed class CompositeBrickRegistry : IBrickRegistry
                 if (entry != null)
                 {
                     var executeBaseUrl = entry.HostBaseUrl ?? catalog.BaseUrl.TrimEnd('/');
-                    entry.HostCapabilities ??= catalog.GetCapabilitiesWithStalenessAsync().GetAwaiter().GetResult().Capabilities;
+                    var capabilityFetch = catalog.GetCapabilitiesWithStalenessAsync().GetAwaiter().GetResult();
+                    entry.HostCapabilities ??= capabilityFetch.Capabilities;
+                    if (capabilityFetch.IsStale)
+                    {
+                        _logger?.LogWarning(
+                            "Remote brick {BrickId} from {BaseUrl} is using stale host capability data.",
+                            entry.Id,
+                            catalog.BaseUrl);
+                    }
                     return new RemoteBrick(entry, _httpClient, executeBaseUrl, null);
                 }
             }
@@ -67,7 +75,14 @@ public sealed class CompositeBrickRegistry : IBrickRegistry
             {
                 var entries = catalog.GetAllAsync().GetAwaiter().GetResult();
                 var baseUrl = catalog.BaseUrl.TrimEnd('/');
-                var hostCapabilities = catalog.GetCapabilitiesWithStalenessAsync().GetAwaiter().GetResult().Capabilities;
+                var capabilityFetch = catalog.GetCapabilitiesWithStalenessAsync().GetAwaiter().GetResult();
+                var hostCapabilities = capabilityFetch.Capabilities;
+                if (capabilityFetch.IsStale)
+                {
+                    _logger?.LogWarning(
+                        "Remote catalog {BaseUrl} returned stale host capability data for brick list.",
+                        catalog.BaseUrl);
+                }
                 foreach (var entry in entries)
                 {
                     if (set.ContainsKey(entry.Id)) continue;

--- a/src/Nexo.Infrastructure/Execution/HttpRemoteBrickCatalog.cs
+++ b/src/Nexo.Infrastructure/Execution/HttpRemoteBrickCatalog.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Nexo.BrickContracts;
 using Nexo.BrickContracts.Capabilities;
 
@@ -15,6 +16,7 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
     private readonly ILogger<HttpRemoteBrickCatalog>? _logger;
     private readonly StaleCapabilitiesSnapshotStore? _staleCapabilities;
     private readonly TimeSpan _capabilityTtl;
+    private readonly TimeSpan _maxStaleCapabilityAge;
     private readonly object _capabilityGate = new();
     private NodeCapabilityManifestDto? _cachedCapabilities;
     private DateTimeOffset _capabilitiesFetchedAt = DateTimeOffset.MinValue;
@@ -23,12 +25,14 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
         HttpClient httpClient,
         ILogger<HttpRemoteBrickCatalog>? logger = null,
         StaleCapabilitiesSnapshotStore? staleCapabilities = null,
-        TimeSpan? capabilityTtl = null)
+        TimeSpan? capabilityTtl = null,
+        TimeSpan? maxStaleCapabilityAge = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _logger = logger;
         _staleCapabilities = staleCapabilities;
         _capabilityTtl = capabilityTtl ?? TimeSpan.FromSeconds(30);
+        _maxStaleCapabilityAge = maxStaleCapabilityAge ?? TimeSpan.FromMinutes(5);
     }
 
     public string BaseUrl => _httpClient.BaseAddress?.ToString() ?? string.Empty;
@@ -128,7 +132,7 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
             _logger?.LogDebug("Capabilities endpoint not found at {BaseUrl}; using cached value when available.", BaseUrl);
             lock (_capabilityGate)
             {
-                var fallback = _cachedCapabilities ?? _staleCapabilities?.Get(BaseUrl);
+                var fallback = SelectEligibleStaleCapabilities();
                 return new CapabilitiesFetchResult
                 {
                     Capabilities = fallback,
@@ -141,7 +145,7 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
             _logger?.LogWarning(ex, "Failed to fetch capabilities from {BaseUrl}", BaseUrl);
             lock (_capabilityGate)
             {
-                var fallback = _cachedCapabilities ?? _staleCapabilities?.Get(BaseUrl);
+                var fallback = SelectEligibleStaleCapabilities();
                 return new CapabilitiesFetchResult
                 {
                     Capabilities = fallback,
@@ -149,6 +153,36 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
                 };
             }
         }
+    }
+
+    private NodeCapabilityManifestDto? SelectEligibleStaleCapabilities()
+    {
+        var stale = _cachedCapabilities ?? _staleCapabilities?.Get(BaseUrl);
+        if (stale is null)
+        {
+            return null;
+        }
+
+        var staleAge = DateTimeOffset.UtcNow - stale.GeneratedAt;
+        if (stale.GeneratedAt > DateTimeOffset.UtcNow.AddMinutes(1))
+        {
+            _logger?.LogWarning(
+                "Discarding stale capabilities for {BaseUrl}; manifest generatedAt is in the future ({GeneratedAt}).",
+                BaseUrl,
+                stale.GeneratedAt);
+            return null;
+        }
+        if (staleAge > _maxStaleCapabilityAge)
+        {
+            _logger?.LogWarning(
+                "Discarding stale capabilities for {BaseUrl}; age {AgeSeconds}s exceeds max {MaxAgeSeconds}s.",
+                BaseUrl,
+                staleAge.TotalSeconds,
+                _maxStaleCapabilityAge.TotalSeconds);
+            return null;
+        }
+
+        return stale;
     }
 
     private async Task<NodeCapabilityManifestDto?> FetchCapabilitiesAsync(CancellationToken cancellationToken)
@@ -248,6 +282,16 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
         }
 
         return items.ToArray();
+    }
+
+    private bool IsStaleWithinAge(NodeCapabilityManifestDto manifest, DateTimeOffset now)
+    {
+        if (manifest.GeneratedAt == default)
+        {
+            return true;
+        }
+        var age = now - manifest.GeneratedAt;
+        return age <= _maxStaleCapabilityAge;
     }
 
     private static TEnum[] ReadEnumArray<TEnum>(JsonElement root, string propertyName)

--- a/src/Nexo.Infrastructure/Execution/HttpRemoteBrickCatalog.cs
+++ b/src/Nexo.Infrastructure/Execution/HttpRemoteBrickCatalog.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Nexo.BrickContracts;
 using Nexo.BrickContracts.Capabilities;
@@ -12,11 +13,22 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<HttpRemoteBrickCatalog>? _logger;
+    private readonly StaleCapabilitiesSnapshotStore? _staleCapabilities;
+    private readonly TimeSpan _capabilityTtl;
+    private readonly object _capabilityGate = new();
+    private NodeCapabilityManifestDto? _cachedCapabilities;
+    private DateTimeOffset _capabilitiesFetchedAt = DateTimeOffset.MinValue;
 
-    public HttpRemoteBrickCatalog(HttpClient httpClient, ILogger<HttpRemoteBrickCatalog>? logger = null)
+    public HttpRemoteBrickCatalog(
+        HttpClient httpClient,
+        ILogger<HttpRemoteBrickCatalog>? logger = null,
+        StaleCapabilitiesSnapshotStore? staleCapabilities = null,
+        TimeSpan? capabilityTtl = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _logger = logger;
+        _staleCapabilities = staleCapabilities;
+        _capabilityTtl = capabilityTtl ?? TimeSpan.FromSeconds(30);
     }
 
     public string BaseUrl => _httpClient.BaseAddress?.ToString() ?? string.Empty;
@@ -25,9 +37,11 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
     {
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<BrickCatalogResponseDto>("/api/bricks", cancellationToken).ConfigureAwait(false);
-            var bricks = response?.Bricks?.ToList() ?? [];
-            var capabilities = await GetCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
+            using var response = await _httpClient.GetAsync("/api/bricks", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            var bricks = await ReadBrickEntriesCompatAsync(stream, cancellationToken).ConfigureAwait(false);
+            var capabilities = (await GetCapabilitiesWithStalenessAsync(cancellationToken).ConfigureAwait(false)).Capabilities;
             if (capabilities is not null)
             {
                 foreach (var entry in bricks)
@@ -57,7 +71,7 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
                 return null;
             }
 
-            entry.HostCapabilities ??= await GetCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
+            entry.HostCapabilities ??= (await GetCapabilitiesWithStalenessAsync(cancellationToken).ConfigureAwait(false)).Capabilities;
             return entry;
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -72,21 +86,376 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
     }
 
     public async Task<NodeCapabilityManifestDto?> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
+        => (await GetCapabilitiesWithStalenessAsync(cancellationToken).ConfigureAwait(false)).Capabilities;
+
+    public async Task<CapabilitiesFetchResult> GetCapabilitiesWithStalenessAsync(CancellationToken cancellationToken = default)
     {
+        var now = DateTimeOffset.UtcNow;
+        lock (_capabilityGate)
+        {
+            if (_cachedCapabilities is not null && now - _capabilitiesFetchedAt <= _capabilityTtl)
+            {
+                return new CapabilitiesFetchResult
+                {
+                    Capabilities = _cachedCapabilities,
+                    IsStale = false
+                };
+            }
+        }
+
         try
         {
-            return await _httpClient
-                .GetFromJsonAsync<NodeCapabilityManifestDto>("/api/capabilities", cancellationToken)
-                .ConfigureAwait(false);
+            var capabilities = await FetchCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
+            if (capabilities is not null)
+            {
+                lock (_capabilityGate)
+                {
+                    _cachedCapabilities = capabilities;
+                    _capabilitiesFetchedAt = DateTimeOffset.UtcNow;
+                }
+
+                _staleCapabilities?.Put(BaseUrl, capabilities);
+            }
+
+            return new CapabilitiesFetchResult
+            {
+                Capabilities = capabilities,
+                IsStale = false
+            };
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
-            return null;
+            _logger?.LogDebug("Capabilities endpoint not found at {BaseUrl}; using cached value when available.", BaseUrl);
+            lock (_capabilityGate)
+            {
+                var fallback = _cachedCapabilities ?? _staleCapabilities?.Get(BaseUrl);
+                return new CapabilitiesFetchResult
+                {
+                    Capabilities = fallback,
+                    IsStale = fallback is not null
+                };
+            }
         }
         catch (Exception ex)
         {
             _logger?.LogWarning(ex, "Failed to fetch capabilities from {BaseUrl}", BaseUrl);
+            lock (_capabilityGate)
+            {
+                var fallback = _cachedCapabilities ?? _staleCapabilities?.Get(BaseUrl);
+                return new CapabilitiesFetchResult
+                {
+                    Capabilities = fallback,
+                    IsStale = fallback is not null
+                };
+            }
+        }
+    }
+
+    private async Task<NodeCapabilityManifestDto?> FetchCapabilitiesAsync(CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.GetAsync("/api/capabilities", cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            throw new HttpRequestException("Capabilities endpoint not found.", null, System.Net.HttpStatusCode.NotFound);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (doc.RootElement.ValueKind != JsonValueKind.Object)
+        {
             return null;
         }
+
+        return new NodeCapabilityManifestDto
+        {
+            NodeId = ReadString(doc.RootElement, "nodeId") ?? string.Empty,
+            Tier = ReadEnum(doc.RootElement, "tier", NodeTierDto.Nano),
+            Platform = ReadEnum(doc.RootElement, "platform", PlatformTypeDto.Unknown),
+            HotModelIds = ReadStringArray(doc.RootElement, "hotModelIds"),
+            AvailableModelIds = ReadStringArray(doc.RootElement, "availableModelIds"),
+            SupportedCapabilities = ReadEnumArray<TaskCapabilityDto>(doc.RootElement, "supportedCapabilities"),
+            AcceptingRemoteWork = ReadBool(doc.RootElement, "acceptingRemoteWork"),
+            GeneratedAt = ReadDateTimeOffset(doc.RootElement, "generatedAt", DateTimeOffset.UtcNow)
+        };
+    }
+
+    private static string? ReadString(JsonElement root, string propertyName)
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null
+        };
+    }
+
+    private static bool ReadBool(JsonElement root, string propertyName)
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value))
+        {
+            return false;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String => bool.TryParse(value.GetString(), out var parsed) && parsed,
+            JsonValueKind.Number => value.TryGetInt32(out var numeric) && numeric != 0,
+            _ => false
+        };
+    }
+
+    private static DateTimeOffset ReadDateTimeOffset(JsonElement root, string propertyName, DateTimeOffset fallback)
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value))
+        {
+            return fallback;
+        }
+
+        if (value.ValueKind == JsonValueKind.String && DateTimeOffset.TryParse(value.GetString(), out var parsed))
+        {
+            return parsed;
+        }
+
+        return fallback;
+    }
+
+    private static string[] ReadStringArray(JsonElement root, string propertyName)
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value) || value.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var items = new List<string>();
+        foreach (var item in value.EnumerateArray())
+        {
+            var text = item.ValueKind == JsonValueKind.String ? item.GetString() : item.GetRawText();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                items.Add(text);
+            }
+        }
+
+        return items.ToArray();
+    }
+
+    private static TEnum[] ReadEnumArray<TEnum>(JsonElement root, string propertyName)
+        where TEnum : struct, Enum
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value) || value.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var items = new List<TEnum>();
+        foreach (var item in value.EnumerateArray())
+        {
+            if (TryParseEnum(item, out TEnum parsed))
+            {
+                items.Add(parsed);
+            }
+        }
+
+        return items.ToArray();
+    }
+
+    private static TEnum ReadEnum<TEnum>(JsonElement root, string propertyName, TEnum fallback)
+        where TEnum : struct, Enum
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value))
+        {
+            return fallback;
+        }
+
+        return TryParseEnum(value, out TEnum parsed) ? parsed : fallback;
+    }
+
+    private static bool TryParseEnum<TEnum>(JsonElement value, out TEnum parsed)
+        where TEnum : struct, Enum
+    {
+        if (value.ValueKind == JsonValueKind.String &&
+            Enum.TryParse(value.GetString(), ignoreCase: true, out parsed))
+        {
+            return true;
+        }
+
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var numeric) &&
+            Enum.IsDefined(typeof(TEnum), numeric))
+        {
+            parsed = (TEnum)Enum.ToObject(typeof(TEnum), numeric);
+            return true;
+        }
+
+        parsed = default;
+        return false;
+    }
+
+    private static bool TryGetPropertyIgnoreCase(JsonElement root, string propertyName, out JsonElement value)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static async Task<List<BrickCatalogEntryDto>> ReadBrickEntriesCompatAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+            !TryGetPropertyIgnoreCase(doc.RootElement, "bricks", out var bricksNode) ||
+            bricksNode.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var entries = new List<BrickCatalogEntryDto>();
+        foreach (var brick in bricksNode.EnumerateArray())
+        {
+            if (brick.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var interfaceNode = TryGetPropertyIgnoreCase(brick, "interface", out var iface)
+                ? iface
+                : default;
+            var metadataNode = TryGetPropertyIgnoreCase(brick, "metadata", out var meta)
+                ? meta
+                : default;
+
+            entries.Add(new BrickCatalogEntryDto
+            {
+                WireFormatVersion = ReadString(brick, "wireFormatVersion") ?? Nexo.BrickContracts.WireFormatVersion.Current,
+                Id = ReadString(brick, "id") ?? string.Empty,
+                Name = ReadString(brick, "name") ?? string.Empty,
+                Version = ReadString(brick, "version") ?? "1.0.0",
+                Icon = ReadString(brick, "icon") ?? "pkg",
+                Category = ReadString(brick, "category") ?? string.Empty,
+                Description = ReadString(brick, "description") ?? string.Empty,
+                HostBaseUrl = ReadString(brick, "hostBaseUrl"),
+                HasDeterministic = ReadBool(brick, "hasDeterministic"),
+                HasAgentic = ReadBool(brick, "hasAgentic"),
+                Interface = new BrickInterfaceDto
+                {
+                    Inputs = ReadInterfaceInputs(interfaceNode),
+                    Outputs = ReadInterfaceOutputs(interfaceNode)
+                },
+                Metadata = new BrickMetadataDto
+                {
+                    Author = ReadString(metadataNode, "author"),
+                    License = ReadString(metadataNode, "license"),
+                    Repository = ReadString(metadataNode, "repository"),
+                    UsageCount = ReadLong(metadataNode, "usageCount"),
+                    LastUpdated = ReadNullableDateTime(metadataNode, "lastUpdated")
+                }
+            });
+        }
+
+        return entries;
+    }
+
+    private static IReadOnlyList<BrickInputDefinitionDto> ReadInterfaceInputs(JsonElement node)
+    {
+        if (node.ValueKind != JsonValueKind.Object ||
+            !TryGetPropertyIgnoreCase(node, "inputs", out var inputsNode) ||
+            inputsNode.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var list = new List<BrickInputDefinitionDto>();
+        foreach (var item in inputsNode.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object) continue;
+            list.Add(new BrickInputDefinitionDto
+            {
+                Name = ReadString(item, "name") ?? string.Empty,
+                Type = ReadString(item, "type") ?? string.Empty,
+                Description = ReadString(item, "description"),
+                Required = ReadBool(item, "required"),
+                Default = ReadString(item, "default")
+            });
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<BrickOutputDefinitionDto> ReadInterfaceOutputs(JsonElement node)
+    {
+        if (node.ValueKind != JsonValueKind.Object ||
+            !TryGetPropertyIgnoreCase(node, "outputs", out var outputsNode) ||
+            outputsNode.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var list = new List<BrickOutputDefinitionDto>();
+        foreach (var item in outputsNode.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object) continue;
+            list.Add(new BrickOutputDefinitionDto
+            {
+                Name = ReadString(item, "name") ?? string.Empty,
+                Type = ReadString(item, "type") ?? string.Empty,
+                Description = ReadString(item, "description")
+            });
+        }
+
+        return list;
+    }
+
+    private static long ReadLong(JsonElement root, string propertyName)
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value))
+        {
+            return 0;
+        }
+
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var parsed))
+        {
+            return parsed;
+        }
+
+        if (value.ValueKind == JsonValueKind.String && long.TryParse(value.GetString(), out parsed))
+        {
+            return parsed;
+        }
+
+        return 0;
+    }
+
+    private static DateTime? ReadNullableDateTime(JsonElement root, string propertyName)
+    {
+        if (!TryGetPropertyIgnoreCase(root, propertyName, out var value))
+        {
+            return null;
+        }
+
+        if (value.ValueKind == JsonValueKind.String && DateTime.TryParse(value.GetString(), out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
     }
 }

--- a/src/Nexo.Infrastructure/Execution/HttpRemoteBrickCatalog.cs
+++ b/src/Nexo.Infrastructure/Execution/HttpRemoteBrickCatalog.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Nexo.BrickContracts;
+using Nexo.BrickContracts.Capabilities;
 
 namespace Nexo.Infrastructure.Execution;
 
@@ -25,7 +26,17 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
         try
         {
             var response = await _httpClient.GetFromJsonAsync<BrickCatalogResponseDto>("/api/bricks", cancellationToken).ConfigureAwait(false);
-            return response?.Bricks ?? [];
+            var bricks = response?.Bricks?.ToList() ?? [];
+            var capabilities = await GetCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
+            if (capabilities is not null)
+            {
+                foreach (var entry in bricks)
+                {
+                    entry.HostCapabilities ??= capabilities;
+                }
+            }
+
+            return bricks;
         }
         catch (Exception ex)
         {
@@ -40,7 +51,14 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
         try
         {
             var url = $"/api/bricks/{Uri.EscapeDataString(brickId)}";
-            return await _httpClient.GetFromJsonAsync<BrickCatalogEntryDto>(url, cancellationToken).ConfigureAwait(false);
+            var entry = await _httpClient.GetFromJsonAsync<BrickCatalogEntryDto>(url, cancellationToken).ConfigureAwait(false);
+            if (entry is null)
+            {
+                return null;
+            }
+
+            entry.HostCapabilities ??= await GetCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
+            return entry;
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -49,6 +67,25 @@ public sealed class HttpRemoteBrickCatalog : IRemoteBrickCatalog
         catch (Exception ex)
         {
             _logger?.LogWarning(ex, "Failed to fetch brick {BrickId} from {BaseUrl}", brickId, BaseUrl);
+            return null;
+        }
+    }
+
+    public async Task<NodeCapabilityManifestDto?> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _httpClient
+                .GetFromJsonAsync<NodeCapabilityManifestDto>("/api/capabilities", cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to fetch capabilities from {BaseUrl}", BaseUrl);
             return null;
         }
     }

--- a/src/Nexo.Infrastructure/Execution/IRemoteBrickCatalog.cs
+++ b/src/Nexo.Infrastructure/Execution/IRemoteBrickCatalog.cs
@@ -21,4 +21,18 @@ public interface IRemoteBrickCatalog
     /// Gets remote node capabilities from companion endpoint.
     /// </summary>
     Task<NodeCapabilityManifestDto?> GetCapabilitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets remote node capabilities and indicates whether the returned value is stale fallback data.
+    /// </summary>
+    Task<CapabilitiesFetchResult> GetCapabilitiesWithStalenessAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result wrapper for capabilities retrieval.
+/// </summary>
+public sealed record CapabilitiesFetchResult
+{
+    public NodeCapabilityManifestDto? Capabilities { get; init; }
+    public bool IsStale { get; init; }
 }

--- a/src/Nexo.Infrastructure/Execution/IRemoteBrickCatalog.cs
+++ b/src/Nexo.Infrastructure/Execution/IRemoteBrickCatalog.cs
@@ -1,4 +1,5 @@
 using Nexo.BrickContracts;
+using Nexo.BrickContracts.Capabilities;
 
 namespace Nexo.Infrastructure.Execution;
 
@@ -15,4 +16,9 @@ public interface IRemoteBrickCatalog
 
     /// <summary>Get one brick's metadata by id, or null if not found.</summary>
     Task<BrickCatalogEntryDto?> GetByIdAsync(string brickId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets remote node capabilities from companion endpoint.
+    /// </summary>
+    Task<NodeCapabilityManifestDto?> GetCapabilitiesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Nexo.Infrastructure/Execution/RemoteBrick.cs
+++ b/src/Nexo.Infrastructure/Execution/RemoteBrick.cs
@@ -49,6 +49,12 @@ public sealed class RemoteBrick : Brick
             UsageCount = catalogEntry.Metadata.UsageCount,
             LastUpdated = catalogEntry.Metadata.LastUpdated
         };
+
+        if (catalogEntry.HostCapabilities is not null)
+        {
+            var capabilitySuffix = string.Join(",", catalogEntry.HostCapabilities.SupportedCapabilities);
+            Description = $"{Description} [host:{catalogEntry.HostCapabilities.NodeId};caps:{capabilitySuffix}]";
+        }
     }
 
     public override async Task<BrickOutput> ExecuteAsync(

--- a/src/Nexo.Infrastructure/Execution/RemoteCapabilitiesOptions.cs
+++ b/src/Nexo.Infrastructure/Execution/RemoteCapabilitiesOptions.cs
@@ -1,0 +1,19 @@
+namespace Nexo.Infrastructure.Execution;
+
+/// <summary>
+/// Options controlling stale remote capability behavior.
+/// </summary>
+public sealed class RemoteCapabilitiesOptions
+{
+    /// <summary>
+    /// How long a freshly fetched capability snapshot stays in fast in-memory cache before refresh.
+    /// </summary>
+    public TimeSpan CapabilityTtl { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Maximum allowed age for stale capability reuse.
+    /// Set to less than or equal to zero to disable stale-age enforcement.
+    /// </summary>
+    public TimeSpan MaxStaleAge { get; set; } = TimeSpan.FromMinutes(10);
+}
+

--- a/src/Nexo.Infrastructure/Execution/StaleCapabilitiesSnapshotStore.cs
+++ b/src/Nexo.Infrastructure/Execution/StaleCapabilitiesSnapshotStore.cs
@@ -1,0 +1,45 @@
+using Nexo.BrickContracts.Capabilities;
+
+namespace Nexo.Infrastructure.Execution;
+
+/// <summary>
+/// Best-effort in-memory cache for last known remote node capabilities.
+/// Used to keep capability hints available when /api/capabilities is temporarily unreachable.
+/// </summary>
+public sealed class StaleCapabilitiesSnapshotStore
+{
+    private readonly Dictionary<string, NodeCapabilityManifestDto> _byBaseUrl = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _gate = new();
+
+    public NodeCapabilityManifestDto? Get(string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return null;
+        }
+
+        var normalized = Normalize(baseUrl);
+        lock (_gate)
+        {
+            return _byBaseUrl.TryGetValue(normalized, out var value)
+                ? value
+                : null;
+        }
+    }
+
+    public void Put(string baseUrl, NodeCapabilityManifestDto value)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl) || value is null)
+        {
+            return;
+        }
+
+        var normalized = Normalize(baseUrl);
+        lock (_gate)
+        {
+            _byBaseUrl[normalized] = value;
+        }
+    }
+
+    private static string Normalize(string baseUrl) => baseUrl.Trim().TrimEnd('/');
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/NullModelServingBackend.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/NullModelServingBackend.cs
@@ -1,0 +1,57 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+
+/// <summary>
+/// No-op backend used as a safe default for runtime wiring and tests.
+/// </summary>
+public sealed class NullModelServingBackend : IModelServingBackend
+{
+    private readonly HashSet<string> _loaded = new(StringComparer.OrdinalIgnoreCase);
+
+    public BackendType BackendType => BackendType.OnnxRuntime;
+
+    public Task<bool> IsAvailableAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(true);
+    }
+
+    public Task<InferenceResult> RunInferenceAsync(InferenceRequest request, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(new InferenceResult
+        {
+            Output = $"[{request.ModelId}] simulated inference output",
+            Duration = TimeSpan.FromMilliseconds(10)
+        });
+    }
+
+    public Task LoadModelAsync(string modelId, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        _loaded.Add(modelId);
+        return Task.CompletedTask;
+    }
+
+    public Task UnloadModelAsync(string modelId, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        _loaded.Remove(modelId);
+        return Task.CompletedTask;
+    }
+
+    public Task PullModelAsync(string modelId, IProgress<PullProgress>? progress = null, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        progress?.Report(new PullProgress { ModelId = modelId, BytesDownloaded = 1, TotalBytes = 1 });
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<string>> ListLoadedModelsAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<string>>(_loaded.ToArray());
+    }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaBackendOptions.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaBackendOptions.cs
@@ -1,0 +1,11 @@
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+
+/// <summary>
+/// Options for the NCR Ollama serving backend.
+/// </summary>
+public sealed class OllamaBackendOptions
+{
+    public const string SectionName = "Nexo:NodeCapabilityRuntime:Ollama";
+
+    public string BaseUrl { get; set; } = "http://127.0.0.1:11434";
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaModelServingBackend.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaModelServingBackend.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Common.Ports;
 using Nexo.Core.Application.NodeCapabilityRuntime.Models;
 using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
 
@@ -13,10 +14,15 @@ namespace Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
 public sealed class OllamaModelServingBackend : IModelServingBackend
 {
     private readonly HttpClient _httpClient;
+    private readonly IMetricsCollector? _metricsCollector;
 
-    public OllamaModelServingBackend(HttpClient httpClient, IOptions<OllamaBackendOptions> options)
+    public OllamaModelServingBackend(
+        HttpClient httpClient,
+        IOptions<OllamaBackendOptions> options,
+        IMetricsCollector? metricsCollector = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _metricsCollector = metricsCollector;
         var opts = options?.Value ?? throw new ArgumentNullException(nameof(options));
         if (_httpClient.BaseAddress is null)
         {
@@ -28,8 +34,20 @@ public sealed class OllamaModelServingBackend : IModelServingBackend
 
     public async Task<bool> IsAvailableAsync(CancellationToken ct = default)
     {
-        using var response = await _httpClient.GetAsync("/api/tags", ct).ConfigureAwait(false);
-        return response.IsSuccessStatusCode;
+        var started = DateTimeOffset.UtcNow;
+        try
+        {
+            using var response = await _httpClient.GetAsync("/api/tags", ct).ConfigureAwait(false);
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.tags.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter(response.IsSuccessStatusCode ? "ncr.ollama.tags.success" : "ncr.ollama.tags.failure");
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.tags.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter("ncr.ollama.tags.error");
+            throw;
+        }
     }
 
     public async Task<InferenceResult> RunInferenceAsync(InferenceRequest request, CancellationToken ct = default)
@@ -41,79 +59,142 @@ public sealed class OllamaModelServingBackend : IModelServingBackend
         var parameters = request.Parameters ?? new Dictionary<string, object>();
         var started = DateTimeOffset.UtcNow;
 
-        var payload = BuildChatPayload(modelId, system, prompt, parameters);
-        using var response = await PostJsonAsync("/api/chat", payload, ct).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-
-        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-        var content = doc.RootElement
-            .GetProperty("message")
-            .GetProperty("content")
-            .GetString() ?? string.Empty;
-
-        return new InferenceResult
+        try
         {
-            Output = content,
-            TokenCount = ApproximateTokenCount(content),
-            Duration = DateTimeOffset.UtcNow - started
-        };
+            var payload = BuildChatPayload(modelId, system, prompt, parameters);
+            _metricsCollector?.IncrementCounter("ncr.ollama.chat.request");
+            using var response = await PostJsonAsync("/api/chat", payload, ct).ConfigureAwait(false);
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.chat.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter(response.IsSuccessStatusCode ? "ncr.ollama.chat.success" : "ncr.ollama.chat.failure");
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+            var content = doc.RootElement
+                .GetProperty("message")
+                .GetProperty("content")
+                .GetString() ?? string.Empty;
+
+            return new InferenceResult
+            {
+                Output = content,
+                TokenCount = ApproximateTokenCount(content),
+                Duration = DateTimeOffset.UtcNow - started
+            };
+        }
+        catch
+        {
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.chat.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter("ncr.ollama.chat.error");
+            throw;
+        }
     }
 
     public async Task LoadModelAsync(string modelId, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
-        var payload = BuildGeneratePayload(modelId, "30m");
-        using var response = await PostJsonAsync("/api/generate", payload, ct).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        var started = DateTimeOffset.UtcNow;
+        try
+        {
+            var payload = BuildGeneratePayload(modelId, "30m");
+            _metricsCollector?.IncrementCounter("ncr.ollama.generate.request");
+            using var response = await PostJsonAsync("/api/generate", payload, ct).ConfigureAwait(false);
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.generate.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter(response.IsSuccessStatusCode ? "ncr.ollama.generate.success" : "ncr.ollama.generate.failure");
+            response.EnsureSuccessStatusCode();
+        }
+        catch
+        {
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.generate.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter("ncr.ollama.generate.error");
+            throw;
+        }
     }
 
     public async Task UnloadModelAsync(string modelId, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
-        var payload = BuildGeneratePayload(modelId, "0s");
-        using var response = await PostJsonAsync("/api/generate", payload, ct).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        var started = DateTimeOffset.UtcNow;
+        try
+        {
+            var payload = BuildGeneratePayload(modelId, "0s");
+            _metricsCollector?.IncrementCounter("ncr.ollama.generate.request");
+            using var response = await PostJsonAsync("/api/generate", payload, ct).ConfigureAwait(false);
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.generate.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter(response.IsSuccessStatusCode ? "ncr.ollama.generate.success" : "ncr.ollama.generate.failure");
+            response.EnsureSuccessStatusCode();
+        }
+        catch
+        {
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.generate.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter("ncr.ollama.generate.error");
+            throw;
+        }
     }
 
     public async Task PullModelAsync(string modelId, IProgress<PullProgress>? progress = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
-        var payload = BuildPullPayload(modelId);
-        using var response = await PostJsonAsync("/api/pull", payload, ct).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-        progress?.Report(new PullProgress { ModelId = modelId, BytesDownloaded = 1, TotalBytes = 1 });
+        var started = DateTimeOffset.UtcNow;
+        try
+        {
+            var payload = BuildPullPayload(modelId);
+            _metricsCollector?.IncrementCounter("ncr.ollama.pull.request");
+            using var response = await PostJsonAsync("/api/pull", payload, ct).ConfigureAwait(false);
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.pull.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter(response.IsSuccessStatusCode ? "ncr.ollama.pull.success" : "ncr.ollama.pull.failure");
+            response.EnsureSuccessStatusCode();
+            progress?.Report(new PullProgress { ModelId = modelId, BytesDownloaded = 1, TotalBytes = 1 });
+        }
+        catch
+        {
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.pull.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter("ncr.ollama.pull.error");
+            throw;
+        }
     }
 
     public async Task<IReadOnlyList<string>> ListLoadedModelsAsync(CancellationToken ct = default)
     {
-        using var response = await _httpClient.GetAsync("/api/ps", ct).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
+        var started = DateTimeOffset.UtcNow;
+        try
         {
-            return [];
-        }
-
-        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-        if (!doc.RootElement.TryGetProperty("models", out var models) || models.ValueKind != JsonValueKind.Array)
-        {
-            return [];
-        }
-
-        var names = new List<string>();
-        foreach (var model in models.EnumerateArray())
-        {
-            if (model.TryGetProperty("name", out var name))
+            using var response = await _httpClient.GetAsync("/api/ps", ct).ConfigureAwait(false);
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.ps.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter(response.IsSuccessStatusCode ? "ncr.ollama.ps.success" : "ncr.ollama.ps.failure");
+            if (!response.IsSuccessStatusCode)
             {
-                var parsed = name.GetString();
-                if (!string.IsNullOrWhiteSpace(parsed))
+                return [];
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+            if (!doc.RootElement.TryGetProperty("models", out var models) || models.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var names = new List<string>();
+            foreach (var model in models.EnumerateArray())
+            {
+                if (model.TryGetProperty("name", out var name))
                 {
-                    names.Add(parsed);
+                    var parsed = name.GetString();
+                    if (!string.IsNullOrWhiteSpace(parsed))
+                    {
+                        names.Add(parsed);
+                    }
                 }
             }
-        }
 
-        return names;
+            return names;
+        }
+        catch
+        {
+            _metricsCollector?.RecordExecutionTime("ncr.ollama.ps.duration", DateTimeOffset.UtcNow - started);
+            _metricsCollector?.IncrementCounter("ncr.ollama.ps.error");
+            throw;
+        }
     }
 
     private static int ApproximateTokenCount(string text)

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaModelServingBackend.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaModelServingBackend.cs
@@ -1,4 +1,5 @@
-using System.Net.Http.Json;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Nexo.Core.Application.NodeCapabilityRuntime.Models;
@@ -11,7 +12,6 @@ namespace Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
 /// </summary>
 public sealed class OllamaModelServingBackend : IModelServingBackend
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _httpClient;
 
     public OllamaModelServingBackend(HttpClient httpClient, IOptions<OllamaBackendOptions> options)
@@ -41,21 +41,8 @@ public sealed class OllamaModelServingBackend : IModelServingBackend
         var parameters = request.Parameters ?? new Dictionary<string, object>();
         var started = DateTimeOffset.UtcNow;
 
-        var payload = new
-        {
-            model = modelId,
-            stream = false,
-            messages = new object[]
-            {
-                new { role = "system", content = system },
-                new { role = "user", content = prompt }
-            },
-            options = parameters
-        };
-
-        using var response = await _httpClient
-            .PostAsJsonAsync("/api/chat", payload, JsonOptions, ct)
-            .ConfigureAwait(false);
+        var payload = BuildChatPayload(modelId, system, prompt, parameters);
+        using var response = await PostJsonAsync("/api/chat", payload, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
@@ -76,30 +63,24 @@ public sealed class OllamaModelServingBackend : IModelServingBackend
     public async Task LoadModelAsync(string modelId, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
-        var payload = new { model = modelId, prompt = string.Empty, stream = false, keep_alive = "30m" };
-        using var response = await _httpClient
-            .PostAsJsonAsync("/api/generate", payload, JsonOptions, ct)
-            .ConfigureAwait(false);
+        var payload = BuildGeneratePayload(modelId, "30m");
+        using var response = await PostJsonAsync("/api/generate", payload, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task UnloadModelAsync(string modelId, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
-        var payload = new { model = modelId, prompt = string.Empty, keep_alive = "0s", stream = false };
-        using var response = await _httpClient
-            .PostAsJsonAsync("/api/generate", payload, JsonOptions, ct)
-            .ConfigureAwait(false);
+        var payload = BuildGeneratePayload(modelId, "0s");
+        using var response = await PostJsonAsync("/api/generate", payload, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task PullModelAsync(string modelId, IProgress<PullProgress>? progress = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
-        var payload = new { name = modelId, stream = false };
-        using var response = await _httpClient
-            .PostAsJsonAsync("/api/pull", payload, JsonOptions, ct)
-            .ConfigureAwait(false);
+        var payload = BuildPullPayload(modelId);
+        using var response = await PostJsonAsync("/api/pull", payload, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         progress?.Report(new PullProgress { ModelId = modelId, BytesDownloaded = 1, TotalBytes = 1 });
     }
@@ -139,5 +120,97 @@ public sealed class OllamaModelServingBackend : IModelServingBackend
     {
         if (string.IsNullOrWhiteSpace(text)) return 0;
         return Math.Max(1, text.Length / 4);
+    }
+
+    private async Task<HttpResponseMessage> PostJsonAsync(
+        string requestUri,
+        string payload,
+        CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+        {
+            Content = new StringContent(payload, Encoding.UTF8)
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        return await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+    }
+
+    private static string BuildChatPayload(
+        string modelId,
+        string systemPrompt,
+        string userPrompt,
+        IReadOnlyDictionary<string, object> parameters)
+    {
+        var systemEscaped = EscapeJsonString(systemPrompt);
+        var userEscaped = EscapeJsonString(userPrompt);
+        var modelEscaped = EscapeJsonString(modelId);
+        var optionsEntries = parameters
+            .Select(kvp => $"\"{EscapeJsonString(kvp.Key)}\":{FormatJsonValue(kvp.Value)}");
+        var options = "{"+ string.Join(",", optionsEntries) + "}";
+        return
+            $"{{\"model\":\"{modelEscaped}\",\"stream\":false," +
+            "\"messages\":[" +
+            $"{{\"role\":\"system\",\"content\":\"{systemEscaped}\"}}," +
+            $"{{\"role\":\"user\",\"content\":\"{userEscaped}\"}}" +
+            "]," +
+            $"\"options\":{options}" +
+            "}";
+    }
+
+    private static string BuildGeneratePayload(string modelId, string keepAlive)
+    {
+        return
+            $"{{\"model\":\"{EscapeJsonString(modelId)}\",\"prompt\":\"\",\"stream\":false,\"keep_alive\":\"{EscapeJsonString(keepAlive)}\"}}";
+    }
+
+    private static string BuildPullPayload(string modelId)
+    {
+        return $"{{\"name\":\"{EscapeJsonString(modelId)}\",\"stream\":false}}";
+    }
+
+    private static string EscapeJsonString(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var sb = new StringBuilder(value.Length + 8);
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '\"': sb.Append("\\\""); break;
+                case '\\': sb.Append("\\\\"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                default:
+                    if (char.IsControl(ch))
+                    {
+                        sb.Append("\\u");
+                        sb.Append(((int)ch).ToString("x4"));
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string FormatJsonValue(object value)
+    {
+        return value switch
+        {
+            null => "null",
+            bool b => b ? "true" : "false",
+            byte or sbyte or short or ushort or int or uint or long or ulong =>
+                Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? "0",
+            float f => f.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            double d => d.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            decimal m => m.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            _ => $"\"{EscapeJsonString(Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty)}\""
+        };
     }
 }

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaModelServingBackend.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Backends/OllamaModelServingBackend.cs
@@ -1,0 +1,143 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+
+/// <summary>
+/// Ollama-backed implementation of NCR model serving backend.
+/// </summary>
+public sealed class OllamaModelServingBackend : IModelServingBackend
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _httpClient;
+
+    public OllamaModelServingBackend(HttpClient httpClient, IOptions<OllamaBackendOptions> options)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        var opts = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri(opts.BaseUrl.TrimEnd('/') + "/", UriKind.Absolute);
+        }
+    }
+
+    public BackendType BackendType => BackendType.Ollama;
+
+    public async Task<bool> IsAvailableAsync(CancellationToken ct = default)
+    {
+        using var response = await _httpClient.GetAsync("/api/tags", ct).ConfigureAwait(false);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<InferenceResult> RunInferenceAsync(InferenceRequest request, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var modelId = string.IsNullOrWhiteSpace(request.ModelId) ? throw new ArgumentException("ModelId is required", nameof(request)) : request.ModelId;
+        var prompt = request.Prompt ?? string.Empty;
+        var system = request.SystemPrompt ?? string.Empty;
+        var parameters = request.Parameters ?? new Dictionary<string, object>();
+        var started = DateTimeOffset.UtcNow;
+
+        var payload = new
+        {
+            model = modelId,
+            stream = false,
+            messages = new object[]
+            {
+                new { role = "system", content = system },
+                new { role = "user", content = prompt }
+            },
+            options = parameters
+        };
+
+        using var response = await _httpClient
+            .PostAsJsonAsync("/api/chat", payload, JsonOptions, ct)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        var content = doc.RootElement
+            .GetProperty("message")
+            .GetProperty("content")
+            .GetString() ?? string.Empty;
+
+        return new InferenceResult
+        {
+            Output = content,
+            TokenCount = ApproximateTokenCount(content),
+            Duration = DateTimeOffset.UtcNow - started
+        };
+    }
+
+    public async Task LoadModelAsync(string modelId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
+        var payload = new { model = modelId, prompt = string.Empty, stream = false, keep_alive = "30m" };
+        using var response = await _httpClient
+            .PostAsJsonAsync("/api/generate", payload, JsonOptions, ct)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task UnloadModelAsync(string modelId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
+        var payload = new { model = modelId, prompt = string.Empty, keep_alive = "0s", stream = false };
+        using var response = await _httpClient
+            .PostAsJsonAsync("/api/generate", payload, JsonOptions, ct)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task PullModelAsync(string modelId, IProgress<PullProgress>? progress = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(modelId)) throw new ArgumentException("Model id is required", nameof(modelId));
+        var payload = new { name = modelId, stream = false };
+        using var response = await _httpClient
+            .PostAsJsonAsync("/api/pull", payload, JsonOptions, ct)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        progress?.Report(new PullProgress { ModelId = modelId, BytesDownloaded = 1, TotalBytes = 1 });
+    }
+
+    public async Task<IReadOnlyList<string>> ListLoadedModelsAsync(CancellationToken ct = default)
+    {
+        using var response = await _httpClient.GetAsync("/api/ps", ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            return [];
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        if (!doc.RootElement.TryGetProperty("models", out var models) || models.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var names = new List<string>();
+        foreach (var model in models.EnumerateArray())
+        {
+            if (model.TryGetProperty("name", out var name))
+            {
+                var parsed = name.GetString();
+                if (!string.IsNullOrWhiteSpace(parsed))
+                {
+                    names.Add(parsed);
+                }
+            }
+        }
+
+        return names;
+    }
+
+    private static int ApproximateTokenCount(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return 0;
+        return Math.Max(1, text.Length / 4);
+    }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/DefaultModelSuite.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/DefaultModelSuite.cs
@@ -1,0 +1,89 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime;
+
+internal static class DefaultModelSuite
+{
+    public static List<ModelDescriptor> CreateForPlatform(PlatformType platform)
+    {
+        var desktopOnly = new HashSet<PlatformType> { PlatformType.Windows, PlatformType.macOS, PlatformType.Linux };
+        var allPlatforms = new HashSet<PlatformType>
+        {
+            PlatformType.Windows,
+            PlatformType.macOS,
+            PlatformType.Linux,
+            PlatformType.iOS,
+            PlatformType.Android
+        };
+
+        return new List<ModelDescriptor>
+        {
+            new()
+            {
+                Id = "phi3-mini",
+                DisplayName = "Phi-3 Mini",
+                Provider = "ollama",
+                ProviderModelId = "phi3:mini",
+                State = ModelState.Warm,
+                QualityScore = 0.62f,
+                SpeedScore = 0.90f,
+                WeightSizeBytes = 2L * 1024 * 1024 * 1024,
+                MinRAMRequiredBytes = 3L * 1024 * 1024 * 1024,
+                Capabilities = new HashSet<TaskCapability> { TaskCapability.TextGeneration },
+                SupportedPlatforms = allPlatforms
+            },
+            new()
+            {
+                Id = "llama3-8b",
+                DisplayName = "Llama 3 8B Instruct",
+                Provider = "ollama",
+                ProviderModelId = "llama3:8b-instruct-q4_K_M",
+                State = ModelState.Cold,
+                QualityScore = 0.80f,
+                SpeedScore = 0.68f,
+                WeightSizeBytes = 5L * 1024 * 1024 * 1024,
+                MinVRAMRequiredBytes = 6L * 1024 * 1024 * 1024,
+                MinRAMRequiredBytes = 10L * 1024 * 1024 * 1024,
+                Capabilities = new HashSet<TaskCapability>
+                {
+                    TaskCapability.TextGeneration,
+                    TaskCapability.Reasoning
+                },
+                SupportedPlatforms = desktopOnly
+            },
+            new()
+            {
+                Id = "qwen-coder-7b",
+                DisplayName = "Qwen2.5 Coder 7B",
+                Provider = "ollama",
+                ProviderModelId = "qwen2.5-coder:7b",
+                State = ModelState.Warm,
+                QualityScore = 0.86f,
+                SpeedScore = 0.64f,
+                WeightSizeBytes = 5L * 1024 * 1024 * 1024,
+                MinVRAMRequiredBytes = 6L * 1024 * 1024 * 1024,
+                MinRAMRequiredBytes = 10L * 1024 * 1024 * 1024,
+                Capabilities = new HashSet<TaskCapability>
+                {
+                    TaskCapability.CodeGeneration,
+                    TaskCapability.TextGeneration
+                },
+                SupportedPlatforms = desktopOnly
+            },
+            new()
+            {
+                Id = "nomic-embed-text",
+                DisplayName = "nomic-embed-text",
+                Provider = "ollama",
+                ProviderModelId = "nomic-embed-text",
+                State = ModelState.Hot,
+                QualityScore = 0.75f,
+                SpeedScore = 0.95f,
+                WeightSizeBytes = 512L * 1024 * 1024,
+                MinRAMRequiredBytes = 1024L * 1024 * 1024,
+                Capabilities = new HashSet<TaskCapability> { TaskCapability.Embeddings },
+                SupportedPlatforms = allPlatforms
+            }
+        };
+    }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Lifecycle/DefaultModelLifecycleManager.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Lifecycle/DefaultModelLifecycleManager.cs
@@ -1,0 +1,43 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Lifecycle;
+
+/// <summary>
+/// Default lifecycle manager delegating to model serving backend.
+/// </summary>
+public sealed class DefaultModelLifecycleManager : IModelLifecycleManager
+{
+    private readonly IModelServingBackend _backend;
+
+    public DefaultModelLifecycleManager(IModelServingBackend backend)
+    {
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+    }
+
+    public async Task<bool> EnsureLoadedAsync(ModelDescriptor model, CancellationToken ct = default)
+    {
+        var loaded = await _backend.ListLoadedModelsAsync(ct).ConfigureAwait(false);
+        if (!loaded.Contains(model.Id, StringComparer.OrdinalIgnoreCase))
+        {
+            await _backend.LoadModelAsync(model.Id, ct).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    public Task UnloadAsync(ModelDescriptor model)
+        => _backend.UnloadModelAsync(model.Id);
+
+    public Task PullAsync(ModelDescriptor model, IProgress<PullProgress>? progress = null, CancellationToken ct = default)
+        => _backend.PullModelAsync(model.Id, progress, ct);
+
+    public Task EvictAsync(ModelDescriptor model)
+        => _backend.UnloadModelAsync(model.Id);
+
+    public Task RunIdleMaintenanceAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NcrStartupHealthService.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NcrStartupHealthService.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime;
+
+/// <summary>
+/// Runs an NCR/Ollama startup probe and logs degradation diagnostics.
+/// </summary>
+public sealed class NcrStartupHealthService : IHostedService
+{
+    private readonly IModelServingBackend _backend;
+    private readonly IPlatformPolicy _policy;
+    private readonly ILogger<NcrStartupHealthService> _logger;
+
+    public NcrStartupHealthService(
+        IModelServingBackend backend,
+        IPlatformPolicy policy,
+        ILogger<NcrStartupHealthService> logger)
+    {
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_backend is not OllamaModelServingBackend)
+        {
+            _logger.LogInformation(
+                "NCR startup health check skipped: backend {BackendType} is non-Ollama.",
+                _backend.BackendType);
+            return;
+        }
+
+        try
+        {
+            var available = await _backend.IsAvailableAsync(cancellationToken).ConfigureAwait(false);
+            if (available)
+            {
+                _logger.LogInformation(
+                    "NCR startup health check passed: Ollama backend is reachable for platform policy {Platform}.",
+                    _policy.Platform);
+                return;
+            }
+
+            _logger.LogWarning(
+                "NCR startup health check degraded: Ollama backend returned unavailable status. " +
+                "Agentic execution may escalate until backend is healthy.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "NCR startup health check degraded: failed to reach Ollama backend. " +
+                "Verify Nexo:NodeCapabilityRuntime:Ollama:BaseUrl and Ollama service availability.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntime.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntime.cs
@@ -1,0 +1,271 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Execution.Ports;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Profiles;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Scoring;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime;
+
+/// <summary>
+/// Default node capability runtime implementation.
+/// </summary>
+public sealed class NodeCapabilityRuntime : INodeCapabilityRuntime
+{
+    private readonly IHardwareProfiler _profiler;
+    private readonly IPlatformPolicy _policy;
+    private readonly IModelLifecycleManager _lifecycle;
+    private readonly ModelScoringService _scoring;
+    private readonly ILogger<NodeCapabilityRuntime> _logger;
+    private readonly string _nodeId;
+    private readonly List<ModelDescriptor> _models;
+    private readonly SimpleObservable<ConstraintUpdate> _constraintChanges = new();
+    private readonly Dictionary<(string ModelId, TaskCapability Capability), float> _qualityFeedback = new();
+    private NodeProfile _currentProfile = new();
+
+    public NodeCapabilityRuntime(
+        IHardwareProfiler profiler,
+        IPlatformPolicy policy,
+        IModelLifecycleManager lifecycle,
+        ModelScoringService scoring,
+        IOptions<NodeCapabilityRuntimeOptions> options,
+        ILogger<NodeCapabilityRuntime> logger)
+    {
+        _profiler = profiler ?? throw new ArgumentNullException(nameof(profiler));
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+        _scoring = scoring ?? throw new ArgumentNullException(nameof(scoring));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        var opts = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _nodeId = string.IsNullOrWhiteSpace(opts.NodeId) ? Environment.MachineName : opts.NodeId;
+        _models = opts.DefaultModels.Count > 0
+            ? new List<ModelDescriptor>(opts.DefaultModels)
+            : DefaultModelSuite.CreateForPlatform(policy.Platform);
+    }
+
+    public NodeProfile CurrentProfile => _currentProfile;
+
+    public IReadOnlyList<ModelDescriptor> AvailableModels => _models.AsReadOnly();
+
+    public IObservable<ConstraintUpdate> ConstraintChanges => _constraintChanges;
+
+    public async Task<ModelResolution> SelectModelAsync(TaskContext context, CancellationToken ct = default)
+    {
+        _currentProfile = await RefreshProfileAsync(ct).ConfigureAwait(false);
+        var profile = _currentProfile;
+        var canRunNow = _policy.CanRunInferenceNow(profile);
+
+        var candidates = _models
+            .Where(model => _scoring.ScoreModel(model, context, profile) > float.MinValue)
+            .Select(model => new
+            {
+                Model = ApplyFeedback(model, context.RequiredCapability),
+                Score = _scoring.ScoreModel(ApplyFeedback(model, context.RequiredCapability), context, profile)
+            })
+            .OrderByDescending(x => x.Score)
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            return new ModelResolution
+            {
+                Target = context.Privacy == PrivacyBoundary.LocalOnly ? InferenceTarget.Local : InferenceTarget.Escalate,
+                Reason = context.Privacy == PrivacyBoundary.LocalOnly
+                    ? ResolutionReason.ForcedLocal
+                    : ResolutionReason.EscalatedInsufficientMemory
+            };
+        }
+
+        var best = candidates[0].Model;
+
+        if (context.Privacy == PrivacyBoundary.LocalOnly)
+        {
+            return new ModelResolution
+            {
+                Model = best,
+                Target = InferenceTarget.Local,
+                Reason = ResolutionReason.ForcedLocal
+            };
+        }
+
+        if (!canRunNow)
+        {
+            return new ModelResolution
+            {
+                Model = best,
+                Target = InferenceTarget.Escalate,
+                Reason = ResolutionReason.EscalatedPolicyBlocked
+            };
+        }
+
+        if (IsQualityInsufficient(context.Quality, best.QualityScore))
+        {
+            return new ModelResolution
+            {
+                Model = best,
+                Target = InferenceTarget.Escalate,
+                Reason = ResolutionReason.EscalatedQualityRequirement
+            };
+        }
+
+        return new ModelResolution
+        {
+            Model = best,
+            Target = InferenceTarget.Local,
+            Reason = ResolutionReason.BestLocalFit
+        };
+    }
+
+    public Task EnsureModelReadyAsync(ModelDescriptor model, CancellationToken ct = default)
+        => _lifecycle.EnsureLoadedAsync(model, ct);
+
+    public Task<NodeTier> GetTierAsync() => Task.FromResult(_currentProfile.Tier);
+
+    public NodeCapabilityManifest GetCapabilityManifest()
+    {
+        var hotModelIds = _models.Where(m => m.State == ModelState.Hot).Select(m => m.Id).ToArray();
+        var capabilitySet = _models
+            .SelectMany(x => x.Capabilities)
+            .Distinct()
+            .ToArray();
+
+        return new NodeCapabilityManifest
+        {
+            NodeId = _nodeId,
+            Tier = _currentProfile.Tier,
+            Platform = _currentProfile.Platform,
+            HotModelIds = hotModelIds,
+            AvailableModelIds = _models.Select(m => m.Id).Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+            SupportedCapabilities = capabilitySet,
+            AcceptingRemoteWork = _policy.CanAdvertiseRemoteWork(_currentProfile),
+            GeneratedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    public Task RecordOutcomeAsync(ModelResolution resolution, BrickExecutionOutcome outcome, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (resolution.Model.Id.Length == 0 || outcome is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var capability = resolution.Model.Capabilities.FirstOrDefault();
+        var key = (resolution.Model.Id, capability);
+        _qualityFeedback.TryGetValue(key, out var currentOffset);
+
+        var delta = 0f;
+        if (outcome.Succeeded) delta += 0.02f;
+        if (outcome.TimedOut) delta -= 0.03f;
+        if (!outcome.Succeeded) delta -= 0.02f;
+        if (outcome.Duration > TimeSpan.FromSeconds(30)) delta -= 0.01f;
+
+        _qualityFeedback[key] = Math.Clamp(currentOffset + delta, -0.2f, 0.2f);
+        _logger.LogDebug(
+            "Recorded NCR outcome for model {ModelId} cap {Capability}: delta={Delta} new={Offset}",
+            resolution.Model.Id,
+            capability,
+            delta,
+            _qualityFeedback[key]);
+        return Task.CompletedTask;
+    }
+
+    private async Task<NodeProfile> RefreshProfileAsync(CancellationToken ct)
+    {
+        var next = await _profiler.CaptureAsync(ct).ConfigureAwait(false);
+        if (_currentProfile != default &&
+            (_currentProfile.Tier != next.Tier ||
+             _currentProfile.AvailableRAMBytes != next.AvailableRAMBytes ||
+             _currentProfile.AvailableVRAMBytes != next.AvailableVRAMBytes ||
+             _currentProfile.ThermalState != next.ThermalState))
+        {
+            _constraintChanges.Publish(new ConstraintUpdate
+            {
+                Previous = _currentProfile,
+                Current = next,
+                Reason = "MaterialConstraintChange"
+            });
+        }
+
+        return next;
+    }
+
+    private ModelDescriptor ApplyFeedback(ModelDescriptor model, TaskCapability capability)
+    {
+        if (!_qualityFeedback.TryGetValue((model.Id, capability), out var offset))
+        {
+            return model;
+        }
+
+        return model with { QualityScore = Math.Clamp(model.QualityScore + offset, 0f, 1f) };
+    }
+
+    private static bool IsQualityInsufficient(QualityRequirement requirement, float qualityScore)
+    {
+        var minimum = requirement switch
+        {
+            QualityRequirement.Maximum => 0.90f,
+            QualityRequirement.High => 0.75f,
+            QualityRequirement.Medium => 0.55f,
+            _ => 0.0f
+        };
+        return qualityScore < minimum;
+    }
+}
+
+internal sealed class SimpleObservable<T> : IObservable<T>
+{
+    private readonly List<IObserver<T>> _observers = new();
+    private readonly object _gate = new();
+
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        if (observer is null) throw new ArgumentNullException(nameof(observer));
+        lock (_gate)
+        {
+            _observers.Add(observer);
+        }
+
+        return new Subscription(_observers, _gate, observer);
+    }
+
+    public void Publish(T value)
+    {
+        List<IObserver<T>> snapshot;
+        lock (_gate)
+        {
+            snapshot = new List<IObserver<T>>(_observers);
+        }
+
+        foreach (var observer in snapshot)
+        {
+            observer.OnNext(value);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly List<IObserver<T>> _observers;
+        private readonly object _gate;
+        private IObserver<T>? _observer;
+
+        public Subscription(List<IObserver<T>> observers, object gate, IObserver<T> observer)
+        {
+            _observers = observers;
+            _gate = gate;
+            _observer = observer;
+        }
+
+        public void Dispose()
+        {
+            if (_observer is null) return;
+            lock (_gate)
+            {
+                _observers.Remove(_observer);
+            }
+
+            _observer = null;
+        }
+    }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntime.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntime.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Common.Ports;
 using Nexo.Core.Application.Execution.Ports;
 using Nexo.Core.Application.NodeCapabilityRuntime.Models;
 using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
@@ -18,6 +19,7 @@ public sealed class NodeCapabilityRuntime : INodeCapabilityRuntime
     private readonly IModelLifecycleManager _lifecycle;
     private readonly ModelScoringService _scoring;
     private readonly ILogger<NodeCapabilityRuntime> _logger;
+    private readonly IMetricsCollector? _metricsCollector;
     private readonly string _nodeId;
     private readonly List<ModelDescriptor> _models;
     private readonly SimpleObservable<ConstraintUpdate> _constraintChanges = new();
@@ -30,13 +32,15 @@ public sealed class NodeCapabilityRuntime : INodeCapabilityRuntime
         IModelLifecycleManager lifecycle,
         ModelScoringService scoring,
         IOptions<NodeCapabilityRuntimeOptions> options,
-        ILogger<NodeCapabilityRuntime> logger)
+        ILogger<NodeCapabilityRuntime> logger,
+        IMetricsCollector? metricsCollector = null)
     {
         _profiler = profiler ?? throw new ArgumentNullException(nameof(profiler));
         _policy = policy ?? throw new ArgumentNullException(nameof(policy));
         _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
         _scoring = scoring ?? throw new ArgumentNullException(nameof(scoring));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _metricsCollector = metricsCollector;
         var opts = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _nodeId = string.IsNullOrWhiteSpace(opts.NodeId) ? Environment.MachineName : opts.NodeId;
         _models = opts.DefaultModels.Count > 0
@@ -52,6 +56,7 @@ public sealed class NodeCapabilityRuntime : INodeCapabilityRuntime
 
     public async Task<ModelResolution> SelectModelAsync(TaskContext context, CancellationToken ct = default)
     {
+        var selectStarted = DateTimeOffset.UtcNow;
         _currentProfile = await RefreshProfileAsync(ct).ConfigureAwait(false);
         var profile = _currentProfile;
         var canRunNow = _policy.CanRunInferenceNow(profile);
@@ -68,57 +73,81 @@ public sealed class NodeCapabilityRuntime : INodeCapabilityRuntime
 
         if (candidates.Count == 0)
         {
-            return new ModelResolution
+            var resolution = new ModelResolution
             {
                 Target = context.Privacy == PrivacyBoundary.LocalOnly ? InferenceTarget.Local : InferenceTarget.Escalate,
                 Reason = context.Privacy == PrivacyBoundary.LocalOnly
                     ? ResolutionReason.ForcedLocal
                     : ResolutionReason.EscalatedInsufficientMemory
             };
+            RecordResolutionTelemetry(resolution, DateTimeOffset.UtcNow - selectStarted);
+            return resolution;
         }
 
         var best = candidates[0].Model;
 
         if (context.Privacy == PrivacyBoundary.LocalOnly)
         {
-            return new ModelResolution
+            var resolution = new ModelResolution
             {
                 Model = best,
                 Target = InferenceTarget.Local,
                 Reason = ResolutionReason.ForcedLocal
             };
+            RecordResolutionTelemetry(resolution, DateTimeOffset.UtcNow - selectStarted);
+            return resolution;
         }
 
         if (!canRunNow)
         {
-            return new ModelResolution
+            var resolution = new ModelResolution
             {
                 Model = best,
                 Target = InferenceTarget.Escalate,
                 Reason = ResolutionReason.EscalatedPolicyBlocked
             };
+            RecordResolutionTelemetry(resolution, DateTimeOffset.UtcNow - selectStarted);
+            return resolution;
         }
 
         if (IsQualityInsufficient(context.Quality, best.QualityScore))
         {
-            return new ModelResolution
+            var resolution = new ModelResolution
             {
                 Model = best,
                 Target = InferenceTarget.Escalate,
                 Reason = ResolutionReason.EscalatedQualityRequirement
             };
+            RecordResolutionTelemetry(resolution, DateTimeOffset.UtcNow - selectStarted);
+            return resolution;
         }
 
-        return new ModelResolution
+        var bestFit = new ModelResolution
         {
             Model = best,
             Target = InferenceTarget.Local,
             Reason = ResolutionReason.BestLocalFit
         };
+        RecordResolutionTelemetry(bestFit, DateTimeOffset.UtcNow - selectStarted);
+        return bestFit;
     }
 
-    public Task EnsureModelReadyAsync(ModelDescriptor model, CancellationToken ct = default)
-        => _lifecycle.EnsureLoadedAsync(model, ct);
+    public async Task EnsureModelReadyAsync(ModelDescriptor model, CancellationToken ct = default)
+    {
+        var started = DateTimeOffset.UtcNow;
+        try
+        {
+            await _lifecycle.EnsureLoadedAsync(model, ct).ConfigureAwait(false);
+            _metricsCollector?.IncrementCounter("ncr.model_load.success");
+            _metricsCollector?.RecordExecutionTime("ncr.model_load.duration", DateTimeOffset.UtcNow - started);
+        }
+        catch
+        {
+            _metricsCollector?.IncrementCounter("ncr.model_load.error");
+            _metricsCollector?.RecordExecutionTime("ncr.model_load.duration", DateTimeOffset.UtcNow - started);
+            throw;
+        }
+    }
 
     public Task<NodeTier> GetTierAsync() => Task.FromResult(_currentProfile.Tier);
 
@@ -168,6 +197,12 @@ public sealed class NodeCapabilityRuntime : INodeCapabilityRuntime
             capability,
             delta,
             _qualityFeedback[key]);
+        _metricsCollector?.IncrementCounter(outcome.Succeeded ? "ncr.outcome.success" : "ncr.outcome.failure");
+        if (outcome.TimedOut)
+        {
+            _metricsCollector?.IncrementCounter("ncr.outcome.timeout");
+        }
+        _metricsCollector?.RecordExecutionTime("ncr.outcome.duration", outcome.Duration);
         return Task.CompletedTask;
     }
 
@@ -186,9 +221,23 @@ public sealed class NodeCapabilityRuntime : INodeCapabilityRuntime
                 Current = next,
                 Reason = "MaterialConstraintChange"
             });
+            _metricsCollector?.IncrementCounter("ncr.profile.constraint_change");
         }
 
         return next;
+    }
+
+    private void RecordResolutionTelemetry(ModelResolution resolution, TimeSpan duration)
+    {
+        _metricsCollector?.RecordExecutionTime("ncr.model_resolution.duration", duration);
+        _metricsCollector?.IncrementCounter($"ncr.model_resolution.target.{resolution.Target}");
+        _metricsCollector?.IncrementCounter($"ncr.model_resolution.reason.{resolution.Reason}");
+        _logger.LogInformation(
+            "NCR model resolution completed: target={Target} reason={Reason} model={ModelId} duration_ms={DurationMs}",
+            resolution.Target,
+            resolution.Reason,
+            resolution.Model.Id,
+            duration.TotalMilliseconds);
     }
 
     private ModelDescriptor ApplyFeedback(ModelDescriptor model, TaskCapability capability)

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeOptions.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeOptions.cs
@@ -1,0 +1,17 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime;
+
+/// <summary>
+/// Configuration options for the node capability runtime.
+/// </summary>
+public sealed class NodeCapabilityRuntimeOptions
+{
+    public const string SectionName = "Nexo:NodeCapabilityRuntime";
+
+    public string NodeId { get; set; } = Environment.MachineName;
+
+    public List<ModelDescriptor> DefaultModels { get; set; } = new();
+
+    public TimeSpan ProfileRefreshInterval { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Nexo.Core.Application.Execution.Ports;
 using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
 using Nexo.Infrastructure.Execution.Agentic;
@@ -25,6 +27,8 @@ public static class NodeCapabilityRuntimeServiceCollectionExtensions
 
         services.AddOptions<NodeCapabilityRuntimeOptions>()
             .Bind(configuration.GetSection(NodeCapabilityRuntimeOptions.SectionName));
+        services.AddOptions<OllamaBackendOptions>()
+            .Bind(configuration.GetSection(OllamaBackendOptions.SectionName));
 
         services.AddSingleton<IHardwareProfiler, EnvironmentHardwareProfiler>();
         services.AddSingleton<IModelServingBackend, NullModelServingBackend>();
@@ -37,23 +41,23 @@ public static class NodeCapabilityRuntimeServiceCollectionExtensions
 
     public static IServiceCollection AddNodeCapabilityRuntimeWindows(
         this IServiceCollection services,
-        IConfiguration _)
+        IConfiguration configuration)
     {
-        return AddPolicy<WindowsPolicy>(services);
+        return AddDesktopPolicyAndBackend<WindowsPolicy>(services, configuration);
     }
 
     public static IServiceCollection AddNodeCapabilityRuntimeMacOS(
         this IServiceCollection services,
-        IConfiguration _)
+        IConfiguration configuration)
     {
-        return AddPolicy<MacOsPolicy>(services);
+        return AddDesktopPolicyAndBackend<MacOsPolicy>(services, configuration);
     }
 
     public static IServiceCollection AddNodeCapabilityRuntimeLinux(
         this IServiceCollection services,
-        IConfiguration _)
+        IConfiguration configuration)
     {
-        return AddPolicy<LinuxPolicy>(services);
+        return AddDesktopPolicyAndBackend<LinuxPolicy>(services, configuration);
     }
 
     public static IServiceCollection AddNodeCapabilityRuntimeiOS(
@@ -75,6 +79,35 @@ public static class NodeCapabilityRuntimeServiceCollectionExtensions
     {
         if (services is null) throw new ArgumentNullException(nameof(services));
         services.AddSingleton<IPlatformPolicy, TPolicy>();
+        return services;
+    }
+
+    private static IServiceCollection AddDesktopPolicyAndBackend<TPolicy>(
+        IServiceCollection services,
+        IConfiguration configuration)
+        where TPolicy : class, IPlatformPolicy, new()
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+        AddPolicy<TPolicy>(services);
+        services.AddOptions<OllamaBackendOptions>()
+            .Bind(configuration.GetSection(OllamaBackendOptions.SectionName));
+
+        services.AddHttpClient(nameof(OllamaModelServingBackend), (sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<OllamaBackendOptions>>().Value;
+            client.BaseAddress = new Uri(options.BaseUrl.TrimEnd('/') + "/", UriKind.Absolute);
+        });
+
+        services.RemoveAll<IModelServingBackend>();
+        services.AddSingleton<IModelServingBackend>(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            var client = factory.CreateClient(nameof(OllamaModelServingBackend));
+            var options = sp.GetRequiredService<IOptions<OllamaBackendOptions>>();
+            return new OllamaModelServingBackend(client, options);
+        });
         return services;
     }
 }

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
@@ -107,7 +107,8 @@ public static class NodeCapabilityRuntimeServiceCollectionExtensions
             var factory = sp.GetRequiredService<IHttpClientFactory>();
             var client = factory.CreateClient(nameof(OllamaModelServingBackend));
             var options = sp.GetRequiredService<IOptions<OllamaBackendOptions>>();
-            return new OllamaModelServingBackend(client, options);
+            var metrics = sp.GetService<Nexo.Core.Application.Common.Ports.IMetricsCollector>();
+            return new OllamaModelServingBackend(client, options, metrics);
         });
         return services;
     }

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.Core.Application.Execution.Ports;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Infrastructure.Execution.Agentic;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Lifecycle;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Profiles;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Scoring;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime;
+
+/// <summary>
+/// DI registration helpers for NCR core and per-platform policy bindings.
+/// </summary>
+public static class NodeCapabilityRuntimeServiceCollectionExtensions
+{
+    public static IServiceCollection AddNodeCapabilityRuntimeCore(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+        services.AddOptions<NodeCapabilityRuntimeOptions>()
+            .Bind(configuration.GetSection(NodeCapabilityRuntimeOptions.SectionName));
+
+        services.AddSingleton<IHardwareProfiler, EnvironmentHardwareProfiler>();
+        services.AddSingleton<IModelServingBackend, NullModelServingBackend>();
+        services.AddSingleton<IModelLifecycleManager, DefaultModelLifecycleManager>();
+        services.AddSingleton<ModelScoringService>();
+        services.AddSingleton<INodeCapabilityRuntime, NodeCapabilityRuntime>();
+        services.AddSingleton<IAgenticBrickEngine, NcrAgenticBrickEngine>();
+        return services;
+    }
+
+    public static IServiceCollection AddNodeCapabilityRuntimeWindows(
+        this IServiceCollection services,
+        IConfiguration _)
+    {
+        return AddPolicy<WindowsPolicy>(services);
+    }
+
+    public static IServiceCollection AddNodeCapabilityRuntimeMacOS(
+        this IServiceCollection services,
+        IConfiguration _)
+    {
+        return AddPolicy<MacOsPolicy>(services);
+    }
+
+    public static IServiceCollection AddNodeCapabilityRuntimeLinux(
+        this IServiceCollection services,
+        IConfiguration _)
+    {
+        return AddPolicy<LinuxPolicy>(services);
+    }
+
+    public static IServiceCollection AddNodeCapabilityRuntimeiOS(
+        this IServiceCollection services,
+        IConfiguration _)
+    {
+        return AddPolicy<iOSPolicy>(services);
+    }
+
+    public static IServiceCollection AddNodeCapabilityRuntimeAndroid(
+        this IServiceCollection services,
+        IConfiguration _)
+    {
+        return AddPolicy<AndroidPolicy>(services);
+    }
+
+    private static IServiceCollection AddPolicy<TPolicy>(IServiceCollection services)
+        where TPolicy : class, IPlatformPolicy, new()
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+        services.AddSingleton<IPlatformPolicy, TPolicy>();
+        return services;
+    }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/NodeCapabilityRuntimeServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class NodeCapabilityRuntimeServiceCollectionExtensions
         services.AddSingleton<ModelScoringService>();
         services.AddSingleton<INodeCapabilityRuntime, NodeCapabilityRuntime>();
         services.AddSingleton<IAgenticBrickEngine, NcrAgenticBrickEngine>();
+        services.AddHostedService<NcrStartupHealthService>();
         return services;
     }
 

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/AndroidPolicy.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/AndroidPolicy.cs
@@ -1,0 +1,48 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+
+public sealed class AndroidPolicy : IPlatformPolicy
+{
+    public PlatformType Platform => PlatformType.Android;
+
+    public bool CanRunInferenceNow(NodeProfile profile) =>
+        profile.ThermalState < ThermalState.Severe &&
+        profile.AppState != AppState.BackgroundRestricted;
+
+    public bool CanLoadModel(ModelDescriptor model, NodeProfile profile) =>
+        model.WeightSizeBytes <= MaxSingleModelBytes &&
+        model.MinRAMRequiredBytes <= profile.AvailableRAMBytes * 0.45f;
+
+    public bool CanPullModel(NodeProfile profile) =>
+        profile.NetworkLatency.IsWifi ||
+        (AllowCellularPull && profile.BatteryLevelPercent > 30f);
+
+    public bool CanAdvertiseRemoteWork(NodeProfile profile) =>
+        profile.IsCharging &&
+        profile.NetworkLatency.IsWifi &&
+        profile.BatteryLevelPercent > MinBatteryForRemoteWork &&
+        !profile.IsBatteryOptimizationEnabled &&
+        profile.ThermalState < ThermalState.Serious;
+
+    public long MaxModelCacheBytes => 3L * 1024 * 1024 * 1024;
+    public long MaxSingleModelBytes => 2L * 1024 * 1024 * 1024;
+    public int MaxConcurrentInferenceRequests => 1;
+    public TimeSpan HotModelTTL => TimeSpan.FromMinutes(15);
+    public TimeSpan ColdEvictionAge => TimeSpan.FromDays(14);
+
+    public bool ShouldUnloadAfterInference(NodeProfile profile) =>
+        profile.AvailableRAMBytes < 512L * 1024 * 1024;
+
+    public bool CanRunIdleMaintenance(NodeProfile profile) =>
+        profile.IsCharging &&
+        !profile.IsBatteryOptimizationEnabled &&
+        profile.NetworkLatency.IsWifi;
+
+    public float MinBatteryForRemoteWork { get; init; } = 20f;
+    public bool AllowCellularPull { get; init; }
+    public bool UseVulkanCompute { get; init; } = true;
+    public bool UseNNAPI { get; init; } = true;
+    public bool DozeAware { get; init; } = true;
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/LinuxPolicy.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/LinuxPolicy.cs
@@ -1,0 +1,40 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+
+public sealed class LinuxPolicy : IPlatformPolicy
+{
+    public PlatformType Platform => PlatformType.Linux;
+
+    public bool CanRunInferenceNow(NodeProfile profile) =>
+        profile.GPUUtilizationPercent < 98f;
+
+    public bool CanLoadModel(ModelDescriptor model, NodeProfile profile) =>
+        model.MinVRAMRequiredBytes <= profile.AvailableVRAMBytes &&
+        model.MinRAMRequiredBytes <= profile.AvailableRAMBytes;
+
+    public bool CanPullModel(NodeProfile profile) => true;
+
+    public bool CanAdvertiseRemoteWork(NodeProfile profile) =>
+        profile.GPUUtilizationPercent < 50f;
+
+    public long MaxModelCacheBytes => long.MaxValue;
+    public long MaxSingleModelBytes => long.MaxValue;
+    public int MaxConcurrentInferenceRequests => 8;
+
+    public TimeSpan HotModelTTL => TimeSpan.FromHours(24);
+    public TimeSpan ColdEvictionAge => TimeSpan.FromDays(90);
+
+    public bool ShouldUnloadAfterInference(NodeProfile profile) => false;
+
+    public bool CanRunIdleMaintenance(NodeProfile profile) => true;
+
+    public bool AllowCUDA { get; init; } = true;
+    public bool AllowROCm { get; init; } = true;
+    public bool AllowVulkan { get; init; } = true;
+    public bool UseHugePages { get; init; }
+    public int OllamaNumGPU { get; init; } = -1;
+    public bool IsContainerized { get; init; }
+    public bool IsHeadless { get; init; }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/MacOsPolicy.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/MacOsPolicy.cs
@@ -1,0 +1,37 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+
+public sealed class MacOsPolicy : IPlatformPolicy
+{
+    public PlatformType Platform => PlatformType.macOS;
+
+    public bool CanRunInferenceNow(NodeProfile profile) =>
+        profile.ThermalState < ThermalState.Serious &&
+        profile.GPUUtilizationPercent < 90f;
+
+    public bool CanLoadModel(ModelDescriptor model, NodeProfile profile) =>
+        model.MinRAMRequiredBytes <= profile.AvailableRAMBytes;
+
+    public bool CanPullModel(NodeProfile profile) =>
+        !profile.IsOnBattery || profile.IsCharging || profile.BatteryLevelPercent > 50f;
+
+    public bool CanAdvertiseRemoteWork(NodeProfile profile) =>
+        profile.IsCharging &&
+        profile.ThermalState < ThermalState.Fair &&
+        profile.CPUUtilizationPercent < 60f;
+
+    public long MaxModelCacheBytes => 50L * 1024 * 1024 * 1024;
+    public long MaxSingleModelBytes => 40L * 1024 * 1024 * 1024;
+    public int MaxConcurrentInferenceRequests => 2;
+
+    public TimeSpan HotModelTTL => TimeSpan.FromMinutes(45);
+    public TimeSpan ColdEvictionAge => TimeSpan.FromDays(45);
+
+    public bool ShouldUnloadAfterInference(NodeProfile profile) =>
+        profile.IsOnBattery && !profile.IsCharging;
+
+    public bool CanRunIdleMaintenance(NodeProfile profile) =>
+        !profile.IsUserActive && profile.ThermalState < ThermalState.Fair;
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/WindowsPolicy.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/WindowsPolicy.cs
@@ -1,0 +1,39 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+
+public sealed class WindowsPolicy : IPlatformPolicy
+{
+    public PlatformType Platform => PlatformType.Windows;
+
+    public bool CanRunInferenceNow(NodeProfile profile) =>
+        profile.GPUUtilizationPercent < 95f;
+
+    public bool CanLoadModel(ModelDescriptor model, NodeProfile profile) =>
+        model.MinVRAMRequiredBytes <= profile.AvailableVRAMBytes &&
+        model.MinRAMRequiredBytes <= profile.AvailableRAMBytes;
+
+    public bool CanPullModel(NodeProfile profile) => true;
+
+    public bool CanAdvertiseRemoteWork(NodeProfile profile) =>
+        profile.GPUUtilizationPercent < 60f &&
+        profile.CPUUtilizationPercent < 70f;
+
+    public long MaxModelCacheBytes => 100L * 1024 * 1024 * 1024;
+    public long MaxSingleModelBytes => 50L * 1024 * 1024 * 1024;
+    public int MaxConcurrentInferenceRequests => 4;
+
+    public TimeSpan HotModelTTL => TimeSpan.FromHours(2);
+    public TimeSpan ColdEvictionAge => TimeSpan.FromDays(60);
+
+    public bool ShouldUnloadAfterInference(NodeProfile profile) =>
+        profile.AvailableVRAMBytes < 512L * 1024 * 1024;
+
+    public bool CanRunIdleMaintenance(NodeProfile profile) =>
+        !profile.IsUserActive;
+
+    public bool AllowCUDA { get; init; } = true;
+    public bool AllowDirectML { get; init; } = true;
+    public bool EnforceDefenderExclusions { get; init; } = true;
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/iOSPolicy.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Policies/iOSPolicy.cs
@@ -1,0 +1,48 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+
+public sealed class iOSPolicy : IPlatformPolicy
+{
+    public PlatformType Platform => PlatformType.iOS;
+
+    public bool CanRunInferenceNow(NodeProfile profile) =>
+        profile.AppState != AppState.Background || profile.HasBackgroundTaskPermission;
+
+    public bool CanLoadModel(ModelDescriptor model, NodeProfile profile) =>
+        model.WeightSizeBytes <= MaxSingleModelBytes &&
+        model.MinRAMRequiredBytes <= (long)(profile.AvailableRAMBytes * 0.4f);
+
+    public bool CanPullModel(NodeProfile profile) =>
+        profile.NetworkLatency.IsWifi &&
+        (!profile.IsOnBattery || profile.IsCharging || profile.BatteryLevelPercent > 20f);
+
+    public bool CanAdvertiseRemoteWork(NodeProfile profile) =>
+        profile.IsCharging &&
+        profile.NetworkLatency.IsWifi &&
+        profile.AppState == AppState.Background &&
+        profile.BatteryLevelPercent > MinBatteryForRemoteWork &&
+        profile.ThermalState < ThermalState.Serious;
+
+    public long MaxModelCacheBytes => 2L * 1024 * 1024 * 1024;
+    public long MaxSingleModelBytes => 1536L * 1024 * 1024;
+    public int MaxConcurrentInferenceRequests => 1;
+
+    public TimeSpan HotModelTTL => TimeSpan.FromMinutes(10);
+    public TimeSpan ColdEvictionAge => TimeSpan.FromDays(7);
+
+    public bool ShouldUnloadAfterInference(NodeProfile profile) =>
+        !profile.IsCharging || profile.AvailableRAMBytes < 512L * 1024 * 1024;
+
+    public bool CanRunIdleMaintenance(NodeProfile profile) =>
+        profile.IsCharging &&
+        profile.NetworkLatency.IsWifi &&
+        profile.AppState == AppState.Background &&
+        profile.HasBackgroundTaskPermission;
+
+    public float MinBatteryForRemoteWork { get; init; } = 20f;
+    public bool UseNeuralEngine { get; init; } = true;
+    public bool UseMetal { get; init; } = true;
+    public bool AllowLowPowerModeInference { get; init; }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Profiles/EnvironmentHardwareProfiler.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Profiles/EnvironmentHardwareProfiler.cs
@@ -1,0 +1,108 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Profiles;
+
+/// <summary>
+/// Lightweight cross-platform hardware profiler based on environment and runtime data.
+/// </summary>
+public sealed class EnvironmentHardwareProfiler : IHardwareProfiler
+{
+    public Task<NodeProfile> CaptureAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var totalRam = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        var availableRam = Math.Max(0L, totalRam - GC.GetTotalMemory(forceFullCollection: false));
+        var totalVram = TryReadInt64Environment("NEXO_TOTAL_VRAM_BYTES");
+        var availableVram = TryReadInt64Environment("NEXO_AVAILABLE_VRAM_BYTES");
+
+        var isOnBattery = TryReadBoolEnvironment("NEXO_ON_BATTERY");
+        var isCharging = TryReadBoolEnvironment("NEXO_CHARGING");
+        var battery = TryReadSingleEnvironment("NEXO_BATTERY_PERCENT", 100f);
+        var thermal = ParseEnumEnvironment("NEXO_THERMAL_STATE", ThermalState.Nominal);
+        var appState = ParseEnumEnvironment("NEXO_APP_STATE", AppState.Foreground);
+
+        var profile = new NodeProfile
+        {
+            TotalRAMBytes = totalRam,
+            AvailableRAMBytes = availableRam,
+            TotalVRAMBytes = totalVram,
+            AvailableVRAMBytes = availableVram > 0 ? availableVram : totalVram,
+            CPUUtilizationPercent = TryReadSingleEnvironment("NEXO_CPU_UTIL_PERCENT", 0f),
+            GPUUtilizationPercent = TryReadSingleEnvironment("NEXO_GPU_UTIL_PERCENT", 0f),
+            IsOnBattery = isOnBattery,
+            IsCharging = isCharging,
+            BatteryLevelPercent = battery,
+            IsUserActive = TryReadBoolEnvironment("NEXO_USER_ACTIVE"),
+            AppState = appState,
+            ThermalState = thermal,
+            HasBackgroundTaskPermission = TryReadBoolEnvironment("NEXO_BACKGROUND_TASK_PERMISSION"),
+            IsBatteryOptimizationEnabled = TryReadBoolEnvironment("NEXO_BATTERY_OPTIMIZATION_ENABLED"),
+            NetworkLatency = new NetworkLatencyProfile
+            {
+                IsWifi = TryReadBoolEnvironment("NEXO_NETWORK_WIFI", true),
+                IsMetered = TryReadBoolEnvironment("NEXO_NETWORK_METERED"),
+                AverageLatencyMs = (int)TryReadInt64Environment("NEXO_NETWORK_LATENCY_MS", 25)
+            },
+            Storage = new StorageProfile
+            {
+                AvailableBytes = TryReadInt64Environment("NEXO_STORAGE_AVAILABLE_BYTES", 0),
+                TotalBytes = TryReadInt64Environment("NEXO_STORAGE_TOTAL_BYTES", 0)
+            },
+            Platform = ResolvePlatform(),
+            CapturedAt = DateTimeOffset.UtcNow
+        };
+
+        return Task.FromResult(profile with { Tier = ClassifyTier(profile) });
+    }
+
+    private static PlatformType ResolvePlatform()
+    {
+        if (OperatingSystem.IsWindows()) return PlatformType.Windows;
+        if (OperatingSystem.IsMacOS()) return PlatformType.macOS;
+        if (OperatingSystem.IsLinux()) return PlatformType.Linux;
+        if (OperatingSystem.IsIOS()) return PlatformType.iOS;
+        if (OperatingSystem.IsAndroid()) return PlatformType.Android;
+        return PlatformType.Unknown;
+    }
+
+    public static NodeTier ClassifyTier(NodeProfile profile)
+    {
+        var ramGiB = profile.TotalRAMBytes / (1024.0 * 1024.0 * 1024.0);
+        var vramGiB = profile.TotalVRAMBytes / (1024.0 * 1024.0 * 1024.0);
+
+        if (ramGiB >= 64 || vramGiB >= 24) return NodeTier.Core;
+        if (ramGiB >= 24 || vramGiB >= 10) return NodeTier.Standard;
+        if (ramGiB >= 10 || vramGiB >= 4) return NodeTier.Micro;
+        return NodeTier.Nano;
+    }
+
+    private static bool TryReadBoolEnvironment(string key, bool defaultValue = false)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        if (bool.TryParse(value, out var parsed)) return parsed;
+        if (string.Equals(value, "1", StringComparison.Ordinal)) return true;
+        if (string.Equals(value, "0", StringComparison.Ordinal)) return false;
+        return defaultValue;
+    }
+
+    private static long TryReadInt64Environment(string key, long defaultValue = 0)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        return long.TryParse(value, out var parsed) ? parsed : defaultValue;
+    }
+
+    private static float TryReadSingleEnvironment(string key, float defaultValue = 0f)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        return float.TryParse(value, out var parsed) ? parsed : defaultValue;
+    }
+
+    private static TEnum ParseEnumEnvironment<TEnum>(string key, TEnum defaultValue)
+        where TEnum : struct, Enum
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        return Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed) ? parsed : defaultValue;
+    }
+}

--- a/src/Nexo.Infrastructure/NodeCapabilityRuntime/Scoring/ModelScoringService.cs
+++ b/src/Nexo.Infrastructure/NodeCapabilityRuntime/Scoring/ModelScoringService.cs
@@ -1,0 +1,60 @@
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+
+namespace Nexo.Infrastructure.NodeCapabilityRuntime.Scoring;
+
+/// <summary>
+/// Scores models for the current task and node profile.
+/// </summary>
+public sealed class ModelScoringService
+{
+    private const long LargeModelThresholdBytes = 7L * 1024 * 1024 * 1024;
+    private readonly IPlatformPolicy _policy;
+
+    public ModelScoringService(IPlatformPolicy policy)
+    {
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+    }
+
+    public float ScoreModel(ModelDescriptor model, TaskContext context, NodeProfile profile)
+    {
+        if (!_policy.CanLoadModel(model, profile)) return float.MinValue;
+        if (!model.Capabilities.Contains(context.RequiredCapability)) return float.MinValue;
+        if (!model.SupportedPlatforms.Contains(profile.Platform)) return float.MinValue;
+        if (context.Privacy == PrivacyBoundary.LocalOnly && model.RequiresRemote) return float.MinValue;
+
+        var qualityWeight = context.Latency switch
+        {
+            LatencyRequirement.RealTime => 0.2f,
+            LatencyRequirement.Interactive => 0.4f,
+            LatencyRequirement.Background => 0.7f,
+            LatencyRequirement.Overnight => 0.9f,
+            _ => 0.5f
+        };
+        var speedWeight = 1.0f - qualityWeight;
+
+        var memoryPressure = profile.TotalVRAMBytes > 0
+            ? 1.0f - (float)profile.AvailableVRAMBytes / profile.TotalVRAMBytes
+            : profile.TotalRAMBytes > 0
+                ? 1.0f - (float)profile.AvailableRAMBytes / profile.TotalRAMBytes
+                : 1.0f;
+
+        var resourcePenalty = memoryPressure * 0.3f;
+        var loadPenalty = model.State switch
+        {
+            ModelState.Hot => 0.0f,
+            ModelState.Warm => 0.1f,
+            _ => 0.3f
+        };
+
+        var batteryPenalty = (profile.IsOnBattery && !profile.IsCharging && model.WeightSizeBytes > LargeModelThresholdBytes)
+            ? 0.5f
+            : 0.0f;
+
+        return (qualityWeight * model.QualityScore)
+               + (speedWeight * model.SpeedScore)
+               - resourcePenalty
+               - loadPenalty
+               - batteryPenalty;
+    }
+}

--- a/src/Nexo.Runtime/Routing/EndpointHealthMonitor.cs
+++ b/src/Nexo.Runtime/Routing/EndpointHealthMonitor.cs
@@ -16,6 +16,7 @@ public sealed class EndpointHealthMonitor : BackgroundService
     private readonly GrpcAgentTransport _grpcTransport;
     private readonly RoutingOptions _routingOptions;
     private readonly ILogger<EndpointHealthMonitor> _logger;
+    private readonly Dictionary<string, int> _consecutiveFailures = new(StringComparer.OrdinalIgnoreCase);
 
     public EndpointHealthMonitor(
         IEndpointRegistry endpointRegistry,
@@ -60,11 +61,20 @@ public sealed class EndpointHealthMonitor : BackgroundService
 
                 if (!health.IsHealthy)
                 {
-                    _logger.LogWarning(
-                        "Endpoint {EndpointName} ({Endpoint}) is degraded: {Diagnostic}",
-                        descriptor.Name,
-                        descriptor.Endpoint,
-                        health.DiagnosticMessage ?? health.Message ?? "No diagnostic message");
+                    var failures = IncrementFailureCount(descriptor.Endpoint);
+                    if (failures >= Math.Max(1, _routingOptions.DegradedLogFailureThreshold))
+                    {
+                        _logger.LogWarning(
+                            "Endpoint {EndpointName} ({Endpoint}) is degraded after {FailureCount} failed probes: {Diagnostic}",
+                            descriptor.Name,
+                            descriptor.Endpoint,
+                            failures,
+                            health.DiagnosticMessage ?? health.Message ?? "No diagnostic message");
+                    }
+                }
+                else
+                {
+                    ResetFailureCount(descriptor.Endpoint);
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -74,12 +84,36 @@ public sealed class EndpointHealthMonitor : BackgroundService
             catch (Exception ex)
             {
                 _endpointRegistry.UpdateHealth(descriptor.Endpoint, false);
-                _logger.LogWarning(
-                    ex,
-                    "Endpoint health probe failed for {EndpointName} ({Endpoint})",
-                    descriptor.Name,
-                    descriptor.Endpoint);
+                var failures = IncrementFailureCount(descriptor.Endpoint);
+                if (failures >= Math.Max(1, _routingOptions.DegradedLogFailureThreshold))
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Endpoint health probe failed for {EndpointName} ({Endpoint}) after {FailureCount} failed probes",
+                        descriptor.Name,
+                        descriptor.Endpoint,
+                        failures);
+                }
             }
+        }
+    }
+
+    private int IncrementFailureCount(string endpoint)
+    {
+        lock (_consecutiveFailures)
+        {
+            _consecutiveFailures.TryGetValue(endpoint, out var current);
+            var next = current + 1;
+            _consecutiveFailures[endpoint] = next;
+            return next;
+        }
+    }
+
+    private void ResetFailureCount(string endpoint)
+    {
+        lock (_consecutiveFailures)
+        {
+            _consecutiveFailures.Remove(endpoint);
         }
     }
 }

--- a/src/Nexo.Runtime/Routing/RemoteCapabilitiesOptions.cs
+++ b/src/Nexo.Runtime/Routing/RemoteCapabilitiesOptions.cs
@@ -1,0 +1,18 @@
+namespace Nexo.Runtime.Routing;
+
+/// <summary>
+/// Runtime-layer options controlling remote capability cache freshness and stale fallback.
+/// </summary>
+public sealed class RemoteCapabilitiesOptions
+{
+    /// <summary>
+    /// How long a freshly fetched capability snapshot stays in fast in-memory cache before refresh.
+    /// </summary>
+    public TimeSpan CapabilityTtl { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Maximum allowed age for stale capability reuse.
+    /// Set to <= 0 to disable stale-age enforcement.
+    /// </summary>
+    public TimeSpan MaxStaleAge { get; set; } = TimeSpan.FromMinutes(10);
+}

--- a/src/Nexo.Runtime/Routing/RoutingOptions.cs
+++ b/src/Nexo.Runtime/Routing/RoutingOptions.cs
@@ -10,6 +10,12 @@ public sealed class RoutingOptions
     public IList<EndpointDescriptorConfig> Endpoints { get; init; } = [];
 
     public int HealthCheckIntervalSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Number of consecutive failed probes required before logging a degraded warning.
+    /// Helps suppress noisy warnings for transient one-off probe failures.
+    /// </summary>
+    public int DegradedLogFailureThreshold { get; init; } = 1;
 }
 
 /// <summary>

--- a/src/Nexo.Tests.BackgroundAgents/Observation/ObservationPipelineServiceTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Observation/ObservationPipelineServiceTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nexo.BackgroundAgents.Observation;
-using Nexo.Core.Application.Observation.Ports;
 using Nexo.Infrastructure.Observation;
 using Xunit;
 
@@ -28,5 +27,38 @@ public class ObservationPipelineServiceTests
         var service = new ObservationPipelineService(options, store, logger, loggerFactory);
 
         service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenPatternStoreFailsAndFailOpenEnabled_DoesNotThrow()
+    {
+        var options = Options.Create(new ObservationPipelineOptions
+        {
+            RepoRoot = Path.GetTempPath(),
+            StorePath = $"nexo_test_{Guid.NewGuid():N}.db",
+            WatchPaths = new[] { "__does_not_exist__" },
+            FailOpenOnStoreErrors = true
+        });
+        var logger = NullLogger<ObservationPipelineService>.Instance;
+        var loggerFactory = NullLoggerFactory.Instance;
+        var service = new ObservationPipelineService(options, new ThrowingPatternStore(), logger, loggerFactory);
+
+        var start = () => service.StartAsync(CancellationToken.None);
+        await start.Should().NotThrowAsync();
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    private sealed class ThrowingPatternStore : Nexo.Core.Application.Observation.Ports.IPatternStore
+    {
+        public Task AddAsync(Nexo.Core.Application.Observation.Models.ObservedPattern pattern, CancellationToken cancellationToken = default)
+            => throw new UnauthorizedAccessException("test fail-open");
+
+        public Task<IReadOnlyList<Nexo.Core.Application.Observation.Models.ObservedPattern>> QueryAsync(
+            Nexo.Core.Application.Observation.Models.PatternStoreQueryParams query,
+            CancellationToken cancellationToken = default)
+            => throw new UnauthorizedAccessException("test fail-open");
+
+        public Task PersistAsync(CancellationToken cancellationToken = default)
+            => throw new UnauthorizedAccessException("test fail-open");
     }
 }

--- a/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
+++ b/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
@@ -46,6 +46,7 @@
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.Tests.Contracts\Nexo.Tests.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Infrastructure\Nexo.Infrastructure.csproj" />
+    <ProjectReference Include="..\Nexo.API\Nexo.API.csproj" />
     <ProjectReference Include="..\Nexo.Policies.Dev\Nexo.Policies.Dev.csproj" />
     <ProjectReference Include="..\Nexo.Orchestration\Nexo.Orchestration.csproj" />
     <ProjectReference Include="..\Nexo.Tests.Application\Nexo.Tests.Application.csproj" />

--- a/src/Nexo.Tests.Infrastructure/Tests/API/CapabilitiesEndpointTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/CapabilitiesEndpointTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nexo.API.Endpoints;
+using Nexo.BrickContracts.Capabilities;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using System.Reflection;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+public sealed class CapabilitiesEndpointTests
+{
+    [Fact]
+    public async Task GetCapabilities_ReturnsManifestDto()
+    {
+        var runtime = new StubNodeCapabilityRuntime();
+        var expected = runtime.GetCapabilityManifest();
+        var method = typeof(NexoEndpoints).GetMethod(
+            "GetCapabilitiesAsync",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("the capabilities endpoint handler should exist");
+
+        var task = (Task<IResult>)method!.Invoke(
+            null,
+            [runtime, CancellationToken.None])!;
+        var result = await task;
+        var dto = ExtractDtoFromResult(result);
+
+        dto.Should().NotBeNull();
+        dto.NodeId.Should().Be(expected.NodeId);
+        dto.AcceptingRemoteWork.Should().Be(expected.AcceptingRemoteWork);
+        dto.SupportedCapabilities.Should().Contain(TaskCapabilityDto.Embeddings);
+    }
+
+    private static NodeCapabilityManifestDto ExtractDtoFromResult(IResult result)
+    {
+        var resultType = result.GetType();
+        var valueProperty = resultType.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
+        valueProperty.Should().NotBeNull();
+
+        var value = valueProperty!.GetValue(result);
+        value.Should().BeOfType<NodeCapabilityManifestDto>();
+        return (NodeCapabilityManifestDto)value!;
+    }
+
+    private sealed class StubNodeCapabilityRuntime : INodeCapabilityRuntime
+    {
+        public NodeProfile CurrentProfile { get; } = new()
+        {
+            Platform = PlatformType.Linux,
+            Tier = NodeTier.Micro
+        };
+
+        public IReadOnlyList<ModelDescriptor> AvailableModels => [];
+
+        public IObservable<ConstraintUpdate> ConstraintChanges => new NoopObservable<ConstraintUpdate>();
+
+        public Task EnsureModelReadyAsync(ModelDescriptor model, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<NodeTier> GetTierAsync()
+            => Task.FromResult(NodeTier.Micro);
+
+        public NodeCapabilityManifest GetCapabilityManifest()
+            => new()
+            {
+                NodeId = "node-123",
+                Tier = NodeTier.Micro,
+                Platform = PlatformType.Linux,
+                HotModelIds = ["nomic-embed-text"],
+                AvailableModelIds = ["nomic-embed-text", "phi3-mini"],
+                SupportedCapabilities = [TaskCapability.Embeddings],
+                AcceptingRemoteWork = true,
+                GeneratedAt = DateTimeOffset.UtcNow
+            };
+
+        public Task RecordOutcomeAsync(ModelResolution resolution, Nexo.Core.Application.Execution.Ports.BrickExecutionOutcome outcome, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<ModelResolution> SelectModelAsync(TaskContext context, CancellationToken ct = default)
+            => Task.FromResult(new ModelResolution
+            {
+                Target = InferenceTarget.Local,
+                Reason = ResolutionReason.BestLocalFit,
+                Model = new ModelDescriptor { Id = "nomic-embed-text" }
+            });
+    }
+
+    private sealed class NoopObservable<T> : IObservable<T>
+    {
+        public IDisposable Subscribe(IObserver<T> observer) => new NoopDisposable();
+
+        private sealed class NoopDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/BehaviorExecutorHotSwapTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/BehaviorExecutorHotSwapTests.cs
@@ -9,6 +9,8 @@ using Nexo.Core.Domain.Bricks;
 using Nexo.Core.Domain.Execution;
 using Nexo.Core.Domain.Execution.Events;
 using Nexo.Core.Domain.Workflows;
+using Nexo.Core.Application.Common.Ports;
+using Nexo.Core.Application.Execution.Ports;
 using Nexo.Infrastructure.Execution;
 using Nexo.Infrastructure.Execution.Models;
 using Nexo.Core.Application.Common.Services;
@@ -184,7 +186,11 @@ public sealed class BehaviorExecutorHotSwapTests : UnitTestBase
         });
     }
 
-    private static BehaviorExecutor CreateExecutor(Brick brick, bool providerAvailable)
+    private static BehaviorExecutor CreateExecutor(
+        Brick brick,
+        bool providerAvailable,
+        IAgenticBrickEngine? agenticBrickEngine = null,
+        IMetricsCollector? metricsCollector = null)
     {
         var loggerFactory = LoggerFactory.Create(b => { });
 
@@ -197,7 +203,10 @@ public sealed class BehaviorExecutorHotSwapTests : UnitTestBase
             providerFactory,
             cache,
             new SequentialLoopKernel(),
-            loggerFactory.CreateLogger<BehaviorExecutor>());
+            loggerFactory.CreateLogger<BehaviorExecutor>(),
+            agenticBrickEngine,
+            null,
+            metricsCollector);
     }
 
     private sealed class SingleBrickRegistry : Nexo.Core.Domain.Execution.IBrickRegistry

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/BehaviorExecutorNcrEscalationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/BehaviorExecutorNcrEscalationTests.cs
@@ -1,0 +1,239 @@
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Common.Ports;
+using Nexo.Core.Application.Execution.Ports;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+using Nexo.Core.Domain.Agents;
+using Nexo.Core.Domain.Behaviors;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using Nexo.Core.Domain.Execution.Events;
+using Nexo.Core.Domain.Workflows;
+using Nexo.Core.Application.Common.Services;
+using Nexo.Infrastructure.Execution;
+
+namespace Nexo.Tests.Infrastructure.Tests.Execution;
+
+public sealed class BehaviorExecutorNcrEscalationTests : UnitTestBase
+{
+    public override async Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await TestEscalationEmitsTypedEventAndFallbackExecutesAsync();
+
+            return new TestResult
+            {
+                Name = nameof(BehaviorExecutorNcrEscalationTests),
+                Category = "Infrastructure",
+                Passed = true,
+                Message = "BehaviorExecutor NCR escalation tests passed"
+            };
+        }
+        catch (AssertionException ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(BehaviorExecutorNcrEscalationTests),
+                Category = "Infrastructure",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            };
+        }
+        catch (Exception ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(BehaviorExecutorNcrEscalationTests),
+                Category = "Infrastructure",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            };
+        }
+    }
+
+    private async Task TestEscalationEmitsTypedEventAndFallbackExecutesAsync()
+    {
+        var loggerFactory = LoggerFactory.Create(_ => { });
+        var metrics = new InMemoryMetricsCollector();
+        var brick = new AgenticThenDeterministicBrick();
+        var registry = new SingleBrickRegistry(brick);
+        var providerFactory = new ProviderAvailableFactory();
+        var cache = new SemanticCache(loggerFactory.CreateLogger<SemanticCache>());
+        var agenticEngine = new EscalatingAgenticEngine();
+
+        var executor = new BehaviorExecutor(
+            registry,
+            providerFactory,
+            cache,
+            new SequentialLoopKernel(),
+            loggerFactory.CreateLogger<BehaviorExecutor>(),
+            agenticEngine,
+            null,
+            metrics);
+
+        var behavior = new Behavior
+        {
+            Id = "b-escalate",
+            Name = "escalate",
+            Description = "escalate",
+            Steps =
+            [
+                new BehaviorStep
+                {
+                    Id = "s-escalate",
+                    BrickId = brick.Id,
+                    Implementation = ImplementationType.Auto,
+                    InputMapping = new Dictionary<string, string>(),
+                    OutputMapping = new Dictionary<string, string> { ["ok"] = "ok" }
+                }
+            ],
+            OnStepFailure = FailurePolicy.Abort
+        };
+
+        var agent = new AgentCard { Id = "a1", Name = "a", Description = "a", Behaviors = [behavior.Id] };
+        var options = new ExecutionOptions
+        {
+            Provider = "ollama",
+            SwapOnFailure = true,
+            ImplementationMode = ImplementationMode.AgenticPreferred
+        };
+
+        var sawEscalated = false;
+        var sawCompleted = false;
+        var implementations = new List<ImplementationType>();
+        await foreach (var evt in executor.ExecuteWithEventsAsync(agent, behavior, new BehaviorInput(), options, CancellationToken.None))
+        {
+            if (evt is StepStartedEvent started)
+            {
+                implementations.Add(started.Implementation);
+            }
+            else if (evt is AgenticEscalatedEvent escalated)
+            {
+                sawEscalated = true;
+                AssertEqual("s-escalate", escalated.StepId);
+                AssertEqual(brick.Id, escalated.BrickId);
+                AssertEqual(ResolutionReason.EscalatedPolicyBlocked.ToString(), escalated.Reason);
+            }
+            else if (evt is StepCompletedEvent)
+            {
+                sawCompleted = true;
+            }
+        }
+
+        AssertTrue(sawEscalated, "Escalation should emit AgenticEscalatedEvent");
+        AssertTrue(sawCompleted, "Deterministic fallback should complete");
+        AssertTrue(implementations.Count >= 2, "Should attempt agentic then deterministic");
+        AssertEqual(ImplementationType.Agentic, implementations[0]);
+        AssertTrue(metrics.Counters.TryGetValue("ncr.execution.escalated.EscalatedPolicyBlocked", out var escalations) && escalations == 1);
+    }
+
+    private sealed class AgenticThenDeterministicBrick : Brick
+    {
+        public AgenticThenDeterministicBrick()
+        {
+            Id = "test.escalating";
+            Name = "Escalating";
+            Description = "Escalates when agentic";
+            Category = BrickCategory.Analysis;
+            Implementations = new BrickImplementations
+            {
+                Deterministic = new DeterministicImplementation { Id = "d", Name = "d", Description = "d", Executor = "x" },
+                Agentic = new AgenticImplementation { Id = "a", Name = "a", Description = "a" }
+            };
+            DefaultImplementation = ImplementationType.Agentic;
+            FallbackChain = [ImplementationType.Agentic, ImplementationType.Deterministic];
+        }
+
+        public override Task<BrickOutput> ExecuteAsync(BrickInput input, ImplementationType implementation, IExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            if (implementation == ImplementationType.Agentic)
+            {
+                throw new InvalidOperationException("agentic path should not execute after escalation");
+            }
+
+            return Task.FromResult(new BrickOutput
+            {
+                ["ok"] = true,
+                Summary = "ok"
+            });
+        }
+    }
+
+    private sealed class EscalatingAgenticEngine : IAgenticBrickEngine
+    {
+        public Task<ModelResolution> ResolveModelForBrickAsync(Brick brick, IExecutionContext context, CancellationToken ct = default)
+        {
+            return Task.FromResult(new ModelResolution
+            {
+                Model = new ModelDescriptor
+                {
+                    Id = "phi3-mini",
+                    Provider = "ollama",
+                    ProviderModelId = "phi3-mini"
+                },
+                Target = InferenceTarget.Escalate,
+                Reason = ResolutionReason.EscalatedPolicyBlocked
+            });
+        }
+
+        public Task RecordExecutionOutcomeAsync(ModelResolution resolution, BrickExecutionOutcome outcome, CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class SingleBrickRegistry : Nexo.Core.Domain.Execution.IBrickRegistry
+    {
+        private readonly Brick _brick;
+
+        public SingleBrickRegistry(Brick brick) => _brick = brick;
+
+        public Brick? GetBrick(string id) => id == _brick.Id ? _brick : null;
+
+        public IReadOnlyList<Brick> GetAllBricks() => [_brick];
+    }
+
+    private sealed class ProviderAvailableFactory : IProviderFactory
+    {
+        public bool IsProviderAvailable(string provider) => true;
+        public Task<string> ExecuteLLMAsync(string provider, string systemPrompt, string userPrompt, object config, CancellationToken cancellationToken = default)
+            => Task.FromResult("{}");
+        public Task<string> ExecuteVisionAsync(string provider, string systemPrompt, string userPrompt, byte[] imageBytes, object config, CancellationToken cancellationToken = default)
+            => Task.FromResult("{}");
+        public Task<string> ExecuteVisionMultiFrameAsync(string provider, string systemPrompt, string userPrompt, IReadOnlyList<byte[]> frameBytes, object config, CancellationToken cancellationToken = default)
+            => Task.FromResult("{}");
+        public Task<string> ExecuteVideoAsync(string systemPrompt, string userPrompt, IReadOnlyList<byte[]> frameBytes, object config, CancellationToken cancellationToken = default)
+            => Task.FromResult("{}");
+        public Task EnsureOllamaReachableAsync(bool requireVisionModel, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class InMemoryMetricsCollector : IMetricsCollector
+    {
+        public Dictionary<string, TimeSpan> ExecutionTimes { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, long> Counters { get; } = new(StringComparer.Ordinal);
+
+        public void RecordExecutionTime(string operationName, TimeSpan duration)
+        {
+            ExecutionTimes.TryGetValue(operationName, out var existing);
+            ExecutionTimes[operationName] = existing + duration;
+        }
+
+        public void IncrementCounter(string counterName, int value = 1)
+        {
+            Counters.TryGetValue(counterName, out var existing);
+            Counters[counterName] = existing + value;
+        }
+
+        public Task<MetricsSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new MetricsSnapshot
+            {
+                ExecutionTimes = new Dictionary<string, TimeSpan>(ExecutionTimes),
+                Counters = new Dictionary<string, long>(Counters)
+            });
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/HttpRemoteBrickCatalogCapabilityFallbackTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/HttpRemoteBrickCatalogCapabilityFallbackTests.cs
@@ -14,9 +14,10 @@ public sealed class HttpRemoteBrickCatalogCapabilityFallbackTests
     [Fact]
     public async Task GetCapabilitiesAsync_ReturnsStaleSnapshot_WhenEndpointUnavailable()
     {
+        var freshGeneratedAt = DateTimeOffset.UtcNow.AddSeconds(-5).ToString("O");
         var responses = new Queue<Func<HttpRequestMessage, HttpResponseMessage>>(
         [
-            static _ => JsonResponse("""
+            _ => JsonResponse($$"""
             {
               "nodeId": "node-a",
               "tier": 1,
@@ -25,7 +26,7 @@ public sealed class HttpRemoteBrickCatalogCapabilityFallbackTests
               "availableModelIds": ["phi3-mini"],
               "supportedCapabilities": [0],
               "acceptingRemoteWork": true,
-              "generatedAt": "2026-01-01T00:00:00Z"
+              "generatedAt": "{{freshGeneratedAt}}"
             }
             """),
             static _ => throw new HttpRequestException("network down")
@@ -55,8 +56,78 @@ public sealed class HttpRemoteBrickCatalogCapabilityFallbackTests
     }
 
     [Fact]
+    public async Task GetCapabilitiesAsync_DropsStaleSnapshot_WhenOlderThanMaxAge()
+    {
+        var staleStore = new StaleCapabilitiesSnapshotStore();
+        var tooOld = DateTimeOffset.UtcNow.AddMinutes(-20);
+        staleStore.Put("http://remote:7777/", new NodeCapabilityManifestDto
+        {
+            NodeId = "node-stale",
+            Tier = NodeTierDto.Micro,
+            Platform = PlatformTypeDto.Linux,
+            HotModelIds = [],
+            AvailableModelIds = ["phi3-mini"],
+            SupportedCapabilities = [TaskCapabilityDto.TextGeneration],
+            AcceptingRemoteWork = true,
+            GeneratedAt = tooOld
+        });
+
+        using var httpClient = new HttpClient(new FakeHttpMessageHandler((req, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable))))
+        {
+            BaseAddress = new Uri("http://remote:7777", UriKind.Absolute)
+        };
+
+        var sut = new HttpRemoteBrickCatalog(
+            httpClient,
+            NullLogger<HttpRemoteBrickCatalog>.Instance,
+            staleStore,
+            capabilityTtl: TimeSpan.Zero,
+            maxStaleCapabilityAge: TimeSpan.FromMinutes(5));
+
+        var fetch = await sut.GetCapabilitiesWithStalenessAsync();
+        fetch.Capabilities.Should().BeNull();
+        fetch.IsStale.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetCapabilitiesAsync_DropsFutureTimestampSnapshot()
+    {
+        var staleStore = new StaleCapabilitiesSnapshotStore();
+        staleStore.Put("http://remote:7777/", new NodeCapabilityManifestDto
+        {
+            NodeId = "node-future",
+            Tier = NodeTierDto.Standard,
+            Platform = PlatformTypeDto.Linux,
+            HotModelIds = [],
+            AvailableModelIds = ["phi3-mini"],
+            SupportedCapabilities = [TaskCapabilityDto.TextGeneration],
+            AcceptingRemoteWork = true,
+            GeneratedAt = DateTimeOffset.UtcNow.AddHours(1)
+        });
+
+        using var httpClient = new HttpClient(new FakeHttpMessageHandler((req, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable))))
+        {
+            BaseAddress = new Uri("http://remote:7777", UriKind.Absolute)
+        };
+
+        var sut = new HttpRemoteBrickCatalog(
+            httpClient,
+            NullLogger<HttpRemoteBrickCatalog>.Instance,
+            staleStore,
+            capabilityTtl: TimeSpan.Zero,
+            maxStaleCapabilityAge: TimeSpan.FromMinutes(15));
+
+        var fetch = await sut.GetCapabilitiesWithStalenessAsync();
+        fetch.Capabilities.Should().BeNull();
+        fetch.IsStale.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task GetAllAsync_AttachesCapabilitiesFromStaleCache_WhenFreshFetchFails()
     {
+        var freshGeneratedAt = DateTimeOffset.UtcNow.AddSeconds(-5).ToString("O");
         var capabilitiesCalls = 0;
         var brickCalls = 0;
         using var httpClient = new HttpClient(new FakeHttpMessageHandler((req, _) =>
@@ -65,7 +136,7 @@ public sealed class HttpRemoteBrickCatalogCapabilityFallbackTests
             {
                 capabilitiesCalls++;
                 return capabilitiesCalls == 1
-                    ? Task.FromResult(JsonResponse("""
+                    ? Task.FromResult(JsonResponse($$"""
                     {
                       "nodeId": "node-cache",
                       "tier": 2,
@@ -74,7 +145,7 @@ public sealed class HttpRemoteBrickCatalogCapabilityFallbackTests
                       "availableModelIds": ["phi3-mini"],
                       "supportedCapabilities": [0],
                       "acceptingRemoteWork": true,
-                      "generatedAt": "2026-01-01T00:00:00Z"
+                      "generatedAt": "{{freshGeneratedAt}}"
                     }
                     """))
                     : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/HttpRemoteBrickCatalogCapabilityFallbackTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/HttpRemoteBrickCatalogCapabilityFallbackTests.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.BrickContracts;
+using Nexo.BrickContracts.Capabilities;
+using Nexo.Infrastructure.Execution;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Execution;
+
+public sealed class HttpRemoteBrickCatalogCapabilityFallbackTests
+{
+    [Fact]
+    public async Task GetCapabilitiesAsync_ReturnsStaleSnapshot_WhenEndpointUnavailable()
+    {
+        var responses = new Queue<Func<HttpRequestMessage, HttpResponseMessage>>(
+        [
+            static _ => JsonResponse("""
+            {
+              "nodeId": "node-a",
+              "tier": 1,
+              "platform": 2,
+              "hotModelIds": [],
+              "availableModelIds": ["phi3-mini"],
+              "supportedCapabilities": [0],
+              "acceptingRemoteWork": true,
+              "generatedAt": "2026-01-01T00:00:00Z"
+            }
+            """),
+            static _ => throw new HttpRequestException("network down")
+        ]);
+
+        using var httpClient = new HttpClient(new FakeHttpMessageHandler((req, _) => Task.FromResult(responses.Dequeue().Invoke(req))))
+        {
+            BaseAddress = new Uri("http://remote:7777", UriKind.Absolute)
+        };
+
+        var staleStore = new StaleCapabilitiesSnapshotStore();
+        var sut = new HttpRemoteBrickCatalog(
+            httpClient,
+            NullLogger<HttpRemoteBrickCatalog>.Instance,
+            staleStore,
+            capabilityTtl: TimeSpan.Zero);
+
+        var first = await sut.GetCapabilitiesWithStalenessAsync();
+        var second = await sut.GetCapabilitiesWithStalenessAsync();
+
+        first.Capabilities.Should().NotBeNull();
+        first.IsStale.Should().BeFalse();
+        second.Capabilities.Should().NotBeNull();
+        second.IsStale.Should().BeTrue();
+        second.Capabilities!.NodeId.Should().Be("node-a");
+        second.Capabilities.Platform.Should().Be(PlatformTypeDto.Linux);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_AttachesCapabilitiesFromStaleCache_WhenFreshFetchFails()
+    {
+        var capabilitiesCalls = 0;
+        var brickCalls = 0;
+        using var httpClient = new HttpClient(new FakeHttpMessageHandler((req, _) =>
+        {
+            if (req.RequestUri!.AbsolutePath == "/api/capabilities")
+            {
+                capabilitiesCalls++;
+                return capabilitiesCalls == 1
+                    ? Task.FromResult(JsonResponse("""
+                    {
+                      "nodeId": "node-cache",
+                      "tier": 2,
+                      "platform": 2,
+                      "hotModelIds": [],
+                      "availableModelIds": ["phi3-mini"],
+                      "supportedCapabilities": [0],
+                      "acceptingRemoteWork": true,
+                      "generatedAt": "2026-01-01T00:00:00Z"
+                    }
+                    """))
+                    : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            }
+
+            if (req.RequestUri.AbsolutePath.StartsWith("/api/bricks", StringComparison.Ordinal))
+            {
+                brickCalls++;
+                if (brickCalls > 1)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+                }
+
+                return Task.FromResult(JsonResponse("""
+                {
+                  "wireFormatVersion": "2025-02",
+                  "bricks": [
+                    {
+                      "wireFormatVersion": "2025-02",
+                      "id": "remote.gen",
+                      "name": "RemoteGen",
+                      "version": "1.0.0",
+                      "icon": "pkg",
+                      "category": "Generation",
+                      "description": "desc",
+                      "interface": { "inputs": [], "outputs": [] },
+                      "hasDeterministic": true,
+                      "hasAgentic": true,
+                      "metadata": { "author": "n", "license": "MIT", "repository": "", "usageCount": 1, "lastUpdated": "2026-01-01T00:00:00Z" }
+                    }
+                  ]
+                }
+                """));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }))
+        {
+            BaseAddress = new Uri("http://remote:7777", UriKind.Absolute)
+        };
+
+        var staleStore = new StaleCapabilitiesSnapshotStore();
+        var sut = new HttpRemoteBrickCatalog(
+            httpClient,
+            NullLogger<HttpRemoteBrickCatalog>.Instance,
+            staleStore,
+            capabilityTtl: TimeSpan.Zero);
+
+        var warm = await sut.GetCapabilitiesWithStalenessAsync();
+        warm.Capabilities.Should().NotBeNull();
+        warm.IsStale.Should().BeFalse();
+
+        _ = await sut.GetCapabilitiesWithStalenessAsync();
+        capabilitiesCalls.Should().BeGreaterThanOrEqualTo(2);
+        var entries = await sut.GetAllAsync();
+        entries.Should().HaveCount(1);
+        entries[0].HostCapabilities.Should().NotBeNull();
+        entries[0].HostCapabilities!.NodeId.Should().Be("node-cache");
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _handler(request, cancellationToken);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/HttpRemoteBrickCatalogStaleGuardrailTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/HttpRemoteBrickCatalogStaleGuardrailTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Infrastructure.Execution;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Execution;
+
+public sealed class HttpRemoteBrickCatalogStaleGuardrailTests
+{
+    [Fact]
+    public async Task GetCapabilitiesWithStalenessAsync_DropsTooOldStaleManifest()
+    {
+        var responses = new Queue<Func<HttpRequestMessage, HttpResponseMessage>>(
+        [
+            static _ => JsonResponse("""
+            {
+              "nodeId": "node-old",
+              "tier": 1,
+              "platform": 2,
+              "hotModelIds": [],
+              "availableModelIds": ["phi3-mini"],
+              "supportedCapabilities": [0],
+              "acceptingRemoteWork": true,
+              "generatedAt": "2020-01-01T00:00:00Z"
+            }
+            """),
+            static _ => throw new HttpRequestException("network down")
+        ]);
+
+        using var httpClient = new HttpClient(new FakeHttpMessageHandler((req, _) => Task.FromResult(responses.Dequeue().Invoke(req))))
+        {
+            BaseAddress = new Uri("http://remote:7777", UriKind.Absolute)
+        };
+
+        var staleStore = new StaleCapabilitiesSnapshotStore();
+        var sut = new HttpRemoteBrickCatalog(
+            httpClient,
+            NullLogger<HttpRemoteBrickCatalog>.Instance,
+            staleStore,
+            capabilityTtl: TimeSpan.Zero,
+            maxStaleCapabilityAge: TimeSpan.FromSeconds(5));
+
+        var first = await sut.GetCapabilitiesWithStalenessAsync();
+        var second = await sut.GetCapabilitiesWithStalenessAsync();
+
+        first.Capabilities.Should().NotBeNull();
+        second.Capabilities.Should().BeNull("manifest is older than MaxStaleAge and should be discarded");
+        second.IsStale.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetCapabilitiesWithStalenessAsync_DropsFutureGeneratedManifest()
+    {
+        var responses = new Queue<Func<HttpRequestMessage, HttpResponseMessage>>(
+        [
+            _ => JsonResponse($$"""
+            {
+              "nodeId": "node-future",
+              "tier": 1,
+              "platform": 2,
+              "hotModelIds": [],
+              "availableModelIds": ["phi3-mini"],
+              "supportedCapabilities": [0],
+              "acceptingRemoteWork": true,
+              "generatedAt": "{{DateTimeOffset.UtcNow.AddMinutes(10):O}}"
+            }
+            """),
+            static _ => throw new HttpRequestException("network down")
+        ]);
+
+        using var httpClient = new HttpClient(new FakeHttpMessageHandler((req, _) => Task.FromResult(responses.Dequeue().Invoke(req))))
+        {
+            BaseAddress = new Uri("http://remote:7777", UriKind.Absolute)
+        };
+
+        var staleStore = new StaleCapabilitiesSnapshotStore();
+        var sut = new HttpRemoteBrickCatalog(
+            httpClient,
+            NullLogger<HttpRemoteBrickCatalog>.Instance,
+            staleStore,
+            capabilityTtl: TimeSpan.Zero,
+            maxStaleCapabilityAge: TimeSpan.FromMinutes(5));
+
+        var first = await sut.GetCapabilitiesWithStalenessAsync();
+        var second = await sut.GetCapabilitiesWithStalenessAsync();
+
+        first.Capabilities.Should().NotBeNull();
+        second.Capabilities.Should().BeNull("future generatedAt should be treated as invalid stale metadata");
+        second.IsStale.Should().BeFalse();
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _handler(request, cancellationToken);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/ModelScoringServiceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/ModelScoringServiceTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Scoring;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class ModelScoringServiceTests
+{
+    [Fact]
+    public void ScoreModel_ReturnsMinValue_WhenCapabilityMissing()
+    {
+        var policy = new LinuxPolicy();
+        var sut = new ModelScoringService(policy);
+        var model = CreateModel(capabilities: new[] { TaskCapability.Embeddings });
+        var context = new TaskContext { RequiredCapability = TaskCapability.CodeGeneration };
+        var profile = CreateProfile();
+
+        var score = sut.ScoreModel(model, context, profile);
+
+        score.Should().Be(float.MinValue);
+    }
+
+    [Fact]
+    public void ScoreModel_PrefersHotModel_AndFastPathForInteractive()
+    {
+        var policy = new LinuxPolicy();
+        var sut = new ModelScoringService(policy);
+        var hot = CreateModel(id: "hot", state: ModelState.Hot, quality: 0.7f, speed: 0.8f);
+        var cold = CreateModel(id: "cold", state: ModelState.Cold, quality: 0.7f, speed: 0.8f);
+        var context = new TaskContext
+        {
+            RequiredCapability = TaskCapability.TextGeneration,
+            Latency = LatencyRequirement.Interactive
+        };
+        var profile = CreateProfile();
+
+        var hotScore = sut.ScoreModel(hot, context, profile);
+        var coldScore = sut.ScoreModel(cold, context, profile);
+
+        hotScore.Should().BeGreaterThan(coldScore);
+    }
+
+    [Fact]
+    public void ScoreModel_AppliesBatteryPenalty_ForLargeModelOnBattery()
+    {
+        var policy = new LinuxPolicy();
+        var sut = new ModelScoringService(policy);
+        var model = CreateModel(weightSizeBytes: 8L * 1024 * 1024 * 1024);
+        var context = new TaskContext { RequiredCapability = TaskCapability.TextGeneration };
+        var profilePlugged = CreateProfile(isOnBattery: false, isCharging: false);
+        var profileBattery = CreateProfile(isOnBattery: true, isCharging: false);
+
+        var pluggedScore = sut.ScoreModel(model, context, profilePlugged);
+        var batteryScore = sut.ScoreModel(model, context, profileBattery);
+
+        batteryScore.Should().BeLessThan(pluggedScore);
+    }
+
+    private static ModelDescriptor CreateModel(
+        string id = "m1",
+        ModelState state = ModelState.Hot,
+        float quality = 0.75f,
+        float speed = 0.75f,
+        long weightSizeBytes = 2L * 1024 * 1024 * 1024,
+        IEnumerable<TaskCapability>? capabilities = null)
+    {
+        return new ModelDescriptor
+        {
+            Id = id,
+            State = state,
+            QualityScore = quality,
+            SpeedScore = speed,
+            WeightSizeBytes = weightSizeBytes,
+            MinRAMRequiredBytes = 1024L * 1024 * 1024,
+            Capabilities = new HashSet<TaskCapability>(capabilities ?? new[] { TaskCapability.TextGeneration }),
+            SupportedPlatforms = new HashSet<PlatformType> { PlatformType.Linux }
+        };
+    }
+
+    private static NodeProfile CreateProfile(bool isOnBattery = false, bool isCharging = true)
+    {
+        return new NodeProfile
+        {
+            Platform = PlatformType.Linux,
+            AvailableRAMBytes = 16L * 1024 * 1024 * 1024,
+            TotalRAMBytes = 32L * 1024 * 1024 * 1024,
+            AvailableVRAMBytes = 10L * 1024 * 1024 * 1024,
+            TotalVRAMBytes = 12L * 1024 * 1024 * 1024,
+            IsOnBattery = isOnBattery,
+            IsCharging = isCharging
+        };
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrAgenticBrickEngineTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrAgenticBrickEngineTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Moq;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using Nexo.Infrastructure.Execution.Agentic;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class NcrAgenticBrickEngineTests
+{
+    [Fact]
+    public async Task ResolveModelForBrickAsync_MapsContext_AndEnsuresModelReady()
+    {
+        var brick = new TestBrick
+        {
+            Id = "test",
+            Name = "test",
+            Category = BrickCategory.Security,
+            Description = "desc",
+            Implementations = new BrickImplementations { Agentic = new AgenticImplementation { Id = "a", Name = "a", Description = "a" } }
+        };
+        var context = new Nexo.Infrastructure.Execution.ExecutionContext
+        {
+            AgentId = "a1",
+            BehaviorId = "b1",
+            Provider = "ollama",
+            IsAirGapped = false,
+            AuditMode = false,
+            Variables = new Dictionary<string, object>
+            {
+                ["nexo:user_facing"] = true,
+                ["nexo:quality"] = "High"
+            }
+        };
+
+        var expectedModel = new ModelDescriptor { Id = "qwen", Provider = "ollama", Capabilities = new HashSet<TaskCapability> { TaskCapability.CodeGeneration } };
+        var ncr = new Mock<INodeCapabilityRuntime>(MockBehavior.Strict);
+        ncr.Setup(x => x.SelectModelAsync(
+                It.Is<TaskContext>(ctx =>
+                    ctx.RequiredCapability == TaskCapability.CodeGeneration &&
+                    ctx.Quality == QualityRequirement.High &&
+                    ctx.Latency == LatencyRequirement.Interactive &&
+                    ctx.Privacy == PrivacyBoundary.Standard &&
+                    ctx.IsUserFacing &&
+                    ctx.RequestedProvider == "ollama"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ModelResolution
+            {
+                Model = expectedModel,
+                Target = InferenceTarget.Local,
+                Reason = ResolutionReason.BestLocalFit
+            });
+        ncr.Setup(x => x.EnsureModelReadyAsync(expectedModel, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = new NcrAgenticBrickEngine(ncr.Object);
+
+        var resolution = await sut.ResolveModelForBrickAsync(brick, context, CancellationToken.None);
+
+        resolution.Target.Should().Be(InferenceTarget.Local);
+        resolution.Model.Id.Should().Be("qwen");
+        ncr.VerifyAll();
+    }
+
+    private sealed class TestBrick : Brick
+    {
+        public override Task<BrickOutput> ExecuteAsync(BrickInput input, ImplementationType implementation, IExecutionContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(new BrickOutput());
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Infrastructure.Execution.Agentic;
+using Nexo.Infrastructure.Execution;
+using Nexo.Infrastructure.NodeCapabilityRuntime;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Lifecycle;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Scoring;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class NcrEngineOllamaIntegrationTests
+{
+    [Fact]
+    public async Task ResolveEnsureInference_RecordOutcome_RoundTrip_Works()
+    {
+        var handler = new FakeHttpMessageHandler((request, ct) =>
+        {
+            return request.RequestUri!.AbsolutePath switch
+            {
+                "/api/chat" => Task.FromResult(JsonResponse("""
+                {
+                  "message": {
+                    "content": "integration-ok"
+                  }
+                }
+                """)),
+                "/api/generate" => Task.FromResult(JsonResponse("""{ "response":"ok" }""")),
+                "/api/ps" => Task.FromResult(JsonResponse("""
+                {
+                  "models": [
+                    { "name": "phi3-mini" }
+                  ]
+                }
+                """)),
+                "/api/tags" => Task.FromResult(JsonResponse("""{ "models": [ { "name":"phi3-mini" } ] }""")),
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound))
+            };
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var backend = new OllamaModelServingBackend(
+            httpClient,
+            Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" }));
+        var lifecycle = new DefaultModelLifecycleManager(backend);
+        var policy = new LinuxPolicy();
+        var runtime = new NodeCapabilityRuntime(
+            new EnvironmentHardwareProfiler(),
+            policy,
+            lifecycle,
+            new ModelScoringService(policy),
+            Options.Create(new NodeCapabilityRuntimeOptions
+            {
+                NodeId = "integration-node",
+                DefaultModels =
+                [
+                    new ModelDescriptor
+                    {
+                        Id = "phi3-mini",
+                        Provider = "ollama",
+                        ProviderModelId = "phi3-mini",
+                        State = ModelState.Warm,
+                        QualityScore = 0.8f,
+                        SpeedScore = 0.8f,
+                        MinRAMRequiredBytes = 1024L * 1024 * 1024,
+                        Capabilities = new HashSet<TaskCapability> { TaskCapability.TextGeneration },
+                        SupportedPlatforms = new HashSet<PlatformType> { PlatformType.Linux }
+                    }
+                ]
+            }),
+            NullLogger<NodeCapabilityRuntime>.Instance);
+
+        var engine = new NcrAgenticBrickEngine(runtime);
+        var brick = new TestBrick
+        {
+            Id = "gen",
+            Name = "gen",
+            Category = BrickCategory.Generation,
+            Description = "generation",
+            Implementations = new BrickImplementations
+            {
+                Agentic = new AgenticImplementation { Id = "a", Name = "a", Description = "a" }
+            }
+        };
+        var context = new ExecutionContext
+        {
+            AgentId = "a1",
+            BehaviorId = "b1",
+            Provider = "ollama",
+            Variables = new Dictionary<string, object>
+            {
+                ["nexo:user_facing"] = true
+            }
+        };
+
+        var resolution = await engine.ResolveModelForBrickAsync(brick, context, CancellationToken.None);
+        var inference = await backend.RunInferenceAsync(new InferenceRequest
+        {
+            ModelId = resolution.Model.ProviderModelId ?? resolution.Model.Id,
+            Prompt = "hello",
+            SystemPrompt = "sys"
+        });
+        await engine.RecordExecutionOutcomeAsync(
+            resolution,
+            new Nexo.Core.Application.Execution.Ports.BrickExecutionOutcome
+            {
+                Succeeded = true,
+                Duration = TimeSpan.FromMilliseconds(50)
+            },
+            CancellationToken.None);
+
+        resolution.Target.Should().Be(InferenceTarget.Local);
+        inference.Output.Should().Be("integration-ok");
+        var paths = handler.Requests.Select(r => r.RequestUri!.AbsolutePath).ToList();
+        paths.Should().Contain("/api/ps");
+        paths.Should().Contain("/api/generate");
+        paths.Should().Contain("/api/chat");
+    }
+
+    private sealed class TestBrick : Brick
+    {
+        public override Task<BrickOutput> ExecuteAsync(BrickInput input, ImplementationType implementation, IExecutionContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(new BrickOutput());
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return _handler(request, cancellationToken);
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
@@ -236,6 +236,61 @@ public sealed class NcrEngineOllamaIntegrationTests
         handler.Requests.Select(r => r.RequestUri!.AbsolutePath).Should().Contain("/api/chat");
     }
 
+    [Fact]
+    public async Task RunInference_WithIntermittentFailures_CompletesAcrossAttempts()
+    {
+        var attempts = 0;
+        var handler = new FakeHttpMessageHandler((request, ct) =>
+        {
+            if (request.RequestUri!.AbsolutePath != "/api/chat")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            attempts++;
+            if (attempts <= 2)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            }
+
+            return Task.FromResult(JsonResponse("""
+            {
+              "message": {
+                "content": "eventual-ok"
+              }
+            }
+            """));
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var backend = new OllamaModelServingBackend(
+            httpClient,
+            Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" }));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            backend.RunInferenceAsync(new InferenceRequest
+            {
+                ModelId = "phi3-mini",
+                Prompt = "hello"
+            }));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            backend.RunInferenceAsync(new InferenceRequest
+            {
+                ModelId = "phi3-mini",
+                Prompt = "hello"
+            }));
+
+        var final = await backend.RunInferenceAsync(new InferenceRequest
+        {
+            ModelId = "phi3-mini",
+            Prompt = "hello"
+        });
+
+        final.Output.Should().Be("eventual-ok");
+        attempts.Should().Be(3);
+    }
+
     [Fact(Timeout = Nexo.Tests.Infrastructure.Helpers.TestTimeouts.Integration)]
     public async Task LiveOllama_WhenEnabled_ResolvesAndInfers()
     {

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
 
+[Trait("Category", "Integration")]
 public sealed class NcrEngineOllamaIntegrationTests
 {
     [Fact]
@@ -124,6 +125,100 @@ public sealed class NcrEngineOllamaIntegrationTests
         var paths = handler.Requests.Select(r => r.RequestUri!.AbsolutePath).ToList();
         paths.Should().Contain("/api/ps");
         paths.Should().Contain("/api/chat");
+    }
+
+    [Fact(Timeout = Nexo.Tests.Infrastructure.Helpers.TestTimeouts.Integration)]
+    public async Task LiveOllama_WhenEnabled_ResolvesAndInfers()
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("NEXO_TEST_REAL_NCR_OLLAMA"), "1", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var baseUrl = (Environment.GetEnvironmentVariable("NEXO_NODECAP_OLLAMA_URL")
+                       ?? Environment.GetEnvironmentVariable("OLLAMA_BASE_URL")
+                       ?? "http://127.0.0.1:11434").TrimEnd('/');
+        var modelId = Environment.GetEnvironmentVariable("NEXO_TEST_REAL_NCR_MODEL")
+                      ?? Environment.GetEnvironmentVariable("OLLAMA_MODEL")
+                      ?? "phi3:mini";
+
+        using var probe = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        using var probeCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        try
+        {
+            var tags = await probe.GetAsync($"{baseUrl}/api/tags", probeCts.Token);
+            if (!tags.IsSuccessStatusCode)
+                return;
+        }
+        catch (HttpRequestException)
+        {
+            return;
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        using var httpClient = new HttpClient { BaseAddress = new Uri(baseUrl + "/", UriKind.Absolute) };
+        var backend = new OllamaModelServingBackend(
+            httpClient,
+            Options.Create(new OllamaBackendOptions { BaseUrl = baseUrl }));
+        var lifecycle = new DefaultModelLifecycleManager(backend);
+        var policy = new LinuxPolicy();
+        var runtime = new NodeCapabilityRuntimeImpl(
+            new EnvironmentHardwareProfiler(),
+            policy,
+            lifecycle,
+            new ModelScoringService(policy),
+            Options.Create(new Nexo.Infrastructure.NodeCapabilityRuntime.NodeCapabilityRuntimeOptions
+            {
+                NodeId = "live-node",
+                DefaultModels =
+                [
+                    new ModelDescriptor
+                    {
+                        Id = modelId,
+                        Provider = "ollama",
+                        ProviderModelId = modelId,
+                        State = ModelState.Warm,
+                        QualityScore = 0.8f,
+                        SpeedScore = 0.7f,
+                        MinRAMRequiredBytes = 1024L * 1024 * 1024,
+                        Capabilities = new HashSet<TaskCapability> { TaskCapability.TextGeneration },
+                        SupportedPlatforms = new HashSet<PlatformType> { PlatformType.Linux, PlatformType.macOS, PlatformType.Windows }
+                    }
+                ]
+            }),
+            NullLogger<NodeCapabilityRuntimeImpl>.Instance);
+
+        var engine = new NcrAgenticBrickEngine(runtime);
+        var brick = new TestBrick
+        {
+            Id = "live-gen",
+            Name = "live-gen",
+            Category = BrickCategory.Generation,
+            Description = "live generation",
+            Implementations = new BrickImplementations
+            {
+                Agentic = new AgenticImplementation { Id = "a", Name = "a", Description = "a" }
+            }
+        };
+        var context = new Nexo.Infrastructure.Execution.ExecutionContext
+        {
+            AgentId = "agent-live",
+            BehaviorId = "behavior-live",
+            Provider = "ollama",
+            Variables = new Dictionary<string, object> { ["nexo:user_facing"] = true }
+        };
+
+        var resolution = await engine.ResolveModelForBrickAsync(brick, context, CancellationToken.None);
+        var inference = await backend.RunInferenceAsync(new InferenceRequest
+        {
+            ModelId = resolution.Model.ProviderModelId ?? resolution.Model.Id,
+            Prompt = "Reply with exactly: NCR_OLLAMA_OK",
+            SystemPrompt = "Return concise output."
+        });
+
+        resolution.Target.Should().Be(InferenceTarget.Local);
+        inference.Output.Should().NotBeNullOrWhiteSpace();
     }
 
     private sealed class TestBrick : Brick

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
@@ -6,10 +6,12 @@ using Microsoft.Extensions.Options;
 using Nexo.Core.Application.NodeCapabilityRuntime.Models;
 using Nexo.Infrastructure.Execution.Agentic;
 using Nexo.Infrastructure.Execution;
+using NodeCapabilityRuntimeImpl = Nexo.Infrastructure.NodeCapabilityRuntime.NodeCapabilityRuntime;
 using Nexo.Infrastructure.NodeCapabilityRuntime;
 using Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
 using Nexo.Infrastructure.NodeCapabilityRuntime.Lifecycle;
 using Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Profiles;
 using Nexo.Infrastructure.NodeCapabilityRuntime.Scoring;
 using Nexo.Core.Domain.Bricks;
 using Nexo.Core.Domain.Execution;
@@ -52,12 +54,12 @@ public sealed class NcrEngineOllamaIntegrationTests
             Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" }));
         var lifecycle = new DefaultModelLifecycleManager(backend);
         var policy = new LinuxPolicy();
-        var runtime = new NodeCapabilityRuntime(
+        var runtime = new NodeCapabilityRuntimeImpl(
             new EnvironmentHardwareProfiler(),
             policy,
             lifecycle,
             new ModelScoringService(policy),
-            Options.Create(new NodeCapabilityRuntimeOptions
+            Options.Create(new Nexo.Infrastructure.NodeCapabilityRuntime.NodeCapabilityRuntimeOptions
             {
                 NodeId = "integration-node",
                 DefaultModels =
@@ -76,7 +78,7 @@ public sealed class NcrEngineOllamaIntegrationTests
                     }
                 ]
             }),
-            NullLogger<NodeCapabilityRuntime>.Instance);
+            NullLogger<NodeCapabilityRuntimeImpl>.Instance);
 
         var engine = new NcrAgenticBrickEngine(runtime);
         var brick = new TestBrick
@@ -90,7 +92,7 @@ public sealed class NcrEngineOllamaIntegrationTests
                 Agentic = new AgenticImplementation { Id = "a", Name = "a", Description = "a" }
             }
         };
-        var context = new ExecutionContext
+        var context = new Nexo.Infrastructure.Execution.ExecutionContext
         {
             AgentId = "a1",
             BehaviorId = "b1",
@@ -121,7 +123,6 @@ public sealed class NcrEngineOllamaIntegrationTests
         inference.Output.Should().Be("integration-ok");
         var paths = handler.Requests.Select(r => r.RequestUri!.AbsolutePath).ToList();
         paths.Should().Contain("/api/ps");
-        paths.Should().Contain("/api/generate");
         paths.Should().Contain("/api/chat");
     }
 

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrEngineOllamaIntegrationTests.cs
@@ -127,6 +127,115 @@ public sealed class NcrEngineOllamaIntegrationTests
         paths.Should().Contain("/api/chat");
     }
 
+    [Fact]
+    public async Task ResolveModel_WhenBackendUnavailable_Throws_AndRecordsFailureSignal()
+    {
+        var handler = new FakeHttpMessageHandler((request, ct) =>
+        {
+            return request.RequestUri!.AbsolutePath switch
+            {
+                "/api/ps" => Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound))
+            };
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var backend = new OllamaModelServingBackend(
+            httpClient,
+            Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" }));
+        var lifecycle = new DefaultModelLifecycleManager(backend);
+        var policy = new LinuxPolicy();
+        var runtime = new NodeCapabilityRuntimeImpl(
+            new EnvironmentHardwareProfiler(),
+            policy,
+            lifecycle,
+            new ModelScoringService(policy),
+            Options.Create(new Nexo.Infrastructure.NodeCapabilityRuntime.NodeCapabilityRuntimeOptions
+            {
+                NodeId = "integration-node-failure",
+                DefaultModels =
+                [
+                    new ModelDescriptor
+                    {
+                        Id = "phi3-mini",
+                        Provider = "ollama",
+                        ProviderModelId = "phi3-mini",
+                        State = ModelState.Warm,
+                        QualityScore = 0.8f,
+                        SpeedScore = 0.8f,
+                        MinRAMRequiredBytes = 1024L * 1024 * 1024,
+                        Capabilities = new HashSet<TaskCapability> { TaskCapability.TextGeneration },
+                        SupportedPlatforms = new HashSet<PlatformType> { PlatformType.Linux }
+                    }
+                ]
+            }),
+            NullLogger<NodeCapabilityRuntimeImpl>.Instance);
+
+        var engine = new NcrAgenticBrickEngine(runtime);
+        var brick = new TestBrick
+        {
+            Id = "gen-failure",
+            Name = "gen-failure",
+            Category = BrickCategory.Generation,
+            Description = "generation",
+            Implementations = new BrickImplementations
+            {
+                Agentic = new AgenticImplementation { Id = "a", Name = "a", Description = "a" }
+            }
+        };
+        var context = new Nexo.Infrastructure.Execution.ExecutionContext
+        {
+            AgentId = "a1",
+            BehaviorId = "b1",
+            Provider = "ollama",
+            Variables = new Dictionary<string, object>
+            {
+                ["nexo:user_facing"] = true
+            }
+        };
+
+        var act = async () => await engine.ResolveModelForBrickAsync(brick, context, CancellationToken.None);
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.Requests.Select(r => r.RequestUri!.AbsolutePath).Should().Contain("/api/ps");
+    }
+
+    [Fact]
+    public async Task RunInference_WhenSlowResponse_Completes_WithMeasuredDuration()
+    {
+        var handler = new FakeHttpMessageHandler(async (request, ct) =>
+        {
+            if (request.RequestUri!.AbsolutePath == "/api/chat")
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(120), ct);
+                return JsonResponse("""
+                {
+                  "message": {
+                    "content": "slow-ok"
+                  }
+                }
+                """);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var backend = new OllamaModelServingBackend(
+            httpClient,
+            Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" }));
+
+        var inference = await backend.RunInferenceAsync(new InferenceRequest
+        {
+            ModelId = "phi3-mini",
+            Prompt = "hello",
+            SystemPrompt = "sys"
+        });
+
+        inference.Output.Should().Be("slow-ok");
+        inference.Duration.Should().BeGreaterThan(TimeSpan.FromMilliseconds(100));
+        handler.Requests.Select(r => r.RequestUri!.AbsolutePath).Should().Contain("/api/chat");
+    }
+
     [Fact(Timeout = Nexo.Tests.Infrastructure.Helpers.TestTimeouts.Integration)]
     public async Task LiveOllama_WhenEnabled_ResolvesAndInfers()
     {

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrStartupHealthServiceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrStartupHealthServiceTests.cs
@@ -25,8 +25,11 @@ public sealed class NcrStartupHealthServiceTests
     [Fact]
     public async Task StartAsync_DoesNotThrow_WhenOllamaUnavailable()
     {
+        using var httpClient = new HttpClient(new ThrowingHandler());
         var service = new NcrStartupHealthService(
-            new ThrowingOllamaBackend(),
+            new OllamaModelServingBackend(
+                httpClient,
+                Microsoft.Extensions.Options.Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" })),
             new LinuxPolicy(),
             NullLogger<NcrStartupHealthService>.Instance);
 
@@ -35,17 +38,9 @@ public sealed class NcrStartupHealthServiceTests
         await act.Should().NotThrowAsync();
     }
 
-    private sealed class ThrowingOllamaBackend : OllamaModelServingBackend
+    private sealed class ThrowingHandler : HttpMessageHandler
     {
-        public ThrowingOllamaBackend()
-            : base(new HttpClient(new ThrowingHandler()), Microsoft.Extensions.Options.Options.Create(new OllamaBackendOptions()))
-        {
-        }
-
-        private sealed class ThrowingHandler : HttpMessageHandler
-        {
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-                => throw new HttpRequestException("No route to host");
-        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("No route to host");
     }
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrStartupHealthServiceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrStartupHealthServiceTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.Infrastructure.NodeCapabilityRuntime;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class NcrStartupHealthServiceTests
+{
+    [Fact]
+    public async Task StartAsync_DoesNotThrow_ForNonOllamaBackend()
+    {
+        var service = new NcrStartupHealthService(
+            new NullModelServingBackend(),
+            new LinuxPolicy(),
+            NullLogger<NcrStartupHealthService>.Instance);
+
+        var act = async () => await service.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_DoesNotThrow_WhenOllamaUnavailable()
+    {
+        var service = new NcrStartupHealthService(
+            new ThrowingOllamaBackend(),
+            new LinuxPolicy(),
+            NullLogger<NcrStartupHealthService>.Instance);
+
+        var act = async () => await service.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private sealed class ThrowingOllamaBackend : OllamaModelServingBackend
+    {
+        public ThrowingOllamaBackend()
+            : base(new HttpClient(new ThrowingHandler()), Microsoft.Extensions.Options.Options.Create(new OllamaBackendOptions()))
+        {
+        }
+
+        private sealed class ThrowingHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => throw new HttpRequestException("No route to host");
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrTelemetryRegressionTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/NcrTelemetryRegressionTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Common.Ports;
+using Nexo.Core.Application.Execution.Ports;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using NodeCapabilityRuntimeImpl = Nexo.Infrastructure.NodeCapabilityRuntime.NodeCapabilityRuntime;
+using Nexo.Infrastructure.NodeCapabilityRuntime;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Lifecycle;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Scoring;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class NcrTelemetryRegressionTests
+{
+    [Fact]
+    public async Task SelectModel_EnsureReady_RecordOutcome_EmitsExpectedMetrics()
+    {
+        var metrics = new InMemoryMetricsCollector();
+        var policy = new LinuxPolicy();
+        var model = new ModelDescriptor
+        {
+            Id = "phi3-mini",
+            Provider = "ollama",
+            ProviderModelId = "phi3-mini",
+            State = ModelState.Warm,
+            QualityScore = 0.8f,
+            SpeedScore = 0.8f,
+            MinRAMRequiredBytes = 256 * 1024 * 1024,
+            Capabilities = new HashSet<TaskCapability> { TaskCapability.TextGeneration },
+            SupportedPlatforms = new HashSet<PlatformType> { PlatformType.Linux }
+        };
+
+        var backend = new StubModelServingBackend();
+        var lifecycle = new DefaultModelLifecycleManager(backend);
+        var runtime = new NodeCapabilityRuntimeImpl(
+            new FixedHardwareProfiler(new NodeProfile
+            {
+                Platform = PlatformType.Linux,
+                Tier = NodeTier.Standard,
+                AvailableRAMBytes = 8L * 1024 * 1024 * 1024,
+                TotalRAMBytes = 16L * 1024 * 1024 * 1024,
+                ThermalState = ThermalState.Nominal
+            }),
+            policy,
+            lifecycle,
+            new ModelScoringService(policy),
+            Options.Create(new NodeCapabilityRuntimeOptions
+            {
+                NodeId = "telemetry-node",
+                DefaultModels = [model]
+            }),
+            NullLogger<NodeCapabilityRuntimeImpl>.Instance,
+            metrics);
+
+        var resolution = await runtime.SelectModelAsync(new TaskContext
+        {
+            RequiredCapability = TaskCapability.TextGeneration,
+            Quality = QualityRequirement.Medium,
+            Latency = LatencyRequirement.Interactive,
+            Privacy = PrivacyBoundary.Standard
+        });
+        await runtime.EnsureModelReadyAsync(resolution.Model);
+        await runtime.RecordOutcomeAsync(
+            resolution,
+            new BrickExecutionOutcome
+            {
+                Succeeded = true,
+                Duration = TimeSpan.FromMilliseconds(55)
+            });
+
+        metrics.Counters.Should().ContainKey("ncr.model_resolution.target.Local");
+        metrics.Counters.Should().ContainKey("ncr.model_resolution.reason.BestLocalFit");
+        metrics.Counters.Should().ContainKey("ncr.model_load.success");
+        metrics.Counters.Should().ContainKey("ncr.outcome.success");
+        metrics.ExecutionTimes.Should().ContainKey("ncr.model_resolution.duration");
+        metrics.ExecutionTimes.Should().ContainKey("ncr.model_load.duration");
+        metrics.ExecutionTimes.Should().ContainKey("ncr.outcome.duration");
+    }
+
+    private sealed class FixedHardwareProfiler : Nexo.Core.Application.NodeCapabilityRuntime.Ports.IHardwareProfiler
+    {
+        private readonly NodeProfile _profile;
+
+        public FixedHardwareProfiler(NodeProfile profile)
+        {
+            _profile = profile;
+        }
+
+        public Task<NodeProfile> CaptureAsync(CancellationToken ct = default) => Task.FromResult(_profile);
+    }
+
+    private sealed class StubModelServingBackend : Nexo.Core.Application.NodeCapabilityRuntime.Ports.IModelServingBackend
+    {
+        public BackendType BackendType => BackendType.Ollama;
+
+        public Task<bool> IsAvailableAsync(CancellationToken ct = default) => Task.FromResult(true);
+
+        public Task<InferenceResult> RunInferenceAsync(InferenceRequest request, CancellationToken ct = default)
+            => Task.FromResult(new InferenceResult { Output = "ok", Duration = TimeSpan.FromMilliseconds(1), TokenCount = 1 });
+
+        public Task LoadModelAsync(string modelId, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task UnloadModelAsync(string modelId, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task PullModelAsync(string modelId, IProgress<PullProgress>? progress = null, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListLoadedModelsAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class InMemoryMetricsCollector : IMetricsCollector
+    {
+        public Dictionary<string, TimeSpan> ExecutionTimes { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, long> Counters { get; } = new(StringComparer.Ordinal);
+
+        public void RecordExecutionTime(string operationName, TimeSpan duration)
+        {
+            ExecutionTimes[operationName] = ExecutionTimes.TryGetValue(operationName, out var current)
+                ? current + duration
+                : duration;
+        }
+
+        public void IncrementCounter(string counterName, int value = 1)
+        {
+            Counters[counterName] = Counters.TryGetValue(counterName, out var current)
+                ? current + value
+                : value;
+        }
+
+        public Task<MetricsSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new MetricsSnapshot
+            {
+                ExecutionTimes = new Dictionary<string, TimeSpan>(ExecutionTimes),
+                Counters = new Dictionary<string, long>(Counters)
+            });
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/OllamaModelServingBackendTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/OllamaModelServingBackendTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class OllamaModelServingBackendTests
+{
+    [Fact]
+    public async Task RunInferenceAsync_UsesChatEndpoint_AndParsesContent()
+    {
+        var handler = new FakeHttpMessageHandler((request, ct) =>
+        {
+            request.RequestUri!.AbsolutePath.Should().Be("/api/chat");
+            return Task.FromResult(JsonResponse("""
+            {
+              "message": {
+                "content": "hello from ollama"
+              }
+            }
+            """));
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var options = Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" });
+        var sut = new OllamaModelServingBackend(httpClient, options);
+
+        var result = await sut.RunInferenceAsync(new InferenceRequest
+        {
+            ModelId = "phi3:mini",
+            Prompt = "Say hello"
+        });
+
+        result.Output.Should().Be("hello from ollama");
+        handler.Requests.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PullLoadUnload_ListLoadedModels_UsesExpectedOllamaEndpoints()
+    {
+        var handler = new FakeHttpMessageHandler((request, ct) =>
+        {
+            return request.RequestUri!.AbsolutePath switch
+            {
+                "/api/pull" => Task.FromResult(JsonResponse("""
+                { "status":"success" }
+                """)),
+                "/api/generate" => Task.FromResult(JsonResponse("""
+                { "response":"ok" }
+                """)),
+                "/api/ps" => Task.FromResult(JsonResponse("""
+                {
+                  "models": [
+                    { "name": "phi3:mini" },
+                    { "name": "nomic-embed-text" }
+                  ]
+                }
+                """)),
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound))
+            };
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var options = Options.Create(new OllamaBackendOptions { BaseUrl = "http://127.0.0.1:11434" });
+        var sut = new OllamaModelServingBackend(httpClient, options);
+
+        await sut.PullModelAsync("phi3:mini");
+        await sut.LoadModelAsync("phi3:mini");
+        await sut.UnloadModelAsync("phi3:mini");
+        var loaded = await sut.ListLoadedModelsAsync();
+
+        loaded.Should().Contain("phi3:mini");
+        loaded.Should().Contain("nomic-embed-text");
+        handler.Requests.Select(r => r.RequestUri!.AbsolutePath).Should().ContainInOrder(
+            "/api/pull",
+            "/api/generate",
+            "/api/generate",
+            "/api/ps");
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return _handler(request, cancellationToken);
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/PlatformPolicyTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/PlatformPolicyTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Policies;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class PlatformPolicyTests
+{
+    [Fact]
+    public void LinuxPolicy_CanAdvertiseRemoteWork_WhenGpuLow()
+    {
+        var policy = new LinuxPolicy();
+        var profile = new NodeProfile { GPUUtilizationPercent = 20f };
+
+        policy.CanAdvertiseRemoteWork(profile).Should().BeTrue();
+    }
+
+    [Fact]
+    public void LinuxPolicy_CanAdvertiseRemoteWork_WhenGpuHigh_ShouldBeFalse()
+    {
+        var policy = new LinuxPolicy();
+        var profile = new NodeProfile { GPUUtilizationPercent = 75f };
+
+        policy.CanAdvertiseRemoteWork(profile).Should().BeFalse();
+    }
+
+    [Fact]
+    public void WindowsPolicy_CanLoadModel_RequiresVramAndRam()
+    {
+        var policy = new WindowsPolicy();
+        var profile = new NodeProfile
+        {
+            AvailableVRAMBytes = 3L * 1024 * 1024 * 1024,
+            AvailableRAMBytes = 8L * 1024 * 1024 * 1024
+        };
+        var model = new ModelDescriptor
+        {
+            MinVRAMRequiredBytes = 4L * 1024 * 1024 * 1024,
+            MinRAMRequiredBytes = 6L * 1024 * 1024 * 1024
+        };
+
+        policy.CanLoadModel(model, profile).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AndroidPolicy_CanPullModel_RespectsCellularFlag()
+    {
+        var policy = new AndroidPolicy { AllowCellularPull = false };
+        var profile = new NodeProfile
+        {
+            BatteryLevelPercent = 80f,
+            NetworkLatency = new NetworkLatencyProfile { IsWifi = false }
+        };
+
+        policy.CanPullModel(profile).Should().BeFalse();
+    }
+
+    [Fact]
+    public void MacPolicy_ShouldUnloadAfterInference_OnBattery()
+    {
+        var policy = new MacOsPolicy();
+        var profile = new NodeProfile
+        {
+            IsOnBattery = true,
+            IsCharging = false
+        };
+
+        policy.ShouldUnloadAfterInference(profile).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IOSPolicy_CanAdvertiseRemoteWork_RequiresBackgroundChargingWifi()
+    {
+        var policy = new iOSPolicy();
+        var profile = new NodeProfile
+        {
+            IsCharging = true,
+            BatteryLevelPercent = 80f,
+            AppState = AppState.Background,
+            ThermalState = ThermalState.Fair,
+            NetworkLatency = new NetworkLatencyProfile { IsWifi = true }
+        };
+
+        policy.CanAdvertiseRemoteWork(profile).Should().BeTrue();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/TierClassificationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/TierClassificationTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Profiles;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+public sealed class TierClassificationTests
+{
+    [Theory]
+    [InlineData(4L, 0L, NodeTier.Nano)]
+    [InlineData(12L, 0L, NodeTier.Micro)]
+    [InlineData(32L, 0L, NodeTier.Standard)]
+    [InlineData(64L, 0L, NodeTier.Core)]
+    [InlineData(8L, 12L, NodeTier.Standard)]
+    [InlineData(8L, 24L, NodeTier.Core)]
+    public void ClassifyTier_MapsRepresentativeHardware(
+        long ramGiB,
+        long vramGiB,
+        NodeTier expected)
+    {
+        var profile = new NodeProfile
+        {
+            TotalRAMBytes = ramGiB * 1024 * 1024 * 1024,
+            TotalVRAMBytes = vramGiB * 1024 * 1024 * 1024
+        };
+
+        var tier = EnvironmentHardwareProfiler.ClassifyTier(profile);
+        tier.Should().Be(expected);
+    }
+}

--- a/src/Nexo.Tests.Orchestration/Routing/EndpointHealthMonitorTests.cs
+++ b/src/Nexo.Tests.Orchestration/Routing/EndpointHealthMonitorTests.cs
@@ -96,6 +96,50 @@ public sealed class EndpointHealthMonitorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_UnhealthyProbe_DoesNotLogBeforeThreshold()
+    {
+        using var env = new EnvironmentVariableScope("DOTNET_ENVIRONMENT", "Development");
+        var endpoint = "http://127.0.0.1:6552";
+        var registry = new TestEndpointRegistry([
+            new EndpointDescriptor(
+                Endpoint: endpoint,
+                Name: "down-threshold",
+                SupportedCapabilities: ["CodeGeneration"],
+                AcceptedBarrierLevels: [],
+                Region: null,
+                Priority: 1,
+                IsHealthy: true)
+        ]);
+
+        using var transport = CreateGrpcTransport();
+        var logger = new Mock<ILogger<EndpointHealthMonitor>>();
+        var monitor = new EndpointHealthMonitor(
+            registry,
+            transport,
+            Options.Create(new RoutingOptions
+            {
+                HealthCheckIntervalSeconds = 30,
+                DegradedLogFailureThreshold = 2
+            }),
+            logger.Object);
+
+        await monitor.StartAsync(CancellationToken.None);
+        await Task.Delay(300);
+        await monitor.StopAsync(CancellationToken.None);
+
+        registry.Updates.Should().ContainSingle();
+        registry.Updates[0].isHealthy.Should().BeFalse();
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_CancellationRequested_StopsPromptly()
     {
         using var env = new EnvironmentVariableScope("DOTNET_ENVIRONMENT", "Development");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Implemented the final release-gate blocker fix by replacing `IReadOnlySet<>` in NCR model contracts with `IReadOnlyCollection<>` to restore `netstandard2.0` compatibility.
- Re-ran the full Production Readiness Gate v1 command set (build + pipeline/runtime tests + CLI validate/run/fallback + LiteDb durable resume).

## Testing
- `dotnet build src/Nexo.Core.Application/Nexo.Core.Application.csproj -f netstandard2.0`
- `dotnet build src/Nexo.Infrastructure/Nexo.Infrastructure.csproj`
- `dotnet build src/Nexo.CLI/Nexo.CLI.csproj`
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter "FullyQualifiedName~Pipelines"`
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net9.0 --filter "FullyQualifiedName~Pipelines"`
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter "FullyQualifiedName~HostingE2ESmokeTests.AddNexo_RegistersObservationPipeline_ByDefault|FullyQualifiedName~Pipelines.PipelineServiceCollectionExtensionsTests.AddNexo_RegistersPipelineCompositionLayerByDefault"`
- `dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline validate --template /tmp/pipeline_gate_demo.json`
- `dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-success --format-json`
- `NEXO_PIPELINE_ENABLE_TEST_HOOKS=1 NEXO_PIPELINE_COMPLETION_POLICY=AllowNonCriticalStageFailures dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-run-fallback --input "fail:hybrid:deterministic=true" --format-json`
- `dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline diagnostics --format-json`
- `NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db NEXO_PIPELINE_ENABLE_TEST_HOOKS=1 dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-source --input "fail:ingest:deterministic=true" --format-json`
- `NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH=/tmp/nexo_pipeline_gate_resume.db dotnet run --project src/Nexo.CLI/Nexo.CLI.csproj -- pipeline run --template /tmp/pipeline_gate_demo.json --run-id gate-resume-target --resume-run-id gate-resume-source --resume-failed-stages --format-json"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69a70212-b05a-4548-8eb4-e685fe27f1d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69a70212-b05a-4548-8eb4-e685fe27f1d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

