### PR TITLE
Add self-hosted game director portal and daily workflow

### DIFF
--- a/.docker/Dockerfile.api
+++ b/.docker/Dockerfile.api
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY . .
+RUN dotnet restore src/Nexo.API/Nexo.API.csproj
+RUN dotnet publish src/Nexo.API/Nexo.API.csproj -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish ./
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Nexo.API.dll"]

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --fil
 Start here:
 - `docs/GettingStarted.md` – guided first-hour setup and usage
 - `docs/DocsIndex.md` – where to find docs by task
+- `apps/runtime-studio/README.md` – application-layer planner+worker agent set integration.
 
 Core references:
 - `docs/Configuration.md` – environment/config options

--- a/README.md
+++ b/README.md
@@ -260,11 +260,15 @@ docker compose -f docker-compose.test.yml up --build test-ubuntu
 # start ephemeral Ollama container (and optional Postgres profile)
 docker compose -f docker-compose.ephemeral.yml up ollama
 docker compose -f docker-compose.ephemeral.yml --profile db up postgres
+
+# start self-hosted director portal (API + dailies + Ollama)
+docker compose -f docker-compose.portal.yml up -d --build
 ```
 
 Notes:
 - `docker-compose.test.yml` mounts `./test-results` and runs `BaseFrameworkSmokeTests` (`net9.0`) in container, writing log/summary artifacts there.
 - `docker-compose.ephemeral.yml` is for disposable local orchestration dependencies.
+- `docker-compose.portal.yml` serves a browser portal on `http://localhost:8080` for iterative directorial runs and daily review.
 
 ## Providers
 

--- a/apps/runtime-studio/README.md
+++ b/apps/runtime-studio/README.md
@@ -1,0 +1,56 @@
+# Runtime Studio (Application Layer)
+
+`runtime-studio` is an application-level integration that composes Nexo runtime services into a planner + worker agent set.
+
+This sits outside kernel internals and uses:
+
+- `Nexo.CLI background-agent daemon --config ...`
+- project-scoped sandboxing under `.nexo/`
+- local-first model routing via Ollama
+
+## Why this exists in `apps/`
+
+This is a runtime application of Nexo, not a kernel primitive.
+Kernel packages stay reusable; Runtime Studio defines product workflow, operator scripts, and agent-set policy.
+
+## Local-first agent set
+
+Config file:
+
+- `apps/runtime-studio/config/agent_set.local.json`
+
+Agent roles included:
+
+- `runtime-planner` (`extender`) - planning + safe code actions through policy-gated self-extend
+- `runtime-worker-optimizer` (`optimizer`) - code analysis worker
+- `runtime-worker-tester` (`tester`) - test verification worker
+
+## Quick start
+
+From repo root:
+
+```bash
+bash apps/runtime-studio/scripts/bootstrap_runtime_studio.sh
+bash apps/runtime-studio/scripts/run_agent_set_local.sh --duration 5m --disable-observation
+```
+
+The run script configures:
+
+- `NEXO_SANDBOX_ROOT`
+- `NEXO_PATH_ALLOWLIST_EXTRA`
+- cache relocation (`TMPDIR`, `NUGET_PACKAGES`, `NPM_CONFIG_CACHE`)
+- local model defaults (`OLLAMA_BASE_URL`, `OLLAMA_MODEL`)
+
+## Customize the agent set
+
+Edit:
+
+- `apps/runtime-studio/config/agent_set.local.json`
+
+Common changes:
+
+- tune schedule intervals
+- update `ModelName` for planner/worker split
+- change tester filter
+- adjust exfiltration policy boundaries
+

--- a/apps/runtime-studio/config/agent_set.local.json
+++ b/apps/runtime-studio/config/agent_set.local.json
@@ -1,0 +1,106 @@
+{
+  "BackgroundAgents": {
+    "Agents": [
+      {
+        "Id": "runtime-planner",
+        "Name": "Runtime Studio Planner",
+        "Role": "extender",
+        "ModelProvider": "ollama",
+        "ModelName": "llama3.1",
+        "Commands": [
+          "plan",
+          "decompose",
+          "propose_changes",
+          "self_extend"
+        ],
+        "Parameters": {
+          "RepoRoot": ".",
+          "Objective": "Plan and drive iterative runtime-studio improvements under sandbox policy.",
+          "AgentName": "runtime-studio-planner"
+        },
+        "Schedule": {
+          "Type": "Interval",
+          "Interval": "00:03:00",
+          "InitialDelay": "00:00:10"
+        },
+        "Enabled": true,
+        "MaxDataSensitivity": "Internal",
+        "AllowedDataSensitivityLevels": [
+          "Public",
+          "Internal"
+        ],
+        "ExfiltrationPolicy": {
+          "BlockExternalLLMs": true,
+          "BlockWebSearch": true,
+          "BlockNetworkExports": true,
+          "RequireLocalOnly": true,
+          "MaxAllowedLevel": "Internal"
+        }
+      },
+      {
+        "Id": "runtime-worker-optimizer",
+        "Name": "Runtime Studio Optimizer Worker",
+        "Role": "optimizer",
+        "ParentId": "runtime-planner",
+        "ModelProvider": "ollama",
+        "ModelName": "llama3.1",
+        "Commands": [
+          "analyze",
+          "suggest"
+        ],
+        "Parameters": {
+          "AnalysisPath": "."
+        },
+        "Schedule": {
+          "Type": "Interval",
+          "Interval": "00:04:00",
+          "InitialDelay": "00:00:20"
+        },
+        "Enabled": true,
+        "MaxDataSensitivity": "Internal",
+        "AllowedDataSensitivityLevels": [
+          "Public",
+          "Internal"
+        ],
+        "ExfiltrationPolicy": {
+          "BlockExternalLLMs": true,
+          "BlockWebSearch": true,
+          "BlockNetworkExports": true,
+          "RequireLocalOnly": true,
+          "MaxAllowedLevel": "Internal"
+        }
+      },
+      {
+        "Id": "runtime-worker-tester",
+        "Name": "Runtime Studio Tester Worker",
+        "Role": "tester",
+        "ParentId": "runtime-planner",
+        "ModelProvider": "deterministic",
+        "Commands": [
+          "test"
+        ],
+        "Parameters": {
+          "Filter": "FullyQualifiedName~PathAllowlist"
+        },
+        "Schedule": {
+          "Type": "Interval",
+          "Interval": "00:05:00",
+          "InitialDelay": "00:00:30"
+        },
+        "Enabled": true,
+        "MaxDataSensitivity": "Internal",
+        "AllowedDataSensitivityLevels": [
+          "Public",
+          "Internal"
+        ],
+        "ExfiltrationPolicy": {
+          "BlockExternalLLMs": true,
+          "BlockWebSearch": true,
+          "BlockNetworkExports": true,
+          "RequireLocalOnly": true,
+          "MaxAllowedLevel": "Internal"
+        }
+      }
+    ]
+  }
+}

--- a/apps/runtime-studio/scripts/bootstrap_runtime_studio.sh
+++ b/apps/runtime-studio/scripts/bootstrap_runtime_studio.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+bash "${ROOT}/scripts/sandbox/init-agent-sandbox.sh" --project-root "${ROOT}" --profile runtime-studio
+
+mkdir -p "${ROOT}/.nexo/tools/cache/tmp"
+mkdir -p "${ROOT}/.nexo/tools/cache/nuget"
+mkdir -p "${ROOT}/.nexo/tools/cache/npm"
+mkdir -p "${ROOT}/.nexo/agents/workspaces/runtime-studio"
+
+echo
+echo "Runtime Studio bootstrap complete."
+echo "Next: bash apps/runtime-studio/scripts/run_agent_set_local.sh --duration 5m --disable-observation"

--- a/apps/runtime-studio/scripts/run_agent_set_local.sh
+++ b/apps/runtime-studio/scripts/run_agent_set_local.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CONFIG_PATH="${REPO_ROOT}/apps/runtime-studio/config/agent_set.local.json"
+
+DURATION="10m"
+DISABLE_OBSERVATION=0
+FORMAT_JSON=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --duration)
+      DURATION="${2:-10m}"
+      shift 2
+      ;;
+    --disable-observation)
+      DISABLE_OBSERVATION=1
+      shift
+      ;;
+    --format-json)
+      FORMAT_JSON=1
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--duration <30s|5m|1h>] [--disable-observation] [--format-json]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+  echo "Missing config file: ${CONFIG_PATH}" >&2
+  exit 1
+fi
+
+bash "${REPO_ROOT}/apps/runtime-studio/scripts/bootstrap_runtime_studio.sh"
+
+export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://127.0.0.1:11434}"
+export OLLAMA_MODEL="${OLLAMA_MODEL:-llama3.1}"
+
+DAEMON_CMD=(
+  dotnet run --project src/Nexo.CLI -- background-agent daemon
+  --config "${CONFIG_PATH}"
+  --duration "${DURATION}"
+)
+
+if [[ "${DISABLE_OBSERVATION}" -eq 1 ]]; then
+  DAEMON_CMD+=(--disable-observation)
+fi
+if [[ "${FORMAT_JSON}" -eq 1 ]]; then
+  DAEMON_CMD+=(--format-json)
+fi
+
+echo "Running Runtime Studio local agent set"
+echo "  repo: ${REPO_ROOT}"
+echo "  config: ${CONFIG_PATH}"
+echo "  duration: ${DURATION}"
+echo "  observation: $([[ "${DISABLE_OBSERVATION}" -eq 1 ]] && echo "disabled" || echo "enabled")"
+echo "  ollama: ${OLLAMA_BASE_URL} (${OLLAMA_MODEL})"
+echo
+
+cd "${REPO_ROOT}"
+"${DAEMON_CMD[@]}"

--- a/docker-compose.portal.yml
+++ b/docker-compose.portal.yml
@@ -1,0 +1,29 @@
+services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-models:/root/.ollama
+    restart: unless-stopped
+
+  nexo-api:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile.api
+    depends_on:
+      - ollama
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      OLLAMA_BASE_URL: http://ollama:11434
+      OLLAMA_MODEL: llama3.2
+      NEXO_DAILIES_PATH: /data/dailies
+    ports:
+      - "8080:8080"
+    volumes:
+      - nexo-dailies:/data/dailies
+    restart: unless-stopped
+
+volumes:
+  ollama-models:
+  nexo-dailies:

--- a/docs/AgentSandboxArchitecture.md
+++ b/docs/AgentSandboxArchitecture.md
@@ -1,0 +1,104 @@
+# Agent Sandbox Architecture (Host + Project-Scoped Tools)
+
+This guide describes how to run Nexo agents in a constrained sandbox while still
+allowing host-bound tools (for example Unity Editor) and dependency downloads.
+
+## Goals
+
+1. Prevent agents from writing outside approved paths.
+2. Keep third-party SDKs/tools and caches in project-scoped directories.
+3. Support host-installed apps that cannot be containerized by default.
+
+## Policy enforcement in this repo
+
+`PathAllowlist` now supports configurable sandbox prefixes:
+
+- Defaults: `src/`, `tests/`, `docs/`
+- Optional env var: `NEXO_AGENT_SANDBOX_PATHS`
+
+When set, `NEXO_AGENT_SANDBOX_PATHS` extends allowed write prefixes (comma-separated):
+
+```bash
+export NEXO_AGENT_SANDBOX_PATHS=".nexo/sandbox/projects/,.nexo/sandbox/tools/,.nexo/sandbox/cache/"
+```
+
+The policy still blocks:
+
+- absolute paths
+- path traversal (`..`)
+- writes outside allowlisted prefixes
+
+## Recommended project layout
+
+Create a per-project sandbox tree under repo root:
+
+```text
+.nexo/
+  sandbox/
+    projects/      # agent-created project artifacts
+    tools/         # third-party tools/SDKs installed for this project
+    cache/         # npm/nuget/pip/unity package caches
+    logs/          # run logs/audit traces
+```
+
+Bootstrap helper:
+
+```bash
+bash scripts/sandbox/init-agent-sandbox.sh
+```
+
+## Host-bound applications (Unity, etc.)
+
+Some tools cannot be containerized economically or by license.
+For these, use a split model:
+
+1. Keep editor/runtime host-installed by a human operator.
+2. Keep project-specific dependencies/caches under `.nexo/sandbox`.
+3. Restrict agent-generated files to sandbox + approved code folders.
+4. Trigger host apps through wrapper scripts that accept only sandboxed paths.
+
+### Unity pattern
+
+- Unity Editor remains host-installed and user-licensed.
+- Agent output goes to:
+  - `.nexo/sandbox/projects/<project>/...`
+  - or directly to controlled Unity project subfolders under repo.
+- Unity package/download caches use `.nexo/sandbox/cache`.
+- Any script invoking Unity should validate paths before execution.
+
+## Operating modes
+
+### Mode A: Fully containerized workers
+
+- Use container execution for generic build/test tasks.
+- Mount only sandbox directories into container.
+
+### Mode B: Hybrid host workers (Unity-capable)
+
+- Use host workers for Unity-specific operations.
+- Keep strict path allowlist + sandbox-rooted caches.
+- Prefer dedicated OS user account for agent processes.
+
+## Minimal hardening checklist
+
+1. Run agent daemons as non-admin user.
+2. Set `NEXO_AGENT_SANDBOX_PATHS` in daemon environment.
+3. Route all temp/cache dirs (`TMPDIR`, package caches) to `.nexo/sandbox/cache`.
+4. Keep network egress rules narrow for worker nodes where possible.
+5. Audit tool calls and denied writes.
+
+## Example daemon env
+
+```bash
+export NEXO_AGENT_SANDBOX_PATHS=".nexo/sandbox/projects/,.nexo/sandbox/tools/,.nexo/sandbox/cache/"
+export TMPDIR="$PWD/.nexo/sandbox/cache/tmp"
+export NUGET_PACKAGES="$PWD/.nexo/sandbox/cache/nuget"
+export npm_config_cache="$PWD/.nexo/sandbox/cache/npm"
+```
+
+Then run:
+
+```bash
+dotnet run --project src/Nexo.CLI -- background-agent daemon --duration 2h
+```
+

--- a/docs/AgentSandboxArchitecture.md
+++ b/docs/AgentSandboxArchitecture.md
@@ -1,7 +1,7 @@
 # Agent Sandbox Architecture (Host + Project-Scoped Tools)
 
 This guide describes how to run Nexo agents in a constrained sandbox while still
-allowing host-bound tools (for example Unity Editor) and dependency downloads.
+allowing host-bound tools and dependency downloads.
 
 ## Goals
 
@@ -11,15 +11,16 @@ allowing host-bound tools (for example Unity Editor) and dependency downloads.
 
 ## Policy enforcement in this repo
 
-`PathAllowlist` now supports configurable sandbox prefixes:
+`PathAllowlist` supports sandboxed writes in two ways:
 
-- Defaults: `src/`, `tests/`, `docs/`
-- Optional env var: `NEXO_AGENT_SANDBOX_PATHS`
+- Relative allowlisted prefixes (defaults): `src/`, `tests/`, `docs/`, `.nexo/`
+- Optional extra prefixes via env: `NEXO_PATH_ALLOWLIST_EXTRA`
+- Absolute paths only when inside sandbox root (`WorldSnapshot["SandboxRoot"]` or `NEXO_SANDBOX_ROOT`)
 
-When set, `NEXO_AGENT_SANDBOX_PATHS` extends allowed write prefixes (comma-separated):
+When set, `NEXO_PATH_ALLOWLIST_EXTRA` extends relative write prefixes (comma-separated):
 
 ```bash
-export NEXO_AGENT_SANDBOX_PATHS=".nexo/sandbox/projects/,.nexo/sandbox/tools/,.nexo/sandbox/cache/"
+export NEXO_PATH_ALLOWLIST_EXTRA=".nexo/host_apps/,.nexo/agents/workspaces/"
 ```
 
 The policy still blocks:
@@ -34,11 +35,17 @@ Create a per-project sandbox tree under repo root:
 
 ```text
 .nexo/
-  sandbox/
-    projects/      # agent-created project artifacts
-    tools/         # third-party tools/SDKs installed for this project
-    cache/         # npm/nuget/pip/unity package caches
-    logs/          # run logs/audit traces
+  agents/
+    workspaces/    # agent-created artifacts and generated work trees
+  tools/
+    bin/           # third-party tools/SDKs installed for this project
+    cache/         # npm/nuget/pip package caches
+  host_apps/
+    projects/      # host-app project data staged for agent workflows
+    cache/         # host-app package/import caches
+    runtimes/      # optional host-app runtime payloads
+  logs/
+  tmp/
 ```
 
 Bootstrap helper:
@@ -47,24 +54,15 @@ Bootstrap helper:
 bash scripts/sandbox/init-agent-sandbox.sh
 ```
 
-## Host-bound applications (Unity, etc.)
+## Host-bound applications (generic)
 
 Some tools cannot be containerized economically or by license.
 For these, use a split model:
 
 1. Keep editor/runtime host-installed by a human operator.
-2. Keep project-specific dependencies/caches under `.nexo/sandbox`.
+2. Keep project-specific dependencies/caches under `.nexo/`.
 3. Restrict agent-generated files to sandbox + approved code folders.
 4. Trigger host apps through wrapper scripts that accept only sandboxed paths.
-
-### Unity pattern
-
-- Unity Editor remains host-installed and user-licensed.
-- Agent output goes to:
-  - `.nexo/sandbox/projects/<project>/...`
-  - or directly to controlled Unity project subfolders under repo.
-- Unity package/download caches use `.nexo/sandbox/cache`.
-- Any script invoking Unity should validate paths before execution.
 
 ## Operating modes
 
@@ -73,27 +71,29 @@ For these, use a split model:
 - Use container execution for generic build/test tasks.
 - Mount only sandbox directories into container.
 
-### Mode B: Hybrid host workers (Unity-capable)
+### Mode B: Hybrid host workers (host-app capable)
 
-- Use host workers for Unity-specific operations.
+- Use host workers for tool/app operations that cannot be containerized by default.
 - Keep strict path allowlist + sandbox-rooted caches.
 - Prefer dedicated OS user account for agent processes.
 
 ## Minimal hardening checklist
 
 1. Run agent daemons as non-admin user.
-2. Set `NEXO_AGENT_SANDBOX_PATHS` in daemon environment.
-3. Route all temp/cache dirs (`TMPDIR`, package caches) to `.nexo/sandbox/cache`.
-4. Keep network egress rules narrow for worker nodes where possible.
-5. Audit tool calls and denied writes.
+2. Set `NEXO_SANDBOX_ROOT` in daemon environment.
+3. Optionally set `NEXO_PATH_ALLOWLIST_EXTRA` for additional project-local prefixes.
+4. Route all temp/cache dirs (`TMPDIR`, package caches) to `.nexo/tools/cache` and `.nexo/host_apps/cache`.
+5. Keep network egress rules narrow for worker nodes where possible.
+6. Audit tool calls and denied writes.
 
 ## Example daemon env
 
 ```bash
-export NEXO_AGENT_SANDBOX_PATHS=".nexo/sandbox/projects/,.nexo/sandbox/tools/,.nexo/sandbox/cache/"
-export TMPDIR="$PWD/.nexo/sandbox/cache/tmp"
-export NUGET_PACKAGES="$PWD/.nexo/sandbox/cache/nuget"
-export npm_config_cache="$PWD/.nexo/sandbox/cache/npm"
+export NEXO_SANDBOX_ROOT="$PWD/.nexo"
+export NEXO_PATH_ALLOWLIST_EXTRA=".nexo/host_apps/,.nexo/agents/workspaces/"
+export TMPDIR="$PWD/.nexo/tools/cache/tmp"
+export NUGET_PACKAGES="$PWD/.nexo/tools/cache/nuget"
+export npm_config_cache="$PWD/.nexo/tools/cache/npm"
 ```
 
 Then run:

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -40,6 +40,7 @@ Use this page as the navigation starting point for docs.
 - `docs/sdk.md` — SDK integration guidance.
 - `docs/runtime/specs/README.md` — runtime spec documents.
 - `docs/runtime/benchmarks/README.md` — runtime benchmark goals and notes.
+- `docs/SelfHostedGameServerPortal.md` — self-hosted game-dev server portal and directorial dailies workflow.
 
 ## Additional Material
 

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -42,6 +42,7 @@ Use this page as the navigation starting point for docs.
 - `docs/runtime/specs/README.md` — runtime spec documents.
 - `docs/runtime/benchmarks/README.md` — runtime benchmark goals and notes.
 - `docs/SelfHostedGameServerPortal.md` — self-hosted game-dev server portal and directorial dailies workflow.
+- `apps/runtime-studio/README.md` — application-layer planner + worker agent-set integration scaffold.
 
 ## Additional Material
 

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -33,6 +33,7 @@ Use this page as the navigation starting point for docs.
 
 - `docs/TrustAndInformationArchitecture.md` — sanitization, audit, access boundaries.
 - `docs/Configuration.md` — environment variables and configuration reference.
+- `docs/AgentSandboxArchitecture.md` — project-scoped sandbox model for agent file/tool execution and host-app integration (Unity-friendly).
 
 ## API / SDK / Runtime
 

--- a/docs/SelfHostedGameServerPortal.md
+++ b/docs/SelfHostedGameServerPortal.md
@@ -1,0 +1,95 @@
+# Self-Hosted Nexo Game Dev Server Portal
+
+This setup gives you a remote web portal for a **directorial workflow**:
+
+1. Provide direction (`goal`) for the next iteration.
+2. Nexo orchestrates generation/tasks.
+3. Validation can run automatically.
+4. Results are persisted as **dailies**.
+5. You review and continue from a prior daily ID.
+
+The portal is served by `Nexo.API` at `/` and uses:
+
+- `POST /api/director/run`
+- `GET /api/director/dailies`
+- `GET /api/director/dailies/{dailyId}`
+
+## 1) Start on your own hardware (Docker Compose)
+
+From repo root:
+
+```bash
+docker compose -f docker-compose.portal.yml up -d --build
+```
+
+Check service health:
+
+```bash
+curl http://localhost:8080/api/status
+```
+
+Open the portal:
+
+- Local: `http://localhost:8080`
+- Remote LAN: `http://<your-server-ip>:8080`
+
+## 2) Directorial iteration flow
+
+In the portal:
+
+1. Enter a **Goal / direction**.
+2. Optional: add **Notes**.
+3. Optional: provide `Continue from daily ID` for iterative continuation.
+4. Leave **Run validation** enabled for automatic test pass/fail data.
+5. Click **Run iteration**.
+
+Each run creates a JSON daily file in `NEXO_DAILIES_PATH` (`/data/dailies` in compose).
+
+## 3) Remote access and hardening
+
+For public Internet access, put a reverse proxy + TLS in front of port `8080` and restrict source IPs where possible.
+
+Suggested baseline:
+
+- Keep `8080` private on your LAN/VPN.
+- Publish only 443/TLS externally.
+- Require VPN or zero-trust access for director review sessions.
+- Back up the `nexo-dailies` Docker volume.
+
+## 4) API quick examples
+
+Create one daily:
+
+```bash
+curl -X POST http://localhost:8080/api/director/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "goal":"Build and test a new combat tuning pass with higher encounter readability",
+    "notes":"Prioritize minute-10 retention signals",
+    "runValidation":true
+  }'
+```
+
+List dailies:
+
+```bash
+curl http://localhost:8080/api/director/dailies
+```
+
+Continue from a prior daily:
+
+```bash
+curl -X POST http://localhost:8080/api/director/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "goal":"Tighten dodge timing and rebalance stamina economy",
+    "continueFromDailyId":"<daily-id>",
+    "runValidation":true
+  }'
+```
+
+## 5) Stop services
+
+```bash
+docker compose -f docker-compose.portal.yml down
+```

--- a/scripts/sandbox/init-agent-sandbox.sh
+++ b/scripts/sandbox/init-agent-sandbox.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(pwd)"
+SANDBOX_ROOT="${ROOT}/.nexo"
+PROFILE="default"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-root)
+      ROOT="${2:-}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="${2:-default}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--project-root <path>] [--profile <default|unity-host>] [--dry-run]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${ROOT}" ]]; then
+  echo "--project-root must not be empty" >&2
+  exit 2
+fi
+
+SANDBOX_ROOT="${ROOT}/.nexo"
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  mkdir -p "${SANDBOX_ROOT}/agents/workspaces"
+  mkdir -p "${SANDBOX_ROOT}/tools/bin"
+  mkdir -p "${SANDBOX_ROOT}/tools/cache"
+  mkdir -p "${SANDBOX_ROOT}/unity/projects"
+  mkdir -p "${SANDBOX_ROOT}/unity/cache"
+  mkdir -p "${SANDBOX_ROOT}/unity/editors"
+  mkdir -p "${SANDBOX_ROOT}/logs"
+  mkdir -p "${SANDBOX_ROOT}/tmp"
+fi
+
+echo "Initialized agent sandbox at: ${SANDBOX_ROOT}"
+echo "Profile: ${PROFILE}"
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  echo "Mode: dry-run (no directories created)"
+fi
+echo
+echo "Recommended environment exports:"
+echo "  export NEXO_SANDBOX_ROOT=\"${SANDBOX_ROOT}\""
+echo "  export NEXO_TOOL_ROOT=\"${SANDBOX_ROOT}/tools\""
+echo "  export NEXO_UNITY_PROJECT_ROOT=\"${SANDBOX_ROOT}/unity/projects\""
+echo "  export NEXO_UNITY_CACHE_ROOT=\"${SANDBOX_ROOT}/unity/cache\""
+echo
+echo "Optional cache/tool relocation (project-local):"
+echo "  export XDG_CACHE_HOME=\"${SANDBOX_ROOT}/tools/cache\""
+echo "  export NUGET_PACKAGES=\"${SANDBOX_ROOT}/tools/cache/nuget\""
+echo "  export NPM_CONFIG_CACHE=\"${SANDBOX_ROOT}/tools/cache/npm\""

--- a/scripts/sandbox/init-agent-sandbox.sh
+++ b/scripts/sandbox/init-agent-sandbox.sh
@@ -22,7 +22,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       echo "Unknown argument: $1" >&2
-      echo "Usage: $0 [--project-root <path>] [--profile <default|unity-host>] [--dry-run]" >&2
+      echo "Usage: $0 [--project-root <path>] [--profile <default|host-apps>] [--dry-run]" >&2
       exit 2
       ;;
   esac
@@ -39,9 +39,9 @@ if [[ "${DRY_RUN}" -eq 0 ]]; then
   mkdir -p "${SANDBOX_ROOT}/agents/workspaces"
   mkdir -p "${SANDBOX_ROOT}/tools/bin"
   mkdir -p "${SANDBOX_ROOT}/tools/cache"
-  mkdir -p "${SANDBOX_ROOT}/unity/projects"
-  mkdir -p "${SANDBOX_ROOT}/unity/cache"
-  mkdir -p "${SANDBOX_ROOT}/unity/editors"
+  mkdir -p "${SANDBOX_ROOT}/host_apps/projects"
+  mkdir -p "${SANDBOX_ROOT}/host_apps/cache"
+  mkdir -p "${SANDBOX_ROOT}/host_apps/runtimes"
   mkdir -p "${SANDBOX_ROOT}/logs"
   mkdir -p "${SANDBOX_ROOT}/tmp"
 fi
@@ -55,8 +55,8 @@ echo
 echo "Recommended environment exports:"
 echo "  export NEXO_SANDBOX_ROOT=\"${SANDBOX_ROOT}\""
 echo "  export NEXO_TOOL_ROOT=\"${SANDBOX_ROOT}/tools\""
-echo "  export NEXO_UNITY_PROJECT_ROOT=\"${SANDBOX_ROOT}/unity/projects\""
-echo "  export NEXO_UNITY_CACHE_ROOT=\"${SANDBOX_ROOT}/unity/cache\""
+echo "  export NEXO_HOST_APP_PROJECT_ROOT=\"${SANDBOX_ROOT}/host_apps/projects\""
+echo "  export NEXO_HOST_APP_CACHE_ROOT=\"${SANDBOX_ROOT}/host_apps/cache\""
 echo
 echo "Optional cache/tool relocation (project-local):"
 echo "  export XDG_CACHE_HOME=\"${SANDBOX_ROOT}/tools/cache\""

--- a/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -250,23 +250,49 @@ public static class NexoEndpoints
         }
 
         var prompt = BuildDirectorPrompt(request, previousDaily);
-        var orchestrationResult = await orchestrator.OrchestrateAsync(prompt, cancellationToken);
+        var success = false;
+        string? summary;
+        string? orchestrationError = null;
+        string? integratedOutputJson = null;
+
+        try
+        {
+            var orchestrationResult = await orchestrator.OrchestrateAsync(prompt, cancellationToken);
+            success = orchestrationResult.Success;
+            summary = orchestrationResult.IntegratedOutput != null
+                ? $"{orchestrationResult.IntegratedOutput.AgentOutputs.Count} agent(s) executed"
+                : "No integrated output generated";
+            integratedOutputJson = SerializeForDaily(orchestrationResult.IntegratedOutput?.IntegratedResults);
+        }
+        catch (Exception ex)
+        {
+            summary = "Orchestration failed before completion";
+            orchestrationError = ex.Message;
+        }
 
         ValidationResponse? validation = null;
         if (request.RunValidation)
         {
-            var validationResult = await mediator.Send(new RunValidationCommand(request.ValidationFilter), cancellationToken);
-            validation = new ValidationResponse(
-                validationResult.Passed,
-                validationResult.Message,
-                validationResult.TestsRun,
-                validationResult.TestsPassed,
-                validationResult.TestsFailed);
+            try
+            {
+                var validationResult = await mediator.Send(new RunValidationCommand(request.ValidationFilter), cancellationToken);
+                validation = new ValidationResponse(
+                    validationResult.Passed,
+                    validationResult.Message,
+                    validationResult.TestsRun,
+                    validationResult.TestsPassed,
+                    validationResult.TestsFailed);
+            }
+            catch (Exception ex)
+            {
+                validation = new ValidationResponse(
+                    false,
+                    $"Validation failed: {ex.Message}",
+                    0,
+                    0,
+                    0);
+            }
         }
-
-        var summary = orchestrationResult.IntegratedOutput != null
-            ? $"{orchestrationResult.IntegratedOutput.AgentOutputs.Count} agent(s) executed"
-            : "No integrated output generated";
 
         var dailyId = $"{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}";
         var entry = new DirectorDailyEntry(
@@ -275,10 +301,11 @@ public static class NexoEndpoints
             request.Goal.Trim(),
             request.Notes?.Trim(),
             request.ContinueFromDailyId,
-            orchestrationResult.Success,
+            success,
             summary,
-            SerializeForDaily(orchestrationResult.IntegratedOutput?.IntegratedResults),
-            validation);
+            integratedOutputJson,
+            validation,
+            orchestrationError);
 
         var dailyPath = Path.Combine(dailiesPath, $"{dailyId}.json");
         await File.WriteAllTextAsync(dailyPath, JsonSerializer.Serialize(entry, DailySerializerOptions), cancellationToken);
@@ -290,6 +317,7 @@ public static class NexoEndpoints
             entry.Summary,
             entry.IntegratedOutputJson,
             entry.Validation,
+            entry.OrchestrationError,
             entry.ContinueFromDailyId));
     }
 
@@ -472,6 +500,7 @@ public sealed record DirectorRunResponse(
     string? Summary,
     string? IntegratedOutputJson,
     ValidationResponse? Validation,
+    string? OrchestrationError,
     string? ContinuedFromDailyId);
 
 public sealed record DirectorDailySummary(
@@ -491,4 +520,5 @@ public sealed record DirectorDailyEntry(
     bool Success,
     string? Summary,
     string? IntegratedOutputJson,
-    ValidationResponse? Validation);
+    ValidationResponse? Validation,
+    string? OrchestrationError);

--- a/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -18,6 +18,11 @@ namespace Nexo.API.Endpoints;
 /// </summary>
 public static class NexoEndpoints
 {
+    private static readonly JsonSerializerOptions DailySerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
     public static IEndpointRouteBuilder MapNexoEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api").WithTags("Nexo");
@@ -66,6 +71,25 @@ public static class NexoEndpoints
             .WithName("GetCapabilities")
             .WithSummary("Get node capability manifest for brick routing")
             .Produces<NodeCapabilityManifestDto>(StatusCodes.Status200OK);
+
+        group.MapPost("/director/run", RunDirectorWorkflowAsync)
+            .WithName("RunDirectorWorkflow")
+            .WithSummary("Run one directorial iteration and persist as a daily")
+            .Produces<DirectorRunResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+        group.MapGet("/director/dailies", ListDailiesAsync)
+            .WithName("ListDirectorDailies")
+            .WithSummary("List persisted directorial dailies")
+            .Produces<List<DirectorDailySummary>>(StatusCodes.Status200OK);
+
+        group.MapGet("/director/dailies/{dailyId}", GetDailyAsync)
+            .WithName("GetDirectorDaily")
+            .WithSummary("Get one persisted directorial daily")
+            .Produces<DirectorDailyEntry>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         return app;
     }
@@ -199,6 +223,185 @@ public static class NexoEndpoints
         return Results.Ok(ToDto(manifest));
     }
 
+    private static async Task<IResult> RunDirectorWorkflowAsync(
+        [FromBody] DirectorRunRequest request,
+        [FromServices] Orchestrator orchestrator,
+        [FromServices] IMediator mediator,
+        [FromServices] IConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request?.Goal))
+            return Results.BadRequest(new ProblemDetails { Title = "Goal is required" });
+
+        var dailiesPath = ResolveDailiesPath(configuration);
+        Directory.CreateDirectory(dailiesPath);
+
+        DirectorDailyEntry? previousDaily = null;
+        if (!string.IsNullOrWhiteSpace(request.ContinueFromDailyId))
+        {
+            if (!IsValidDailyId(request.ContinueFromDailyId))
+                return Results.BadRequest(new ProblemDetails { Title = "ContinueFromDailyId is invalid" });
+
+            var previousPath = Path.Combine(dailiesPath, $"{request.ContinueFromDailyId}.json");
+            if (File.Exists(previousPath))
+            {
+                previousDaily = await TryReadDailyAsync(previousPath, cancellationToken);
+            }
+        }
+
+        var prompt = BuildDirectorPrompt(request, previousDaily);
+        var orchestrationResult = await orchestrator.OrchestrateAsync(prompt, cancellationToken);
+
+        ValidationResponse? validation = null;
+        if (request.RunValidation)
+        {
+            var validationResult = await mediator.Send(new RunValidationCommand(request.ValidationFilter), cancellationToken);
+            validation = new ValidationResponse(
+                validationResult.Passed,
+                validationResult.Message,
+                validationResult.TestsRun,
+                validationResult.TestsPassed,
+                validationResult.TestsFailed);
+        }
+
+        var summary = orchestrationResult.IntegratedOutput != null
+            ? $"{orchestrationResult.IntegratedOutput.AgentOutputs.Count} agent(s) executed"
+            : "No integrated output generated";
+
+        var dailyId = $"{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}";
+        var entry = new DirectorDailyEntry(
+            dailyId,
+            DateTimeOffset.UtcNow,
+            request.Goal.Trim(),
+            request.Notes?.Trim(),
+            request.ContinueFromDailyId,
+            orchestrationResult.Success,
+            summary,
+            SerializeForDaily(orchestrationResult.IntegratedOutput?.IntegratedResults),
+            validation);
+
+        var dailyPath = Path.Combine(dailiesPath, $"{dailyId}.json");
+        await File.WriteAllTextAsync(dailyPath, JsonSerializer.Serialize(entry, DailySerializerOptions), cancellationToken);
+
+        return Results.Ok(new DirectorRunResponse(
+            entry.Success,
+            entry.DailyId,
+            dailyPath,
+            entry.Summary,
+            entry.IntegratedOutputJson,
+            entry.Validation,
+            entry.ContinueFromDailyId));
+    }
+
+    private static async Task<IResult> ListDailiesAsync(
+        [FromServices] IConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        var dailiesPath = ResolveDailiesPath(configuration);
+        if (!Directory.Exists(dailiesPath))
+            return Results.Ok(Array.Empty<DirectorDailySummary>());
+
+        var summaries = new List<DirectorDailySummary>();
+        foreach (var file in Directory.EnumerateFiles(dailiesPath, "*.json"))
+        {
+            var entry = await TryReadDailyAsync(file, cancellationToken);
+            if (entry is null)
+                continue;
+
+            summaries.Add(new DirectorDailySummary(
+                entry.DailyId,
+                entry.CreatedAtUtc,
+                entry.Goal,
+                entry.Success,
+                entry.Summary,
+                entry.ContinueFromDailyId));
+        }
+
+        return Results.Ok(summaries.OrderByDescending(x => x.CreatedAtUtc));
+    }
+
+    private static async Task<IResult> GetDailyAsync(
+        string dailyId,
+        [FromServices] IConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        if (!IsValidDailyId(dailyId))
+            return Results.BadRequest(new ProblemDetails { Title = "dailyId is invalid" });
+
+        var dailiesPath = ResolveDailiesPath(configuration);
+        var dailyPath = Path.Combine(dailiesPath, $"{dailyId}.json");
+        if (!File.Exists(dailyPath))
+            return Results.NotFound(new ProblemDetails { Title = "dailyId not found" });
+
+        var entry = await TryReadDailyAsync(dailyPath, cancellationToken);
+        if (entry is null)
+            return Results.NotFound(new ProblemDetails { Title = "daily entry is unreadable" });
+
+        return Results.Ok(entry);
+    }
+
+    private static string ResolveDailiesPath(IConfiguration configuration)
+    {
+        var configuredPath = configuration["NEXO_DAILIES_PATH"];
+        if (string.IsNullOrWhiteSpace(configuredPath))
+            configuredPath = configuration["Nexo:DailiesPath"];
+
+        configuredPath ??= Path.Combine(AppContext.BaseDirectory, "dailies");
+        return Path.GetFullPath(configuredPath);
+    }
+
+    private static bool IsValidDailyId(string dailyId)
+    {
+        if (string.IsNullOrWhiteSpace(dailyId))
+            return false;
+
+        if (dailyId.Contains("..", StringComparison.Ordinal))
+            return false;
+
+        return dailyId.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+    }
+
+    private static async Task<DirectorDailyEntry?> TryReadDailyAsync(string path, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var stream = File.OpenRead(path);
+            return await JsonSerializer.DeserializeAsync<DirectorDailyEntry>(stream, DailySerializerOptions, cancellationToken);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string BuildDirectorPrompt(DirectorRunRequest request, DirectorDailyEntry? previousDaily)
+    {
+        if (previousDaily is null)
+            return request.Goal.Trim();
+
+        var previousSummary = previousDaily.Summary ?? "No prior summary";
+        return
+            $"Continue from daily {previousDaily.DailyId}. " +
+            $"Previous goal: {previousDaily.Goal}. " +
+            $"Previous summary: {previousSummary}. " +
+            $"Director notes for this iteration: {request.Goal.Trim()}";
+    }
+
+    private static string? SerializeForDaily(object? payload)
+    {
+        if (payload is null)
+            return null;
+
+        try
+        {
+            return JsonSerializer.Serialize(payload, DailySerializerOptions);
+        }
+        catch
+        {
+            return payload.ToString();
+        }
+    }
+
     private static NodeCapabilityManifestDto ToDto(NodeCapabilityManifest manifest)
     {
         return new NodeCapabilityManifestDto
@@ -254,3 +457,38 @@ public sealed record ExecutionBuildResponse(bool Success, string? ErrorMessage, 
 
 public sealed record ExecutionRunRequest(string ImageTag, string[] Command, Dictionary<string, string>? EnvironmentVariables = null, Dictionary<string, string>? VolumeMounts = null, string? WorkingDirectory = null);
 public sealed record ExecutionRunResponse(bool Success, int ExitCode, string StandardOutput, string StandardError, string? ContainerId, double DurationMs);
+
+public sealed record DirectorRunRequest(
+    string Goal,
+    string? Notes = null,
+    bool RunValidation = true,
+    string? ValidationFilter = null,
+    string? ContinueFromDailyId = null);
+
+public sealed record DirectorRunResponse(
+    bool Success,
+    string DailyId,
+    string DailyPath,
+    string? Summary,
+    string? IntegratedOutputJson,
+    ValidationResponse? Validation,
+    string? ContinuedFromDailyId);
+
+public sealed record DirectorDailySummary(
+    string DailyId,
+    DateTimeOffset CreatedAtUtc,
+    string Goal,
+    bool Success,
+    string? Summary,
+    string? ContinueFromDailyId);
+
+public sealed record DirectorDailyEntry(
+    string DailyId,
+    DateTimeOffset CreatedAtUtc,
+    string Goal,
+    string? Notes,
+    string? ContinueFromDailyId,
+    bool Success,
+    string? Summary,
+    string? IntegratedOutputJson,
+    ValidationResponse? Validation);

--- a/src/Nexo.API/Program.cs
+++ b/src/Nexo.API/Program.cs
@@ -18,6 +18,10 @@ builder.Services.AddNexo(options =>
 
 var app = builder.Build();
 
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
 app.MapNexoEndpoints();
+app.MapFallbackToFile("index.html");
 
 app.Run();

--- a/src/Nexo.API/wwwroot/index.html
+++ b/src/Nexo.API/wwwroot/index.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Nexo Director Portal</title>
+  <style>
+    :root {
+      --bg: #0b1220;
+      --panel: #121a2b;
+      --line: #334155;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --accent: #38bdf8;
+      --ok: #22c55e;
+      --warn: #f59e0b;
+      --bad: #ef4444;
+    }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    .wrap {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    h1, h2 {
+      margin: 0 0 12px 0;
+    }
+    .sub {
+      color: var(--muted);
+      margin-bottom: 14px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+    label {
+      display: block;
+      margin-top: 10px;
+      margin-bottom: 6px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    input, textarea {
+      width: 100%;
+      box-sizing: border-box;
+      border: 1px solid var(--line);
+      background: #0f172a;
+      color: var(--text);
+      border-radius: 8px;
+      padding: 10px;
+      font-size: 14px;
+    }
+    textarea {
+      min-height: 130px;
+      resize: vertical;
+    }
+    .row {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      margin-top: 10px;
+      flex-wrap: wrap;
+    }
+    button {
+      border: 1px solid #0284c7;
+      background: var(--accent);
+      color: #082f49;
+      border-radius: 8px;
+      padding: 10px 14px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    button.secondary {
+      border-color: var(--line);
+      background: transparent;
+      color: var(--text);
+    }
+    .status {
+      margin-top: 10px;
+      padding: 10px;
+      border-radius: 8px;
+      border: 1px solid var(--line);
+      white-space: pre-wrap;
+      background: #0f172a;
+      font-size: 13px;
+    }
+    .daily-list button {
+      width: 100%;
+      text-align: left;
+      margin-top: 8px;
+      background: #0f172a;
+      color: var(--text);
+      border-color: var(--line);
+      font-weight: 500;
+    }
+    .badge {
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      margin-left: 8px;
+      font-weight: 700;
+    }
+    .ok { background: color-mix(in srgb, var(--ok) 20%, transparent); color: #86efac; }
+    .bad { background: color-mix(in srgb, var(--bad) 20%, transparent); color: #fca5a5; }
+    .muted { color: var(--muted); font-size: 12px; }
+    .json {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #0f172a;
+      padding: 10px;
+      overflow: auto;
+      max-height: 500px;
+      white-space: pre-wrap;
+      font-size: 12px;
+    }
+    @media (max-width: 900px) {
+      .grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Nexo Director Portal</h1>
+    <div class="sub">Iterative game-dev workflow: direct, generate, test, and review dailies from your browser.</div>
+
+    <div class="grid">
+      <section class="panel">
+        <h2>Run directorial iteration</h2>
+        <label for="goal">Goal / direction</label>
+        <textarea id="goal" placeholder="Add a stamina-based dodge and tune combat pacing for minute-5 retention."></textarea>
+
+        <label for="notes">Notes (optional)</label>
+        <textarea id="notes" placeholder="Keep UI minimal. Prioritize responsive feel over visual effects."></textarea>
+
+        <label for="continueFromDailyId">Continue from daily ID (optional)</label>
+        <input id="continueFromDailyId" placeholder="20260404010101999-..." />
+
+        <div class="row">
+          <input id="runValidation" type="checkbox" checked style="width:auto;" />
+          <label for="runValidation" style="margin:0;">Run validation after orchestration</label>
+        </div>
+
+        <label for="validationFilter">Validation filter (optional)</label>
+        <input id="validationFilter" placeholder="FullyQualifiedName~Playtest" />
+
+        <div class="row">
+          <button id="runBtn">Run iteration</button>
+          <button id="refreshBtn" class="secondary">Refresh dailies</button>
+        </div>
+
+        <div id="status" class="status">Idle.</div>
+      </section>
+
+      <section class="panel">
+        <h2>Dailies</h2>
+        <div class="muted">Newest first. Click an entry to inspect details.</div>
+        <div id="dailies" class="daily-list"></div>
+      </section>
+    </div>
+
+    <section class="panel">
+      <h2>Selected daily</h2>
+      <div id="selectedDaily" class="json">No daily selected.</div>
+    </section>
+  </div>
+
+  <script>
+    const runBtn = document.getElementById("runBtn");
+    const refreshBtn = document.getElementById("refreshBtn");
+    const statusEl = document.getElementById("status");
+    const dailiesEl = document.getElementById("dailies");
+    const selectedDailyEl = document.getElementById("selectedDaily");
+
+    function setStatus(text) {
+      statusEl.textContent = text;
+    }
+
+    function pretty(value) {
+      return JSON.stringify(value, null, 2);
+    }
+
+    async function fetchJson(url, options) {
+      const res = await fetch(url, options);
+      const text = await res.text();
+      let body = text;
+      try { body = text ? JSON.parse(text) : null; } catch {}
+      if (!res.ok) {
+        throw new Error((body && body.title) ? body.title : `HTTP ${res.status}`);
+      }
+      return body;
+    }
+
+    async function loadDailies() {
+      const items = await fetchJson("/api/director/dailies");
+      dailiesEl.innerHTML = "";
+
+      if (!items || !items.length) {
+        dailiesEl.innerHTML = '<div class="muted" style="margin-top:8px;">No dailies yet.</div>';
+        return;
+      }
+
+      for (const item of items) {
+        const btn = document.createElement("button");
+        const created = new Date(item.createdAtUtc).toLocaleString();
+        btn.innerHTML = `
+          <div>
+            <strong>${item.dailyId}</strong>
+            <span class="badge ${item.success ? "ok" : "bad"}">${item.success ? "PASS" : "FAIL"}</span>
+          </div>
+          <div class="muted">${created}</div>
+          <div style="margin-top:6px;">${item.goal}</div>
+        `;
+        btn.onclick = () => loadDaily(item.dailyId);
+        dailiesEl.appendChild(btn);
+      }
+    }
+
+    async function loadDaily(dailyId) {
+      setStatus(`Loading daily ${dailyId}...`);
+      const daily = await fetchJson(`/api/director/dailies/${encodeURIComponent(dailyId)}`);
+      selectedDailyEl.textContent = pretty(daily);
+      setStatus(`Loaded daily ${dailyId}.`);
+    }
+
+    async function runIteration() {
+      const payload = {
+        goal: document.getElementById("goal").value.trim(),
+        notes: document.getElementById("notes").value.trim() || null,
+        continueFromDailyId: document.getElementById("continueFromDailyId").value.trim() || null,
+        runValidation: document.getElementById("runValidation").checked,
+        validationFilter: document.getElementById("validationFilter").value.trim() || null
+      };
+
+      if (!payload.goal) {
+        setStatus("Goal is required.");
+        return;
+      }
+
+      setStatus("Running directorial iteration...");
+      runBtn.disabled = true;
+
+      try {
+        const result = await fetchJson("/api/director/run", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload)
+        });
+
+        setStatus(
+          `Completed.\nDaily ID: ${result.dailyId}\n` +
+          `Success: ${result.success}\nSummary: ${result.summary ?? "n/a"}`
+        );
+
+        await loadDailies();
+        if (result.dailyId) {
+          await loadDaily(result.dailyId);
+        }
+      } catch (err) {
+        setStatus(`Run failed: ${err.message}`);
+      } finally {
+        runBtn.disabled = false;
+      }
+    }
+
+    runBtn.addEventListener("click", runIteration);
+    refreshBtn.addEventListener("click", async () => {
+      setStatus("Refreshing dailies...");
+      try {
+        await loadDailies();
+        setStatus("Dailies refreshed.");
+      } catch (err) {
+        setStatus(`Refresh failed: ${err.message}`);
+      }
+    });
+
+    loadDailies().catch(err => setStatus(`Failed to load dailies: ${err.message}`));
+  </script>
+</body>
+</html>

--- a/src/Nexo.Policies.Dev/PathAllowlist.cs
+++ b/src/Nexo.Policies.Dev/PathAllowlist.cs
@@ -16,7 +16,36 @@ namespace Nexo.Policies.Dev;
 /// </summary>
 public sealed class PathAllowlist : IPolicy
 {
-    private static readonly string[] Allowed = { "src/", "tests/", "docs/" };
+    private static readonly string[] DefaultAllowed =
+    {
+        "src/",
+        "tests/",
+        "docs/",
+        ".nexo/"
+    };
+
+    private readonly string[] _allowedPrefixes;
+
+    public PathAllowlist(IEnumerable<string>? extraAllowedPrefixes = null)
+    {
+        var merged = new List<string>(DefaultAllowed);
+
+        if (extraAllowedPrefixes is not null)
+            merged.AddRange(extraAllowedPrefixes);
+
+        var fromEnv = Environment.GetEnvironmentVariable("NEXO_PATH_ALLOWLIST_EXTRA");
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+        {
+            foreach (var entry in fromEnv.Split(',', ';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                merged.Add(entry);
+        }
+
+        _allowedPrefixes = merged
+            .Select(NormalizePrefix)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray()!;
+    }
 
     public bool Approve(ToolCall call, WorldSnapshot s, out string reason)
     {
@@ -35,15 +64,38 @@ public sealed class PathAllowlist : IPolicy
                 }
                 if (Path.IsPathRooted(raw) || raw.StartsWith("/", StringComparison.Ordinal))
                 {
-                    reason = $"Path not allowed: absolute path not permitted: {raw}";
-                    return false;
+                    var sandboxRoot = ResolveSandboxRoot(s);
+                    if (string.IsNullOrWhiteSpace(sandboxRoot))
+                    {
+                        reason = $"Path not allowed: absolute path not permitted: {raw}";
+                        return false;
+                    }
+
+                    string fullPath;
+                    try
+                    {
+                        fullPath = Path.GetFullPath(raw);
+                    }
+                    catch
+                    {
+                        reason = $"Path not allowed: invalid absolute path: {raw}";
+                        return false;
+                    }
+
+                    if (!IsPathWithinRoot(fullPath, sandboxRoot))
+                    {
+                        reason = $"Path not allowed: outside SandboxRoot: {fullPath}";
+                        return false;
+                    }
+
+                    return true;
                 }
                 if (rel.Contains("..", StringComparison.Ordinal))
                 {
                     reason = $"Path not allowed: path traversal not permitted: {rel}";
                     return false;
                 }
-                if (!Allowed.Any(a => rel.StartsWith(a, StringComparison.OrdinalIgnoreCase)))
+                if (!_allowedPrefixes.Any(a => rel.StartsWith(a, StringComparison.OrdinalIgnoreCase)))
                 {
                     reason = $"Path not allowed: {rel}";
                     return false;
@@ -51,5 +103,58 @@ public sealed class PathAllowlist : IPolicy
             }
         }
         return true;
+    }
+
+    private static string? NormalizePrefix(string? prefix)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+            return null;
+
+        var normalized = prefix.Replace('\\', '/').Trim();
+        normalized = normalized.TrimStart('/');
+        if (string.IsNullOrWhiteSpace(normalized))
+            return null;
+
+        if (normalized.Contains("..", StringComparison.Ordinal))
+            return null;
+
+        if (!normalized.EndsWith("/", StringComparison.Ordinal))
+            normalized += "/";
+
+        return normalized;
+    }
+
+    private static string? ResolveSandboxRoot(WorldSnapshot snapshot)
+    {
+        string? root = null;
+        if (snapshot.Data.TryGetValue("SandboxRoot", out var rootObj) && rootObj is string fromSnapshot)
+            root = fromSnapshot;
+
+        if (string.IsNullOrWhiteSpace(root))
+            root = Environment.GetEnvironmentVariable("NEXO_SANDBOX_ROOT");
+
+        if (string.IsNullOrWhiteSpace(root))
+            return null;
+
+        try
+        {
+            return Path.GetFullPath(root);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsPathWithinRoot(string candidate, string root)
+    {
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedCandidate = candidate;
+
+        if (normalizedCandidate.Equals(normalizedRoot, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var prefix = normalizedRoot + Path.DirectorySeparatorChar;
+        return normalizedCandidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/Policies/PathAllowlistTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Policies/PathAllowlistTests.cs
@@ -157,6 +157,57 @@ public sealed class PathAllowlistTests
     }
 
     [Fact]
+    public void Approve_RepoFsWrite_WithSandboxRootConfigured_AllowsPathUnderSandboxRoot()
+    {
+        var sandboxRoot = Path.Combine(Path.GetTempPath(), "nexo-sandbox");
+        Environment.SetEnvironmentVariable("NEXO_SANDBOX_ROOT", sandboxRoot);
+        var fullPath = Path.GetFullPath(Path.Combine(sandboxRoot, "workspaces/project-a/generated/file.cs"));
+        var json = JsonSerializer.SerializeToElement(new { path = fullPath });
+        var call = new ToolCall("repo.fs.write", json);
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?> { ["SandboxRoot"] = sandboxRoot });
+
+        var result = _policy.Approve(call, snapshot, out var reason);
+
+        result.Should().BeTrue();
+        reason.Should().Be("OK");
+        Environment.SetEnvironmentVariable("NEXO_SANDBOX_ROOT", null);
+    }
+
+    [Fact]
+    public void Approve_RepoFsWrite_WithSandboxRootConfigured_RejectsEscapePath()
+    {
+        var sandboxRoot = Path.Combine(Path.GetTempPath(), "nexo-sandbox");
+        Environment.SetEnvironmentVariable("NEXO_SANDBOX_ROOT", sandboxRoot);
+        var escaped = Path.GetFullPath(Path.Combine(sandboxRoot, "../outside/file.cs"));
+        var json = JsonSerializer.SerializeToElement(new { path = escaped });
+        var call = new ToolCall("repo.fs.write", json);
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?> { ["SandboxRoot"] = sandboxRoot });
+
+        var result = _policy.Approve(call, snapshot, out var reason);
+
+        result.Should().BeFalse();
+        reason.Should().Contain("outside SandboxRoot");
+        Environment.SetEnvironmentVariable("NEXO_SANDBOX_ROOT", null);
+    }
+
+    [Fact]
+    public void Approve_RepoFsWrite_WithSandboxRootConfigured_RejectsAbsolutePathOutsideSandboxRoot()
+    {
+        var sandboxRoot = Path.Combine(Path.GetTempPath(), "nexo-sandbox");
+        Environment.SetEnvironmentVariable("NEXO_SANDBOX_ROOT", sandboxRoot);
+        var outsidePath = Path.Combine(Path.GetTempPath(), "elsewhere", "file.cs");
+        var json = JsonSerializer.SerializeToElement(new { path = outsidePath });
+        var call = new ToolCall("repo.fs.write", json);
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?> { ["SandboxRoot"] = sandboxRoot });
+
+        var result = _policy.Approve(call, snapshot, out var reason);
+
+        result.Should().BeFalse();
+        reason.Should().Contain("outside SandboxRoot");
+        Environment.SetEnvironmentVariable("NEXO_SANDBOX_ROOT", null);
+    }
+
+    [Fact]
     public void Approve_RepoFsWrite_WithEmptyPath_ReturnsFalse()
     {
         var call = CreateToolCall("repo.fs.write", "");

--- a/src/Nexo.Tests.Infrastructure/Tests/Safety/PathAllowlistPropertyTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Safety/PathAllowlistPropertyTests.cs
@@ -65,17 +65,38 @@ public sealed class PathAllowlistPropertyTests
     [Fact]
     public void PathAllowlist_AllowedPrefixes_AreConsistentlyAllowed()
     {
+        var sandboxRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "nexo-policy-prop-sandbox"));
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?>
+        {
+            ["SandboxRoot"] = sandboxRoot
+        });
+
         // Suffix must not contain ".." (path traversal) which would cause rejection
-        Gen.OneOf(Gen.Const("src/"), Gen.Const("tests/"), Gen.Const("docs/"))
+        Gen.OneOf(Gen.Const("src/"), Gen.Const("tests/"), Gen.Const("docs/"), Gen.Const(".nexo/"))
             .SelectMany(prefix => Gen.String[1, 50]
                 .Where(s => !s.Contains("..", StringComparison.Ordinal))
                 .Select(suffix => prefix + suffix))
             .Sample(path =>
             {
                 var call = CreateWriteCall(path);
-                var result = _allowlist.Approve(call, EmptySnapshot, out var reason);
+                var result = _allowlist.Approve(call, snapshot, out var reason);
 
                 result.Should().BeTrue($"path under allowed prefix without traversal must be allowed: {path}");
+                reason.Should().Be("OK");
+            });
+
+        // Files under sandbox root should also be accepted.
+        Gen.String[1, 50]
+            .Where(s => !s.Contains("..", StringComparison.Ordinal))
+            .Where(s => s.IndexOfAny(Path.GetInvalidFileNameChars()) < 0)
+            .Sample(suffix =>
+            {
+                var relative = $"tools-cache/{suffix}.txt";
+                var full = Path.GetFullPath(Path.Combine(sandboxRoot, relative));
+                var call = CreateWriteCall(full);
+                var result = _allowlist.Approve(call, snapshot, out var reason);
+
+                result.Should().BeTrue($"sandbox path should be allowed: {full}");
                 reason.Should().Be("OK");
             });
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add directorial workflow endpoints to `Nexo.API` for running iterations and persisting dailies
- add built-in browser portal (`/`) for creating iterations, browsing dailies, and inspecting daily JSON
- add `.docker/Dockerfile.api` and `docker-compose.portal.yml` for self-host deployment on personal hardware
- add `docs/SelfHostedGameServerPortal.md` and index/readme links
- make `/api/director/run` resilient: orchestration failures now return a persisted failed daily instead of HTTP 500
- add project-scoped sandbox architecture for agent operations and host-bound dependency workflows
- add `scripts/sandbox/init-agent-sandbox.sh` to create `.nexo` sandbox roots for agents/tools/caches/host-app data
- extend `PathAllowlist` to support absolute-path writes only when they stay inside `SandboxRoot` / `NEXO_SANDBOX_ROOT`
- decouple sandbox setup/docs from Unity-specific assumptions and keep host-app model generic-first
- add `apps/runtime-studio` application-layer scaffold with local-first planner+worker agent set and bootstrap/run scripts

## Walkthrough artifacts
[nexo_director_portal_iterate_and_review_dailies.mp4](https://cursor.com/agents/bc-107cce3a-bab7-46b6-82bd-42906cd899bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnexo_director_portal_iterate_and_review_dailies.mp4)
[Portal run result](https://cursor.com/agents/bc-107cce3a-bab7-46b6-82bd-42906cd899bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdirector_portal_run_result.webp)
[Portal selected daily details](https://cursor.com/agents/bc-107cce3a-bab7-46b6-82bd-42906cd899bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdirector_portal_daily_details.webp)
[Portal initial state](https://cursor.com/agents/bc-107cce3a-bab7-46b6-82bd-42906cd899bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdirector_portal_initial_state.webp)

## Validation done
- built `Nexo.API` successfully
- verified directorial portal root and API endpoints
- manually verified portal run/dailies flow end-to-end
- sandbox policy tests (`PathAllowlistTests`, `PathAllowlistPropertyTests`) pass on `net9.0`
- sandbox init script validated for both `--dry-run` and normal run with `--profile host-apps`
- runtime-studio scripts validated (`bootstrap_runtime_studio.sh`, `run_agent_set_local.sh`)
- runtime-studio agent set config validated with daemon mode (`background-agent daemon --config apps/runtime-studio/config/agent_set.local.json --duration ... --disable-observation --format-json`)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-107cce3a-bab7-46b6-82bd-42906cd899bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-107cce3a-bab7-46b6-82bd-42906cd899bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

