### PR TITLE
docs: align roadmap/trust docs and improve command comment with current state

### DIFF
--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -22,7 +22,8 @@ RUN dotnet restore src/Nexo.CLI/Nexo.CLI.csproj -p:TargetFramework="${TARGETFRAM
         -p:ErrorOnDuplicatePublishOutputFiles=false
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_RUNTIME_VERSION}
+# CLI transitively depends on ASP.NET Core shared framework via hosting references.
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_RUNTIME_VERSION}
 WORKDIR /app
 
 COPY --from=build /app/publish/ /app/

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -15,9 +15,10 @@ ENV SkipCopyAssemblies=true
 ENV TARGETFRAMEWORK=${TARGETFRAMEWORK:-net8.0}
 
 # Restore and publish CLI - framework dependent by default.
-RUN dotnet restore src/Nexo.CLI/Nexo.CLI.csproj -p:TargetFramework="${TARGETFRAMEWORK}" && \
+# Use single-node MSBuild in container builds to avoid intermittent file-lock races.
+RUN dotnet restore src/Nexo.CLI/Nexo.CLI.csproj -p:TargetFramework="${TARGETFRAMEWORK}" -m:1 && \
     dotnet publish src/Nexo.CLI/Nexo.CLI.csproj -c Release -o /app/publish \
-        --self-contained false -p:TargetFramework="${TARGETFRAMEWORK}" -p:UseAppHost=false -p:SkipCopyAssemblies=true \
+        -m:1 --self-contained false -p:TargetFramework="${TARGETFRAMEWORK}" -p:BuildInParallel=false -p:UseAppHost=false -p:SkipCopyAssemblies=true \
         -p:ErrorOnDuplicatePublishOutputFiles=false
 
 # Runtime stage

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -52,6 +52,7 @@ Nexo is an AI-enhanced development orchestration platform with a layered archite
 - **SanitizingProviderFactory**: Wraps `IProviderFactory`, sanitizes prompts before cloud
 - **CloudSanitizationProxy**: PII checks, `ISensitiveContentFilter` (email, phone, SSN, API keys)
 - **Audit log**: Redactions and decisions
+- **Scope note**: Trust wiring is automatic in `AddNexo()` hosting registration; standalone CLI command DI graphs must explicitly opt in.
 
 ### Hosting
 

--- a/docs/DogfoodValidation.md
+++ b/docs/DogfoodValidation.md
@@ -139,7 +139,7 @@ Nexo's North Star: every capability must be used by Nexo on itself. Each block h
 
 **Status:** Implemented. `DogfoodClosedLoopTests.ImproveFlow_AnalyzeBlock1Path_Completes` validates the gate.
 
-### Phase F: Changelog and Test Failure Store
+### Phase F (continued): Changelog and Test Failure Store
 
 **Gate:** Changelog generated from promoted changes; test failures stored for adaptation trigger.
 

--- a/docs/GapAnalysis.md
+++ b/docs/GapAnalysis.md
@@ -11,7 +11,7 @@
 | Area | Status | Gap Severity |
 |------|--------|---------------|
 | Dogfood gates (Blocks 1–9 + Phase F) | All implemented in tests; `make dogfood-all` passes | Low |
-| CLI dogfood parity | Only `nexo dogfood block1` exposed; blocks 2–9 test-only | Medium |
+| CLI dogfood parity | `nexo dogfood` exposes `block1`–`block9`, `closedloop`, `phasef`, `all` | Resolved |
 | Observe → Improve integration | Observe and improve are separate; patterns don't drive analysis | Medium |
 | Test failure → adaptation trigger | Self-improvement loop exists; test failure ingestion unclear | Low |
 | Trust in improve flow | Trust phases 1–4 implemented; improve may not use sanitization | Low |
@@ -25,13 +25,14 @@
 - All 9 blocks and Phase F (closed loop, changelog, test failure store) have passing tests.
 - `make dogfood-all` runs Phase C (blocks 1–6), Phase D+E (blocks 7–9), closed loop, and Phase F.
 - CI supports `scope=dogfood` in Cross-Platform Tests workflow.
+- `nexo dogfood` exposes `block1`–`block9`, `closedloop`, `phasef`, and `all`.
 
 ### Gap
-- **CLI parity:** `nexo dogfood` only exposes `block1`. Blocks 2–9, closed loop, and Phase F are validated only via `dotnet test` / `make dogfood-*`.
-- **North Star expectation:** Users should be able to run each gate from the CLI for quick validation without invoking the test runner.
+- **No functional parity gap.** CLI and test runner both cover all dogfood gates.
+- **Discoverability gap:** users still need clearer docs on when to use `nexo dogfood ...` vs `make dogfood-*`.
 
 ### Recommendation
-Add `nexo dogfood block2` through `nexo dogfood block9`, `nexo dogfood closedloop`, and `nexo dogfood phasef` subcommands that invoke the same logic as the tests (or delegate to test runner with a filter).
+Keep CLI parity marked as resolved; prioritize documentation examples that map each `nexo dogfood` command to the equivalent `make` and test-filter paths.
 
 ---
 
@@ -75,16 +76,17 @@ Add `nexo dogfood block2` through `nexo dogfood block9`, `nexo dogfood closedloo
 
 ### Current State
 - Trust phases 1–4 implemented: classification, sanitization, access boundary, audit dashboard.
-- `SanitizingProviderFactory` wraps `IProviderFactory` when Trust is enabled.
-- `ImproveCommand` uses `ProviderFactory` (and fix generation may call LLM). Trust/sanitization is applied when the host is configured with `NEXO_TRUST_ENABLED` and `AddNexo` Trust options.
+- `SanitizingProviderFactory` wraps `IProviderFactory` when Trust is enabled via hosting registration (`AddNexo`).
+- `ImproveCommand` builds a lightweight service collection and registers `ProviderFactory` directly.
+- Default `FixGenerator` paths are rule-based; cloud LLM usage in improve is optional and configuration-dependent.
 
 ### Gap
-- **ImproveCommand builds its own `ServiceProvider`** with `AddCodeAnalyzers`, `AddAdaptationInfrastructure`, etc. It does not use `AddNexo()` from Hosting. Whether `SanitizingProviderFactory` is registered in this light-weight service setup is unclear.
-- If fix generation uses LLM and Trust is not wired in the improve flow, prompts could reach cloud without sanitization when running `nexo improve`.
+- **Trust wiring gap risk:** `ImproveCommand` does not inherit hosting-level Trust registration by default.
+- If future improve paths send prompts to cloud providers, they must explicitly include Trust sanitization registration in the CLI-local DI graph.
 
 ### Recommendation
-- Audit `ImproveCommand` service registration: ensure `SanitizingProviderFactory` is used when Trust is enabled.
-- Add a dogfood test that runs improve with Trust enabled and asserts sanitization/audit behavior.
+- Document the current improve wiring (local DI, default rule-based fix generation).
+- Add a focused test that validates Trust sanitization is active when improve is configured to use cloud-backed fix generation.
 
 ---
 
@@ -126,11 +128,10 @@ Add `nexo dogfood block2` through `nexo dogfood block9`, `nexo dogfood closedloo
 
 | Priority | Gap | Effort | Impact |
 |----------|-----|--------|--------|
-| 1 | CLI dogfood parity (blocks 2–9, closedloop, phasef) | Medium | High – aligns CLI with North Star gates |
-| 2 | Observe → improve integration (pattern-driven analysis) | High | Medium – completes "observe → analyze → adapt" |
-| 3 | Trust in improve flow (sanitization when LLM used) | Low | High – security/compliance |
-| 4 | Test failure ingestion path documentation | Low | Medium – enables self-improvement in production |
-| 5 | Documentation (North Star, changelog, dogfood in README/GettingStarted) | Low | Medium – discoverability |
+| 1 | Observe → improve integration (pattern-driven analysis) | High | Medium – completes "observe → analyze → adapt" |
+| 2 | Trust in improve flow (sanitization when LLM used) | Low | High – security/compliance |
+| 3 | Test failure ingestion path documentation | Low | Medium – enables self-improvement in production |
+| 4 | Documentation (North Star, changelog, dogfood in README/GettingStarted) | Low | Medium – discoverability |
 
 ---
 

--- a/docs/TrustAndInformationArchitecture.md
+++ b/docs/TrustAndInformationArchitecture.md
@@ -215,30 +215,32 @@ IReadOnlyList<DataDecisionAuditEntry> GetRecent(int maxCount, DateTimeOffset? si
 
 ## Delivery Phases (Revised)
 
+The sections above define the target architecture. The phase list below reflects implementation status in the current codebase.
+
 ### Phase 1 — Classification + Sanitization (Extend Existing) — Implemented
-- Add `IDataTaxonomy` and `DataTaxonomy` with config file
-- Add `SanitizingProviderFactory` wrapping `IProviderFactory`
-- Use `ISensitiveContentFilter` for PII in prompts
-- Add `ICloudSanitizationProxy` and `ISanitizationAuditLog`
-- Register wrapper in DI when Trust is enabled
+- Implemented `IDataTaxonomy` and `DataTaxonomy` with config file support
+- Implemented `SanitizingProviderFactory` wrapping `IProviderFactory`
+- Implemented prompt PII filtering via `ISensitiveContentFilter`
+- Implemented `ICloudSanitizationProxy` and `ISanitizationAuditLog`
+- Implemented DI registration for Trust-enabled wrapper wiring
 
 ### Phase 2 — Knowledge Log with Provenance — Implemented
-- Add `IUserKnowledgeLogStore` (LiteDB impl: `LiteDbUserKnowledgeLogStore`)
-- Schema: entries, provenance (`SourceObservationIds`), versioning
-- Export to JSON/Markdown (`ExportToJsonAsync`, `ExportToMarkdownAsync`)
-- No changes to `IKnowledgeChunkStore` or `IKnowledgeSyncService`
+- Implemented `IUserKnowledgeLogStore` (LiteDB impl: `LiteDbUserKnowledgeLogStore`)
+- Implemented schema with entries, provenance (`SourceObservationIds`), and versioning
+- Implemented JSON/Markdown export (`ExportToJsonAsync`, `ExportToMarkdownAsync`)
+- Preserved `IKnowledgeChunkStore` and `IKnowledgeSyncService` unchanged
 
 ### Phase 3 — Access Boundary + Observation Gate — Implemented
-- Add `IAccessBoundary` and `IObservationGate` (`AccessBoundary`, `ObservationGate`)
-- Persist boundary config (JSON or SQLite)
-- Integrate into observation pipelines (`KnowledgeBaseIndexer`, `ObservationPipelineService`)
-- Add pause control and per-project overrides (`TrustCommand` pause, resume, allow, deny, boundary)
+- Implemented `IAccessBoundary` and `IObservationGate` (`AccessBoundary`, `ObservationGate`)
+- Implemented boundary config persistence (JSON/SQLite)
+- Integrated checks into observation pipelines (`KnowledgeBaseIndexer`, `ObservationPipelineService`)
+- Implemented pause controls and per-project overrides (`TrustCommand` pause/resume/allow/deny/boundary)
 
 ### Phase 4 — Audit Dashboard + Compliance — Implemented
-- Add `IDataDecisionAuditLog` (or extend `ISanitizationAuditLog`)
-- Unify sanitization, boundary, classification events
-- Export for compliance (structured JSON, Markdown, CSV via `TrustCommand.AuditAsync`)
-- UI: persistent boundary indicator, audit view (`TrustCommand.DashboardAsync`, `BoundaryAsync`)
+- Implemented `IDataDecisionAuditLog` support (or equivalent `ISanitizationAuditLog` extension)
+- Unified sanitization, boundary, and classification events
+- Implemented compliance export (structured JSON, Markdown, CSV via `TrustCommand.AuditAsync`)
+- Implemented persistent boundary indicator and audit view (`TrustCommand.DashboardAsync`, `BoundaryAsync`)
 
 ---
 

--- a/src/Nexo.CLI/Commands/ImproveCommand.cs
+++ b/src/Nexo.CLI/Commands/ImproveCommand.cs
@@ -24,7 +24,7 @@ namespace Nexo.CLI.Commands;
 
 /// <summary>
 /// Block 4: Closed-loop improve. Runs analyze bricks → adapt from violations.
-/// Dogfood: observe → analyze → adapt.
+/// Dogfood flow is sequential: run observe separately, then this command for analyze → adapt.
 /// </summary>
 public sealed class ImproveCommand : Command
 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- synchronized stale roadmap and trust docs to match current repo behavior and implementation status
- resolved outdated dogfood CLI parity claims in `docs/GapAnalysis.md`
- clarified implemented-state wording in trust delivery phases and removed duplicate/ambiguous Phase F heading wording
- updated architecture trust scope note and `ImproveCommand` XML summary to match actual DI and execution behavior
- fixed container-image gate regressions by:
  - serializing Docker `dotnet restore/publish` MSBuild execution to reduce file-lock races
  - switching runtime image from `dotnet/runtime` to `dotnet/aspnet` because published CLI transitively requires `Microsoft.AspNetCore.App`

## Validation
- targeted ripgrep checks confirm stale phrases were removed and replacement phrases are present
- restored/build-validated `src/Nexo.CLI/Nexo.CLI.csproj` after dependency restore
- matched the gate publish command locally (`dotnet restore/publish` flags from Dockerfile)
- inspected failing Actions logs to confirm root causes before each fix iteration
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8dbbda7-edb7-40c0-8a23-2d07565bc6f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8dbbda7-edb7-40c0-8a23-2d07565bc6f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

