### PR TITLE
Add supervisor-driven iterative Unity sidecar loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ bash scripts/oh-shit-demo.sh --quick --no-build
 
 # unity sidecar demo (generate + compile validation + dogfood block1)
 bash scripts/unity-sidecar-demo.sh run-demo --prompt "add a dash ability"
+
+# supervisor loop (gameplay/combat/economy/ai) with iterative validation
+bash scripts/unity-sidecar-demo.sh supervise --game "co-op dungeon crawler" --iterations 2
 ```
 
 References:

--- a/docs/UnitySidecarDemo.md
+++ b/docs/UnitySidecarDemo.md
@@ -23,6 +23,7 @@ dotnet run --project tools/Nexo.UnitySidecarDemo -- <args>
 - `generate` – takes a gameplay prompt, calls Nexo orchestration, and writes Unity-style generated scripts
 - `validate` – compiles generated scripts in Ubuntu using Unity stubs
 - `run-demo` – runs `generate` + `validate` + dogfood block1 checks
+- `supervise` – runs a supervisor loop across Gameplay/Combat/Economy/AI roles and validates each iteration
 
 Output root defaults to:
 
@@ -56,6 +57,9 @@ bash scripts/unity-sidecar-demo.sh generate --prompt "add a health pickup system
 
 # Validate generated scripts compile
 bash scripts/unity-sidecar-demo.sh validate
+
+# Supervisor-driven iterative team loop
+bash scripts/unity-sidecar-demo.sh supervise --game "co-op dungeon crawler" --iterations 2
 ```
 
 ## Suggested next step (Unity machine)

--- a/scripts/unity-sidecar-demo.sh
+++ b/scripts/unity-sidecar-demo.sh
@@ -10,6 +10,7 @@ Usage:
   bash scripts/unity-sidecar-demo.sh generate --prompt "add a dash ability"
   bash scripts/unity-sidecar-demo.sh validate
   bash scripts/unity-sidecar-demo.sh run-demo --prompt "add a health pickup system"
+  bash scripts/unity-sidecar-demo.sh supervise --game "co-op dungeon crawler" --iterations 2
 EOF
   exit 1
 fi

--- a/tools/Nexo.UnitySidecarDemo/Program.cs
+++ b/tools/Nexo.UnitySidecarDemo/Program.cs
@@ -31,6 +31,7 @@ internal static class Program
             "generate" => await GenerateAsync(repoRoot, options),
             "validate" => await ValidateAsync(repoRoot, options),
             "run-demo" => await RunDemoAsync(repoRoot, options),
+            "supervise" => await SuperviseAsync(repoRoot, options),
             _ => UnknownCommand(command)
         };
     }
@@ -71,6 +72,125 @@ internal static class Program
         Console.WriteLine(JsonSerializer.Serialize(payload, JsonOptions()));
 
         return dogfoodResult.ExitCode;
+    }
+
+    private static async Task<int> SuperviseAsync(string repoRoot, Dictionary<string, string> options)
+    {
+        var gameConcept = options.TryGetValue("game", out var requestedGame) && !string.IsNullOrWhiteSpace(requestedGame)
+            ? requestedGame.Trim()
+            : "a co-op arena action roguelite";
+
+        var outputRoot = options.TryGetValue("output-root", out var providedRoot)
+            ? providedRoot
+            : DefaultOutputRoot;
+
+        var iterations = 2;
+        if (options.TryGetValue("iterations", out var rawIterations))
+        {
+            if (!int.TryParse(rawIterations, out iterations) || iterations <= 0)
+            {
+                Console.Error.WriteLine("supervise requires --iterations to be a positive integer.");
+                return 2;
+            }
+        }
+
+        var team = BuildSupervisorTeam();
+        var allIterationsPassed = true;
+        var iterationReports = new List<object>();
+        var generatedFiles = new List<string>();
+
+        for (var iteration = 1; iteration <= iterations; iteration++)
+        {
+            var roleReports = new List<object>();
+            foreach (var role in team)
+            {
+                var iterationPrompt = BuildSupervisorPrompt(gameConcept, role, iteration, iterations);
+                var systemName = SanitizeClassName($"{role.RoleName}Iteration{iteration}System");
+                var generateOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["prompt"] = iterationPrompt,
+                    ["output-root"] = outputRoot,
+                    ["system-name"] = systemName
+                };
+
+                var generateExit = await GenerateAsync(repoRoot, generateOptions);
+                var generatedFile = Path.Combine(outputRoot, "Assets", "GeneratedSystems", $"{systemName}.cs");
+                generatedFiles.Add(generatedFile);
+
+                roleReports.Add(new
+                {
+                    role = role.RoleName,
+                    focus = role.FocusArea,
+                    systemName,
+                    generatedFile,
+                    exitCode = generateExit,
+                    ok = generateExit == 0
+                });
+
+                if (generateExit != 0)
+                {
+                    allIterationsPassed = false;
+                    iterationReports.Add(new
+                    {
+                        iteration,
+                        ok = false,
+                        roleReports
+                    });
+                    break;
+                }
+            }
+
+            if (!allIterationsPassed)
+                break;
+
+            var validateExit = await ValidateAsync(repoRoot, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["output-root"] = outputRoot
+            });
+
+            var iterationPassed = validateExit == 0;
+            if (!iterationPassed)
+                allIterationsPassed = false;
+
+            iterationReports.Add(new
+            {
+                iteration,
+                ok = iterationPassed,
+                validateExitCode = validateExit,
+                roleReports
+            });
+
+            if (!iterationPassed)
+                break;
+        }
+
+        var absoluteOutputRoot = Path.GetFullPath(Path.Combine(repoRoot, outputRoot));
+        Directory.CreateDirectory(absoluteOutputRoot);
+        var reportPath = Path.Combine(absoluteOutputRoot, "supervisor_report.json");
+        var reportPayload = new
+        {
+            ok = allIterationsPassed,
+            stage = "supervise",
+            game = gameConcept,
+            iterations,
+            generatedFiles,
+            iterationReports,
+            generatedAtUtc = DateTimeOffset.UtcNow
+        };
+        await File.WriteAllTextAsync(reportPath, JsonSerializer.Serialize(reportPayload, JsonOptions()));
+
+        var consolePayload = new
+        {
+            ok = allIterationsPassed,
+            stage = "supervise",
+            game = gameConcept,
+            iterations,
+            teamSize = team.Count,
+            outputRoot = Path.GetRelativePath(repoRoot, absoluteOutputRoot),
+            reportFile = Path.GetRelativePath(repoRoot, reportPath)
+        };
+        Console.WriteLine(JsonSerializer.Serialize(consolePayload, JsonOptions()));
+        return allIterationsPassed ? 0 : 1;
     }
 
     private static async Task<int> GenerateAsync(string repoRoot, Dictionary<string, string> options)
@@ -568,13 +688,37 @@ public static class Mathf
         help.AppendLine("  generate  --prompt \"...\" [--output-root tools/unity-demo-output] [--system-name DashAbilitySystem]");
         help.AppendLine("  validate  [--output-root tools/unity-demo-output]");
         help.AppendLine("  run-demo  [--prompt \"...\"] [--output-root tools/unity-demo-output]");
+        help.AppendLine("  supervise [--game \"...\"] [--iterations 2] [--output-root tools/unity-demo-output]");
         help.AppendLine();
         help.AppendLine("Examples:");
         help.AppendLine("  dotnet run --project tools/Nexo.UnitySidecarDemo -- generate --prompt \"add a dash ability\"");
         help.AppendLine("  dotnet run --project tools/Nexo.UnitySidecarDemo -- validate");
         help.AppendLine("  dotnet run --project tools/Nexo.UnitySidecarDemo -- run-demo --prompt \"add a health pickup system\"");
+        help.AppendLine("  dotnet run --project tools/Nexo.UnitySidecarDemo -- supervise --game \"build a coop dungeon crawler\" --iterations 2");
         Console.WriteLine(help.ToString());
+    }
+
+    private static List<SupervisorRole> BuildSupervisorTeam()
+    {
+        return new List<SupervisorRole>
+        {
+            new("Gameplay", "Core movement and player loop", "Design or improve the core movement loop for {GAME}. Include a dash or traversal interaction and clear tunables."),
+            new("Combat", "Combat interactions and balance", "Design combat mechanics for {GAME}. Include timing windows, risk/reward, and a dash-attack interaction."),
+            new("Economy", "Rewards and progression pacing", "Design rewards and progression for {GAME}. Include health pickup balance, recovery pacing, and spend/sink signals."),
+            new("AI", "Enemy and encounter behavior", "Design enemy behavior for {GAME}. Define one encounter pattern, telegraphs, and adaptation to player movement.")
+        };
+    }
+
+    private static string BuildSupervisorPrompt(
+        string gameConcept,
+        SupervisorRole role,
+        int iteration,
+        int totalIterations)
+    {
+        return $"{role.PromptTemplate.Replace("{GAME}", gameConcept, StringComparison.Ordinal)} " +
+               $"Iteration {iteration} of {totalIterations}: produce a focused, implementable gameplay system script.";
     }
 }
 
 internal sealed record CommandResult(int ExitCode, string StdOut, string StdErr);
+internal sealed record SupervisorRole(string RoleName, string FocusArea, string PromptTemplate);

--- a/tools/Nexo.UnitySidecarDemo/Program.cs
+++ b/tools/Nexo.UnitySidecarDemo/Program.cs
@@ -244,7 +244,7 @@ internal static class Program
 
         var payload = new
         {
-            ok = true,
+            ok = nexoResult.ExitCode == 0,
             stage = "generate",
             prompt,
             className,
@@ -254,7 +254,7 @@ internal static class Program
             nexoChatExitCode = nexoResult.ExitCode
         };
         Console.WriteLine(JsonSerializer.Serialize(payload, JsonOptions()));
-        return 0;
+        return nexoResult.ExitCode == 0 ? 0 : 1;
     }
 
     private static async Task<int> ValidateAsync(string repoRoot, Dictionary<string, string> options)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `supervise` command to `tools/Nexo.UnitySidecarDemo` that acts as a supervisor over a role-based Nexo team (Gameplay, Combat, Economy, AI)
- run generation for each role per iteration and compile-validate the generated Unity-sidecar scripts after every iteration
- emit `supervisor_report.json` with per-iteration and per-role outcomes for iterative review
- document command usage in `docs/UnitySidecarDemo.md`, `scripts/unity-sidecar-demo.sh`, and `README.md`

## Testing
- ✅ `dotnet build tools/Nexo.UnitySidecarDemo/Nexo.UnitySidecarDemo.csproj`
- ✅ `dotnet run --project tools/Nexo.UnitySidecarDemo -- --help`
- ✅ `bash scripts/unity-sidecar-demo.sh supervise --game "co-op dungeon crawler" --iterations 2 --output-root "tools/unity-demo-output-supervise"`
- ✅ validated generated report contents at `tools/unity-demo-output-supervise/supervisor_report.json`

Artifacts:
- `/opt/cursor/artifacts/unity_sidecar_supervise_build.log`
- `/opt/cursor/artifacts/unity_sidecar_supervise_help.log`
- `/opt/cursor/artifacts/unity_sidecar_supervise_run.log`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-284e8f6c-b770-4c3f-bd8d-1191f9f7673d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-284e8f6c-b770-4c3f-bd8d-1191f9f7673d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

