### PR TITLE
Harden API surface defaults and security advisory tests

### DIFF
--- a/docker-compose.agent-server.yml
+++ b/docker-compose.agent-server.yml
@@ -12,7 +12,7 @@ services:
   ollama:
     image: ${NEXO_OLLAMA_IMAGE:-ollama/ollama:latest}
     ports:
-      - "${NEXO_OLLAMA_HOST_PORT:-11434}:11434"
+      - "127.0.0.1:${NEXO_OLLAMA_HOST_PORT:-11434}:11434"
     volumes:
       - ollama-models:/root/.ollama
     restart: unless-stopped
@@ -34,7 +34,7 @@ services:
       Nexo__Barriers__RequireExplicitBarrier: ${Nexo__Barriers__RequireExplicitBarrier:-false}
       NEXO_OBSERVATION_DEGRADED_MODE: ${NEXO_OBSERVATION_DEGRADED_MODE:-1}
     ports:
-      - "${NEXO_AGENT_SERVER_HTTP_PORT:-8080}:8080"
+      - "127.0.0.1:${NEXO_AGENT_SERVER_HTTP_PORT:-8080}:8080"
     volumes:
       # Named volume; keep mount path aligned with NEXO_DAILIES_PATH (default /data/dailies).
       - nexo-dailies:/data/dailies

--- a/docker-compose.portal.yml
+++ b/docker-compose.portal.yml
@@ -2,7 +2,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     volumes:
       - ollama-models:/root/.ollama
     restart: unless-stopped
@@ -23,7 +23,7 @@ services:
       # Nexo__Security__ShowAdvisoryInPortal: "true"
       # Nexo__Security__CustomAdvisory: "Restrict with Tailscale ACLs; Ollama not on funnel."
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - nexo-dailies:/data/dailies
     restart: unless-stopped

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -24,6 +24,10 @@ Advisory only — does not enforce firewalls or Tailscale ACLs. See **`docs/Tail
 | `Nexo__Security__ExposureProfile` | `Localhost`, `Lan`, `Tailnet`, or `Public` (case-insensitive) | `Localhost` in `appsettings.json` |
 | `Nexo__Security__CustomAdvisory` | Optional extra line shown in the Director portal advisory | unset |
 | `Nexo__Security__ShowAdvisoryInPortal` | `true` / `false` — show advisory banner in portal | `true` |
+| `Nexo__Security__RequireApiKeyForMutatingEndpoints` | `true` / `false` — enforce API key checks for POST/PUT/PATCH/DELETE under `/api/*` | `false` |
+| `Nexo__Security__ApiKey` | Shared secret required for protected mutating requests | unset (disabled) |
+| `Nexo__Security__ApiKeyHeaderName` | Header used for key checks | `X-Nexo-Api-Key` |
+| `Nexo__Security__ExcludedApiKeyPaths` | Comma-separated API path prefixes exempted from key checks | none |
 
 ## Pipelines (`NEXO_PIPELINE_*`)
 

--- a/docs/config/security-exposure.env.example
+++ b/docs/config/security-exposure.env.example
@@ -4,6 +4,15 @@
 # ExposureProfile: Localhost | Lan | Tailnet | Public (case-insensitive)
 Nexo__Security__ExposureProfile=Tailnet
 
+# Optional built-in API key auth for mutating endpoints:
+# - enforced on POST/PUT/PATCH/DELETE under /api/*
+# - advisory/status/capabilities GET routes remain open
+# - set true to enforce and provide key via X-Nexo-Api-Key header
+# Nexo__Security__RequireApiKeyForMutatingEndpoints=true
+# Nexo__Security__ApiKey=replace-with-strong-secret
+# Nexo__Security__ApiKeyHeaderName=X-Nexo-Api-Key
+# Nexo__Security__ExcludedApiKeyPaths=/api/director/run,/api/orchestrate
+
 # Optional extra line in the Director portal advisory banner
 # Nexo__Security__CustomAdvisory=Use tag:nexo; no shared accounts.
 

--- a/src/Nexo.API/Program.cs
+++ b/src/Nexo.API/Program.cs
@@ -67,10 +67,17 @@ var app = builder.Build();
             log.LogInformation("ExposureProfile is {Profile}: review docs for firewall / ACL guidance.", prof);
         }
     }
+
+    if (sec.RequireApiKeyForMutatingEndpoints && string.IsNullOrWhiteSpace(sec.ApiKey))
+    {
+        log.LogWarning(
+            "Nexo API key auth is required for mutating endpoints, but no API key is configured. Mutating endpoints are effectively unauthenticated.");
+    }
 }
 
 app.UseDefaultFiles();
 app.UseStaticFiles();
+app.UseNexoApiKeyAuth();
 
 app.MapNexoEndpoints();
 app.MapFallbackToFile("index.html");

--- a/src/Nexo.API/Security/NexoApiKeyAuthMiddleware.cs
+++ b/src/Nexo.API/Security/NexoApiKeyAuthMiddleware.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+
+namespace Nexo.API.Security;
+
+/// <summary>
+/// Optional API key middleware for mutating Nexo API routes.
+/// When enabled, requests to configured paths must include a matching key.
+/// </summary>
+public sealed class NexoApiKeyAuthMiddleware
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly RequestDelegate _next;
+    private readonly NexoSecurityOptions _options;
+
+    public NexoApiKeyAuthMiddleware(RequestDelegate next, IOptions<NexoSecurityOptions> optionsAccessor)
+    {
+        _next = next;
+        _options = optionsAccessor.Value;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!ShouldProtect(context.Request))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
+        {
+            await _next(context);
+            return;
+        }
+
+        var configured = _options.ApiKey.Trim();
+        var provided = context.Request.Headers[_options.ApiKeyHeaderName].ToString().Trim();
+        if (!string.Equals(configured, provided, StringComparison.Ordinal))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Response.ContentType = "application/json";
+            var payload = JsonSerializer.Serialize(new
+            {
+                title = "Unauthorized",
+                detail = $"Missing or invalid API key header '{_options.ApiKeyHeaderName}'."
+            }, JsonOptions);
+            await context.Response.WriteAsync(payload);
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private bool ShouldProtect(HttpRequest request)
+    {
+        if (!_options.RequireApiKeyForMutatingEndpoints)
+            return false;
+
+        var method = request.Method;
+        if (!HttpMethods.IsPost(method) &&
+            !HttpMethods.IsPut(method) &&
+            !HttpMethods.IsPatch(method) &&
+            !HttpMethods.IsDelete(method))
+        {
+            return false;
+        }
+
+        return request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase)
+               && !_options.ExcludedApiKeyPaths.Any(prefix =>
+                   request.Path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase));
+    }
+}
+
+public static class NexoApiKeyAuthMiddlewareExtensions
+{
+    public static IApplicationBuilder UseNexoApiKeyAuth(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<NexoApiKeyAuthMiddleware>();
+    }
+}

--- a/src/Nexo.API/Security/NexoSecurityOptions.cs
+++ b/src/Nexo.API/Security/NexoSecurityOptions.cs
@@ -18,6 +18,27 @@ public sealed class NexoSecurityOptions
     public string? CustomAdvisory { get; set; }
 
     /// <summary>
+    /// When true, mutating API routes (POST/PUT/PATCH/DELETE under /api) require an API key header.
+    /// </summary>
+    public bool RequireApiKeyForMutatingEndpoints { get; set; }
+
+    /// <summary>
+    /// Shared secret value expected in <see cref="ApiKeyHeaderName"/> for protected requests.
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Header name used for API key checks.
+    /// </summary>
+    public string ApiKeyHeaderName { get; set; } = "X-Nexo-Api-Key";
+
+    /// <summary>
+    /// Optional API route prefixes (e.g., /api/director/run) that bypass API key checks when
+    /// <see cref="RequireApiKeyForMutatingEndpoints"/> is true.
+    /// </summary>
+    public string[] ExcludedApiKeyPaths { get; set; } = [];
+
+    /// <summary>
     /// When false, <c>/api/security/advisory</c> still works but the portal hides the banner.
     /// </summary>
     public bool ShowAdvisoryInPortal { get; set; } = true;

--- a/src/Nexo.API/appsettings.json
+++ b/src/Nexo.API/appsettings.json
@@ -22,6 +22,10 @@
     },
     "Security": {
       "ExposureProfile": "Localhost",
+      "RequireApiKeyForMutatingEndpoints": false,
+      "ApiKeyHeaderName": "X-Nexo-Api-Key",
+      "ApiKey": null,
+      "ExcludedApiKeyPaths": [],
       "CustomAdvisory": null,
       "ShowAdvisoryInPortal": true
     },

--- a/src/Nexo.Tests.Infrastructure/Tests/API/NexoApiKeyAuthMiddlewareTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/NexoApiKeyAuthMiddlewareTests.cs
@@ -1,0 +1,111 @@
+using System.IO;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Nexo.API.Security;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+public sealed class NexoApiKeyAuthMiddlewareTests
+{
+    private static readonly RequestDelegate Next = _ => Task.CompletedTask;
+
+    [Fact]
+    public async Task InvokeAsync_WhenApiKeyRequiredAndMissing_ReturnsUnauthorized()
+    {
+        var options = CreateOptions(apiKey: "secret-key", required: true);
+        var middleware = new NexoApiKeyAuthMiddleware(Next, options);
+        var context = CreateContext("/api/orchestrate", method: "POST");
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenApiKeyRequiredAndValidHeader_AllowsRequest()
+    {
+        var nextCalled = false;
+        var middleware = new NexoApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, CreateOptions(apiKey: "secret-key", required: true));
+
+        var context = CreateContext("/api/orchestrate", method: "POST");
+        context.Request.Headers["X-Nexo-Api-Key"] = "secret-key";
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenReadOnlyEndpoint_WithoutApiKey_AllowsRequest()
+    {
+        var nextCalled = false;
+        var middleware = new NexoApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, CreateOptions(apiKey: "secret-key", required: true));
+
+        var context = CreateContext("/api/status", method: "GET");
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue("status endpoint is read-only and should remain accessible");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenApiKeyNotConfigured_AllowsRequest()
+    {
+        var nextCalled = false;
+        var middleware = new NexoApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, CreateOptions(apiKey: null, required: true));
+
+        var context = CreateContext("/api/orchestrate", method: "POST");
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue("missing configured API key means middleware runs in disabled mode");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenEndpointExcluded_AllowsRequest()
+    {
+        var nextCalled = false;
+        var middleware = new NexoApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, CreateOptions(apiKey: "secret-key", required: true, excluded: ["/api/orchestrate"]));
+
+        var context = CreateContext("/api/orchestrate", method: "POST");
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue("excluded path should bypass API key enforcement");
+    }
+
+    private static IOptions<NexoSecurityOptions> CreateOptions(string? apiKey, bool required, string[]? excluded = null)
+        => Options.Create(new NexoSecurityOptions
+        {
+            ApiKey = apiKey,
+            RequireApiKeyForMutatingEndpoints = required,
+            ExcludedApiKeyPaths = excluded ?? []
+        });
+
+    private static DefaultHttpContext CreateContext(string path, string method)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.Method = method;
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/API/SecurityAdvisoryEndpointTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/SecurityAdvisoryEndpointTests.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Nexo.API.Endpoints;
+using Nexo.API.Security;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+public sealed class SecurityAdvisoryEndpointTests
+{
+    [Theory]
+    [InlineData("Localhost", "Localhost", "this machine only")]
+    [InlineData("Lan", "Lan", "local network")]
+    [InlineData("Tailnet", "Tailnet", "Tailscale")]
+    [InlineData("Public", "Public", "Internet")]
+    public void GetSecurityAdvisory_MapsConfiguredExposureProfile(
+        string configuredProfile,
+        string expectedProfile,
+        string expectedSummaryFragment)
+    {
+        var response = InvokeGetSecurityAdvisory(new NexoSecurityOptions
+        {
+            ExposureProfile = configuredProfile
+        });
+
+        response.ExposureProfile.Should().Be(expectedProfile);
+        response.Summary.Should().Contain(expectedSummaryFragment);
+        response.Hints.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void GetSecurityAdvisory_WhenProfileIsInvalid_FallsBackToLocalhost()
+    {
+        var response = InvokeGetSecurityAdvisory(new NexoSecurityOptions
+        {
+            ExposureProfile = "not-a-real-profile"
+        });
+
+        response.ExposureProfile.Should().Be("Localhost");
+        response.Summary.Should().Contain("this machine only");
+    }
+
+    private static SecurityAdvisoryResponse InvokeGetSecurityAdvisory(NexoSecurityOptions options)
+    {
+        var method = typeof(NexoEndpoints).GetMethod(
+            "GetSecurityAdvisory",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("security advisory endpoint handler should exist");
+
+        var result = (IResult)method!.Invoke(
+            null,
+            [Options.Create(options)])!;
+
+        var valueProperty = result.GetType().GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
+        valueProperty.Should().NotBeNull();
+
+        var value = valueProperty!.GetValue(result);
+        value.Should().BeOfType<SecurityAdvisoryResponse>();
+        return (SecurityAdvisoryResponse)value!;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add optional API-key middleware for mutating `/api/*` routes with configurable header and excluded paths
- bind new security options in API startup and log when auth is required but no key is configured
- switch compose port publishing defaults to loopback-only binds for API and Ollama
- add API tests for middleware behavior and exposure-profile advisory mapping/fallback
- update security configuration docs and env examples to match runtime options

## Notes
- This PR is opened before post-change test execution to keep an auditable pre-test checkpoint on the branch.

## Testing
- Pending targeted test run in follow-up commit/update.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-107cce3a-bab7-46b6-82bd-42906cd899bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-107cce3a-bab7-46b6-82bd-42906cd899bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

