### PR TITLE
Workflow stress lab + benchmark reporting

### DIFF
--- a/src/Nexo.CLI/Commands/WorkflowCommand.cs
+++ b/src/Nexo.CLI/Commands/WorkflowCommand.cs
@@ -1,0 +1,801 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Nexo.CLI.Runtime;
+using Nexo.Orchestration.Models;
+
+namespace Nexo.CLI.Commands;
+
+/// <summary>
+/// First-class workflow lab command for composing and stress-testing orchestrated agent workflows.
+/// </summary>
+public sealed class WorkflowCommand : Command
+{
+    internal delegate Task<ScenarioExecutionResult> ScenarioExecutor(
+        string request,
+        string runtimeSpecJson,
+        string? provider,
+        bool outputJson,
+        bool verbose,
+        CancellationToken cancellationToken);
+
+    private readonly ScenarioExecutor _scenarioExecutor;
+
+    public WorkflowCommand(Func<OrchestrateCommand> orchestrateFactory)
+        : this(async (request, runtimeSpecJson, provider, outputJson, verbose, ct) =>
+        {
+            var orchestrate = orchestrateFactory();
+            return await ExecuteScenarioAsync(orchestrate, request, runtimeSpecJson, provider, outputJson, verbose, ct).ConfigureAwait(false);
+        })
+    {
+    }
+
+    internal WorkflowCommand(ScenarioExecutor scenarioExecutor)
+        : base("workflow", "Scaffold and stress-test agentic workflow compositions.")
+    {
+        _scenarioExecutor = scenarioExecutor ?? throw new ArgumentNullException(nameof(scenarioExecutor));
+        ConfigureScaffoldCommand();
+        ConfigureStressCommand();
+        ConfigureHistoryCommand();
+    }
+
+    private void ConfigureScaffoldCommand()
+    {
+        var scaffold = new Command("scaffold", "Write a workflow lab runtime spec template.");
+        var outputOpt = new Option<string>(
+            "--output",
+            () => Path.Combine(Environment.CurrentDirectory, ".nexo", "workflow", "workflow_lab.runtime.json"),
+            "Destination path for scaffolded workflow lab runtime spec.");
+        var forceOpt = new Option<bool>("--force", () => false, "Overwrite output if it already exists.");
+        var jsonOpt = new Option<bool>("--json", () => false, "Emit machine-readable JSON output.");
+        scaffold.AddOption(outputOpt);
+        scaffold.AddOption(forceOpt);
+        scaffold.AddOption(jsonOpt);
+        scaffold.SetHandler((InvocationContext ctx) =>
+        {
+            var exitCode = ExecuteScaffoldAsync(
+                ctx.ParseResult.GetValueForOption(outputOpt) ?? string.Empty,
+                ctx.ParseResult.GetValueForOption(forceOpt),
+                ctx.ParseResult.GetValueForOption(jsonOpt)).GetAwaiter().GetResult();
+            ctx.ExitCode = exitCode;
+        });
+        AddCommand(scaffold);
+    }
+
+    private void ConfigureStressCommand()
+    {
+        var stress = new Command("stress", "Execute a workflow composition/model stress matrix.");
+        var requestOverrideOpt = new Option<string?>(
+            "--request",
+            () => null,
+            "Optional request override used for all scenarios.");
+        var specPathOpt = new Option<string?>(
+            "--spec",
+            () => null,
+            "Path to workflow lab runtime spec JSON (defaults to .nexo/workflow/workflow_lab.runtime.json).");
+        var specJsonOpt = new Option<string?>("--spec-json", () => null, "Inline workflow lab runtime spec JSON.");
+        var providerOpt = new Option<string?>(
+            "--provider",
+            () => null,
+            "Override provider for all profile entries unless explicitly set.");
+        var preferOpt = new Option<string?>(
+            "--prefer",
+            () => null,
+            "Override model preference for all profile entries (agentic|deterministic|auto).");
+        var iterationsOverrideOpt = new Option<int?>(
+            "--iterations",
+            () => null,
+            "Override iteration count from execution spec.");
+        var benchmarkSetOpt = new Option<string?>(
+            "--benchmark-set",
+            () => null,
+            "Benchmark set tag to persist in workflow lab history.");
+        var persistHistoryOpt = new Option<bool?>(
+            "--persist-history",
+            () => null,
+            "Persist workflow lab results in JSONL history.");
+        var jsonOpt = new Option<bool>("--json", () => false, "Emit machine-readable JSON output.");
+        var verboseOpt = new Option<bool>("--verbose", () => false, "Emit orchestrator progress output.");
+
+        stress.AddOption(requestOverrideOpt);
+        stress.AddOption(specPathOpt);
+        stress.AddOption(specJsonOpt);
+        stress.AddOption(providerOpt);
+        stress.AddOption(preferOpt);
+        stress.AddOption(iterationsOverrideOpt);
+        stress.AddOption(benchmarkSetOpt);
+        stress.AddOption(persistHistoryOpt);
+        stress.AddOption(jsonOpt);
+        stress.AddOption(verboseOpt);
+        stress.SetHandler((InvocationContext ctx) =>
+        {
+            var exitCode = ExecuteStressAsync(
+                ctx.ParseResult.GetValueForOption(requestOverrideOpt),
+                ctx.ParseResult.GetValueForOption(specPathOpt),
+                ctx.ParseResult.GetValueForOption(specJsonOpt),
+                ctx.ParseResult.GetValueForOption(providerOpt),
+                ctx.ParseResult.GetValueForOption(preferOpt),
+                ctx.ParseResult.GetValueForOption(iterationsOverrideOpt),
+                ctx.ParseResult.GetValueForOption(benchmarkSetOpt),
+                ctx.ParseResult.GetValueForOption(persistHistoryOpt),
+                ctx.ParseResult.GetValueForOption(jsonOpt),
+                ctx.ParseResult.GetValueForOption(verboseOpt),
+                ctx.GetCancellationToken()).GetAwaiter().GetResult();
+            ctx.ExitCode = exitCode;
+        });
+        AddCommand(stress);
+    }
+
+    private void ConfigureHistoryCommand()
+    {
+        var history = new Command("history", "Show recent workflow stress runs.");
+        var repoRootOpt = new Option<string>("--repo-root", () => Environment.CurrentDirectory, "Repository root path.");
+        var limitOpt = new Option<int>("--limit", () => 20, "Maximum history entries to return.");
+        var benchmarkSetOpt = new Option<string?>("--benchmark-set", () => null, "Optional benchmark-set filter.");
+        var jsonOpt = new Option<bool>("--json", () => false, "Emit machine-readable JSON output.");
+        history.AddOption(repoRootOpt);
+        history.AddOption(limitOpt);
+        history.AddOption(benchmarkSetOpt);
+        history.AddOption(jsonOpt);
+        history.SetHandler((InvocationContext ctx) =>
+        {
+            var exitCode = ExecuteHistoryAsync(
+                ctx.ParseResult.GetValueForOption(repoRootOpt) ?? Environment.CurrentDirectory,
+                ctx.ParseResult.GetValueForOption(limitOpt),
+                ctx.ParseResult.GetValueForOption(benchmarkSetOpt),
+                ctx.ParseResult.GetValueForOption(jsonOpt)).GetAwaiter().GetResult();
+            ctx.ExitCode = exitCode;
+        });
+        AddCommand(history);
+    }
+
+    internal Task<int> ExecuteScaffoldAsync(string outputPath, bool force, bool json)
+    {
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            WriteScaffoldResult(new WorkflowScaffoldResult(false, "Output path is required."), json);
+            return Task.FromResult(1);
+        }
+
+        var fullPath = Path.GetFullPath(outputPath);
+        var parent = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrWhiteSpace(parent))
+            Directory.CreateDirectory(parent);
+
+        if (File.Exists(fullPath) && !force)
+        {
+            WriteScaffoldResult(new WorkflowScaffoldResult(false, $"File already exists: {fullPath}. Use --force to overwrite.", fullPath), json);
+            return Task.FromResult(1);
+        }
+
+        var scaffold = WorkflowLabRuntimeSpec.Default();
+        var payload = JsonSerializer.Serialize(scaffold, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(fullPath, payload);
+        WriteScaffoldResult(new WorkflowScaffoldResult(true, "Workflow lab spec scaffolded successfully.", fullPath), json);
+        return Task.FromResult(0);
+    }
+
+    internal Task<int> ExecuteHistoryAsync(string repoRoot, int limit, string? benchmarkSet, bool json)
+    {
+        var fullRepoRoot = Path.GetFullPath(string.IsNullOrWhiteSpace(repoRoot) ? Environment.CurrentDirectory : repoRoot);
+        if (!Directory.Exists(fullRepoRoot))
+        {
+            WriteHistoryResult(new WorkflowHistoryResult(false, $"Repo root not found: {fullRepoRoot}"), json);
+            return Task.FromResult(1);
+        }
+
+        var rows = WorkflowLabHistoryStore.ReadRecent(fullRepoRoot, Math.Max(1, limit));
+        if (!string.IsNullOrWhiteSpace(benchmarkSet))
+        {
+            var normalized = benchmarkSet.Trim().ToLowerInvariant();
+            rows = rows
+                .Where(x => string.Equals(x.BenchmarkSet, normalized, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        var total = rows.Count;
+        var successCount = rows.Count(x => x.Success);
+        var best = rows
+            .OrderByDescending(x => x.Success)
+            .ThenByDescending(x => x.Score)
+            .ThenBy(x => x.ElapsedMs)
+            .FirstOrDefault();
+
+        WriteHistoryResult(new WorkflowHistoryResult(
+            true,
+            $"Loaded {total} workflow stress history entries.",
+            rows,
+            new WorkflowHistorySummary(total, successCount, total - successCount, best?.ScenarioId, best?.Score)), json);
+        return Task.FromResult(0);
+    }
+
+    internal async Task<int> ExecuteStressAsync(
+        string? requestOverride,
+        string? specPath,
+        string? specJson,
+        string? providerOverride,
+        string? preferOverride,
+        int? iterationsOverride,
+        string? benchmarkSetOverride,
+        bool? persistHistoryOverride,
+        bool json,
+        bool verbose,
+        CancellationToken ct)
+    {
+        var resolvedSpecPath = ResolveDefaultSpecPath(specPath);
+        WorkflowLabRuntimeSpec spec;
+        try
+        {
+            spec = WorkflowLabRuntimeSpecLoader.Load(resolvedSpecPath, specJson);
+        }
+        catch (Exception ex)
+        {
+            WriteStressResult(new WorkflowStressResult(false, $"Failed to load workflow lab spec: {ex.Message}"), json);
+            return 1;
+        }
+
+        var repoRoot = Environment.CurrentDirectory;
+        var requests = NormalizeRequests(spec.Requests);
+        var compositions = NormalizeCompositions(spec.Compositions);
+        var profiles = NormalizeProfiles(spec.ModelProfiles, providerOverride, preferOverride);
+        if (requests.Length == 0 || compositions.Length == 0 || profiles.Length == 0)
+        {
+            WriteStressResult(new WorkflowStressResult(
+                false,
+                "Workflow stress spec must include at least one request, composition, and model profile."), json);
+            return 1;
+        }
+
+        var benchmarkSet = NormalizeBenchmarkSet(benchmarkSetOverride, spec.Execution.BenchmarkSet);
+        var persistHistory = persistHistoryOverride ?? spec.Execution.PersistHistory;
+        var iterations = Math.Max(1, iterationsOverride ?? spec.Execution.Iterations);
+        var sharedRequest = string.IsNullOrWhiteSpace(requestOverride) ? null : requestOverride.Trim();
+
+        var runs = new List<WorkflowStressRunRecord>();
+        foreach (var request in requests)
+        {
+            foreach (var composition in compositions)
+            {
+                foreach (var profile in profiles)
+                {
+                    for (var i = 1; i <= iterations; i++)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        var scenarioId = BuildScenarioId(request.Id, composition.Id, profile.Id, i);
+                        var runtime = BuildRuntimeSpec(composition, profile);
+                        var runtimeJson = JsonSerializer.Serialize(runtime);
+                        var runtimeExecutionRequest = BuildExecutionRequest(request, composition, profile, sharedRequest);
+                        var startedAt = DateTimeOffset.UtcNow;
+                        var sw = Stopwatch.StartNew();
+                        ScenarioExecutionResult scenario;
+                        try
+                        {
+                            scenario = await _scenarioExecutor(
+                                runtimeExecutionRequest,
+                                runtimeJson,
+                                profile.Default.Provider,
+                                true,
+                                verbose,
+                                ct).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            scenario = new ScenarioExecutionResult(
+                                Ok: false,
+                                Summary: $"Scenario executor failed: {ex.Message}",
+                                ConflictCount: 0,
+                                EscalationCount: 0);
+                        }
+                        var elapsedMs = sw.ElapsedMilliseconds;
+                        var score = ComputeScore(scenario.Ok, elapsedMs, composition, profile);
+                        runs.Add(new WorkflowStressRunRecord(
+                            scenarioId,
+                            request.Id,
+                            composition.Id,
+                            profile.Id,
+                            i,
+                            scenario.Ok,
+                            composition.Roles.Count,
+                            scenario.ConflictCount,
+                            scenario.EscalationCount,
+                            elapsedMs,
+                            score,
+                            scenario.Summary,
+                            startedAt,
+                            benchmarkSet));
+                    }
+                }
+            }
+        }
+
+        var aggregates = runs
+            .GroupBy(x => new { x.RequestId, x.CompositionId, x.ModelProfileId })
+            .Select(group =>
+            {
+                var list = group.ToArray();
+                var successCount = list.Count(x => x.Success);
+                var avgElapsed = (long)Math.Round(list.Select(x => (double)x.ElapsedMs).DefaultIfEmpty(0d).Average());
+                var avgScore = Math.Round(list.Select(x => x.Score).DefaultIfEmpty(0d).Average(), 3);
+                return new WorkflowStressAggregate(
+                    ScenarioGroupId: $"{group.Key.RequestId}::{group.Key.CompositionId}::{group.Key.ModelProfileId}",
+                    group.Key.RequestId,
+                    group.Key.CompositionId,
+                    group.Key.ModelProfileId,
+                    list.Length,
+                    successCount,
+                    list.Length - successCount,
+                    avgElapsed,
+                    avgScore);
+            })
+            .OrderByDescending(x => x.AverageScore)
+            .ThenByDescending(x => x.Successes)
+            .ThenBy(x => x.AverageElapsedMs)
+            .ToArray();
+
+        if (persistHistory)
+        {
+            foreach (var run in runs)
+            {
+                WorkflowLabHistoryStore.Append(
+                    repoRoot,
+                    new WorkflowLabStressHistoryRow
+                    {
+                        ScenarioId = run.ScenarioId,
+                        RequestId = run.RequestId,
+                        CompositionId = run.CompositionId,
+                        ModelProfileId = run.ModelProfileId,
+                        Iteration = run.Iteration,
+                        StartedAtUtc = run.StartedAtUtc,
+                        ElapsedMs = run.ElapsedMs,
+                        Success = run.Success,
+                        AgentCount = run.AgentCount,
+                        ConflictCount = run.ConflictCount,
+                        EscalationCount = run.EscalationCount,
+                        Score = run.Score,
+                        Summary = run.Summary,
+                        BenchmarkSet = run.BenchmarkSet
+                    });
+            }
+        }
+
+        var allPassed = runs.All(run => run.Success);
+        var failureCount = runs.Count(run => !run.Success);
+        var best = aggregates.FirstOrDefault(x => x.Successes > 0);
+        var result = new WorkflowStressResult(
+            allPassed,
+            allPassed
+                ? $"Workflow stress completed: {runs.Count} run(s) across {aggregates.Length} scenario groups."
+                : $"Workflow stress completed with {failureCount} failing run(s) out of {runs.Count}.",
+            runs,
+            aggregates,
+            best,
+            benchmarkSet,
+            persistHistory);
+        WriteStressResult(result, json);
+        return result.Ok ? 0 : 1;
+    }
+
+    private static string BuildExecutionRequest(
+        WorkflowLabRequestSpec request,
+        WorkflowLabCompositionSpec composition,
+        WorkflowLabModelProfileSpec profile,
+        string? requestOverride)
+    {
+        if (!string.IsNullOrWhiteSpace(requestOverride))
+            return requestOverride;
+
+        var roleLines = composition.Roles.Select(role =>
+        {
+            var chain = role.CommandChain.Count == 0 ? string.Empty : $" chain={string.Join(">", role.CommandChain)}";
+            var reportsTo = string.IsNullOrWhiteSpace(role.ReportsToAgentId) ? string.Empty : $" reportsTo={role.ReportsToAgentId}";
+            var cluster = string.IsNullOrWhiteSpace(role.ClusterId) ? string.Empty : $" cluster={role.ClusterId}";
+            var roleModel = ResolveRoleModel(profile, role);
+            var modelDirective = string.IsNullOrWhiteSpace(roleModel) ? string.Empty : $" model={roleModel}";
+            return
+                $"- agentId={role.AgentId} role={role.Role} domain={role.Domain}{cluster}{reportsTo}{chain}{modelDirective} goal={role.Goal}";
+        });
+        return
+            $"{request.Prompt}\n\n" +
+            $"Use this workflow composition:\n{string.Join('\n', roleLines)}\n" +
+            "Treat the composition as mandatory orchestration constraints.";
+    }
+
+    private static async Task<ScenarioExecutionResult> ExecuteScenarioAsync(
+        OrchestrateCommand orchestrate,
+        string request,
+        string runtimeSpecJson,
+        string? provider,
+        bool json,
+        bool verbose,
+        CancellationToken ct)
+    {
+        var (stdOut, stdErr) = await CaptureConsoleAsync(
+            () => orchestrate.ExecuteAsync(
+                request,
+                runtimeSpecPath: null,
+                runtimeSpecJson,
+                preferModel: null,
+                provider,
+                barrierLevel: null,
+                preferredRegion: null,
+                json,
+                verbose),
+            ct).ConfigureAwait(false);
+        var combined = string.Join(
+            Environment.NewLine,
+            new[] { stdOut, stdErr }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        var parsed = TryParseOrchestratePayload(combined);
+        if (parsed is null)
+        {
+            return new ScenarioExecutionResult(
+                false,
+                "Scenario failed: orchestrate output did not contain JSON payload.",
+                0,
+                0);
+        }
+
+        return new ScenarioExecutionResult(
+            parsed.Ok,
+            parsed.Summary,
+            parsed.ConflictCount,
+            parsed.EscalationCount);
+    }
+
+    private static async Task<(string StdOut, string StdErr)> CaptureConsoleAsync(
+        Func<Task<int>> run,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        using var outWriter = new StringWriter();
+        using var errWriter = new StringWriter();
+        try
+        {
+            Console.SetOut(outWriter);
+            Console.SetError(errWriter);
+            await run().ConfigureAwait(false);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+
+        return (outWriter.ToString(), errWriter.ToString());
+    }
+
+    private static ParsedOrchestratePayload? TryParseOrchestratePayload(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return null;
+
+        var idx = output.LastIndexOf('{');
+        while (idx >= 0)
+        {
+            var candidate = output[idx..].Trim();
+            try
+            {
+                using var doc = JsonDocument.Parse(candidate);
+                var root = doc.RootElement;
+                var ok = root.TryGetProperty("ok", out var okNode) && okNode.ValueKind == JsonValueKind.True;
+                if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
+                    return new ParsedOrchestratePayload(ok, "Orchestrate response missing data payload.", 0, 0);
+                var summary = data.TryGetProperty("success", out var successNode) && successNode.ValueKind == JsonValueKind.True
+                    ? "Orchestration run completed successfully."
+                    : "Orchestration reported failure.";
+                var conflictCount = data.TryGetProperty("conflicts", out var conflictsNode) ? conflictsNode.GetInt32() : 0;
+                var escalationCount = data.TryGetProperty("escalations", out var escalationsNode) ? escalationsNode.GetInt32() : 0;
+                return new ParsedOrchestratePayload(ok, summary, conflictCount, escalationCount);
+            }
+            catch
+            {
+                idx = idx > 0 ? output.LastIndexOf('{', idx - 1) : -1;
+            }
+        }
+
+        return null;
+    }
+
+    private static OrchestrationRuntimeSpec BuildRuntimeSpec(
+        WorkflowLabCompositionSpec composition,
+        WorkflowLabModelProfileSpec profile)
+    {
+        var defaultModel = profile.Default;
+        var byAgent = new Dictionary<string, ModelRuntimeSpec>(profile.Agents, StringComparer.OrdinalIgnoreCase);
+        foreach (var role in composition.Roles)
+        {
+            if (string.IsNullOrWhiteSpace(role.AgentId))
+                continue;
+            if (byAgent.ContainsKey(role.AgentId))
+                continue;
+
+            var provider = string.IsNullOrWhiteSpace(role.Provider) ? defaultModel.Provider : role.Provider;
+            var prefer = string.IsNullOrWhiteSpace(role.Prefer) ? defaultModel.Prefer : role.Prefer!;
+            byAgent[role.AgentId] = new ModelRuntimeSpec
+            {
+                Prefer = string.IsNullOrWhiteSpace(prefer) ? "auto" : prefer,
+                Provider = provider
+            };
+        }
+
+        return new OrchestrationRuntimeSpec
+        {
+            Model = defaultModel,
+            Domains = new Dictionary<string, ModelRuntimeSpec>(profile.Domains, StringComparer.OrdinalIgnoreCase),
+            Agents = byAgent
+        };
+    }
+
+    private static WorkflowLabRequestSpec[] NormalizeRequests(IReadOnlyList<WorkflowLabRequestSpec> requests)
+    {
+        return (requests ?? Array.Empty<WorkflowLabRequestSpec>())
+            .Where(x => !string.IsNullOrWhiteSpace(x.Id))
+            .Where(x => !string.IsNullOrWhiteSpace(x.Prompt))
+            .Select(x => x with { Id = x.Id.Trim(), Prompt = x.Prompt.Trim() })
+            .ToArray();
+    }
+
+    private static WorkflowLabCompositionSpec[] NormalizeCompositions(IReadOnlyList<WorkflowLabCompositionSpec> compositions)
+    {
+        var output = new List<WorkflowLabCompositionSpec>();
+        foreach (var composition in compositions ?? Array.Empty<WorkflowLabCompositionSpec>())
+        {
+            if (string.IsNullOrWhiteSpace(composition.Id))
+                continue;
+
+            var normalizedRoles = (composition.Roles ?? Array.Empty<WorkflowLabAgentRoleSpec>())
+                .Where(role => !string.IsNullOrWhiteSpace(role.AgentId))
+                .Where(role => !string.IsNullOrWhiteSpace(role.Goal))
+                .Select(role => role with
+                {
+                    AgentId = role.AgentId.Trim(),
+                    Role = string.IsNullOrWhiteSpace(role.Role) ? "builder" : role.Role.Trim(),
+                    Domain = string.IsNullOrWhiteSpace(role.Domain) ? "general" : role.Domain.Trim(),
+                    Goal = role.Goal.Trim(),
+                    CommandChain = (role.CommandChain ?? Array.Empty<string>())
+                        .Where(entry => !string.IsNullOrWhiteSpace(entry))
+                        .Select(entry => entry.Trim())
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray()
+                })
+                .ToArray();
+            if (normalizedRoles.Length == 0)
+                continue;
+
+            output.Add(composition with
+            {
+                Id = composition.Id.Trim(),
+                Description = composition.Description?.Trim() ?? string.Empty,
+                Roles = normalizedRoles
+            });
+        }
+
+        return output.ToArray();
+    }
+
+    private static WorkflowLabModelProfileSpec[] NormalizeProfiles(
+        IReadOnlyList<WorkflowLabModelProfileSpec> profiles,
+        string? providerOverride,
+        string? preferOverride)
+    {
+        var provider = string.IsNullOrWhiteSpace(providerOverride) ? null : providerOverride.Trim();
+        var prefer = string.IsNullOrWhiteSpace(preferOverride) ? null : preferOverride.Trim();
+        var output = new List<WorkflowLabModelProfileSpec>();
+        foreach (var profile in profiles ?? Array.Empty<WorkflowLabModelProfileSpec>())
+        {
+            if (string.IsNullOrWhiteSpace(profile.Id))
+                continue;
+
+            var defaultRuntime = ApplyOverrides(profile.Default, provider, prefer);
+            var domains = profile.Domains.ToDictionary(
+                kvp => kvp.Key,
+                kvp => ApplyOverrides(kvp.Value, provider, prefer),
+                StringComparer.OrdinalIgnoreCase);
+            var agents = profile.Agents.ToDictionary(
+                kvp => kvp.Key,
+                kvp => ApplyOverrides(kvp.Value, provider, prefer),
+                StringComparer.OrdinalIgnoreCase);
+
+            output.Add(profile with
+            {
+                Id = profile.Id.Trim(),
+                Description = profile.Description?.Trim() ?? string.Empty,
+                Default = defaultRuntime,
+                Domains = domains,
+                Agents = agents
+            });
+        }
+
+        return output.ToArray();
+    }
+
+    private static ModelRuntimeSpec ApplyOverrides(ModelRuntimeSpec runtime, string? provider, string? prefer)
+    {
+        var updated = runtime with { Prefer = string.IsNullOrWhiteSpace(runtime.Prefer) ? "auto" : runtime.Prefer };
+        if (!string.IsNullOrWhiteSpace(provider))
+            updated = updated with { Provider = provider };
+        if (!string.IsNullOrWhiteSpace(prefer))
+            updated = updated with { Prefer = prefer };
+        return updated;
+    }
+
+    private static string ResolveDefaultSpecPath(string? explicitPath)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitPath))
+            return Path.GetFullPath(explicitPath);
+        return Path.Combine(Environment.CurrentDirectory, ".nexo", "workflow", "workflow_lab.runtime.json");
+    }
+
+    private static string BuildScenarioId(string requestId, string compositionId, string profileId, int iteration)
+        => $"{requestId}::{compositionId}::{profileId}::iter-{iteration}";
+
+    private static string NormalizeBenchmarkSet(string? benchmarkSetOverride, string defaultValue)
+    {
+        var value = string.IsNullOrWhiteSpace(benchmarkSetOverride) ? defaultValue : benchmarkSetOverride;
+        var normalized = (value ?? "workflow-lab").Trim().ToLowerInvariant();
+        return string.IsNullOrWhiteSpace(normalized) ? "workflow-lab" : normalized;
+    }
+
+    private static string? ResolveRoleModel(WorkflowLabModelProfileSpec profile, WorkflowLabAgentRoleSpec role)
+    {
+        if (!string.IsNullOrWhiteSpace(role.OllamaModel))
+            return role.OllamaModel.Trim();
+        if (profile.AgentModelHints.TryGetValue(role.AgentId, out var hint) && !string.IsNullOrWhiteSpace(hint))
+            return hint.Trim();
+        return null;
+    }
+
+    private static double ComputeScore(
+        bool success,
+        long elapsedMs,
+        WorkflowLabCompositionSpec composition,
+        WorkflowLabModelProfileSpec profile)
+    {
+        var successScore = success ? 100d : 0d;
+        var latencyPenalty = Math.Min(60d, elapsedMs / 200d);
+        var complexityBonus = Math.Min(20d, composition.Roles.Count * 2d);
+        var diversityBonus = Math.Min(10d, profile.Agents.Count + profile.Domains.Count + profile.AgentModelHints.Count);
+        var score = successScore - latencyPenalty + complexityBonus + diversityBonus;
+        return Math.Round(score, 3);
+    }
+
+    private static void WriteScaffoldResult(WorkflowScaffoldResult result, bool json)
+    {
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = result.Ok,
+                summary = result.Summary,
+                outputPath = result.OutputPath
+            }, new JsonSerializerOptions { WriteIndented = true }));
+            return;
+        }
+
+        Console.WriteLine($"workflow scaffold: {(result.Ok ? "ok" : "failed")}");
+        Console.WriteLine(result.Summary);
+        if (!string.IsNullOrWhiteSpace(result.OutputPath))
+            Console.WriteLine($"  output={result.OutputPath}");
+    }
+
+    private static void WriteStressResult(WorkflowStressResult result, bool json)
+    {
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = result.Ok,
+                summary = result.Summary,
+                benchmarkSet = result.BenchmarkSet,
+                persistHistory = result.PersistHistory,
+                runs = result.Runs,
+                aggregates = result.Aggregates,
+                best = result.Best
+            }, new JsonSerializerOptions { WriteIndented = true }));
+            return;
+        }
+
+        Console.WriteLine($"workflow stress: {(result.Ok ? "ok" : "failed")}");
+        Console.WriteLine(result.Summary);
+        if (!string.IsNullOrWhiteSpace(result.BenchmarkSet))
+            Console.WriteLine($"  benchmark-set={result.BenchmarkSet} (persist-history={result.PersistHistory})");
+        foreach (var aggregate in (result.Aggregates ?? Array.Empty<WorkflowStressAggregate>()).Take(5))
+        {
+            Console.WriteLine(
+                $"  {aggregate.ScenarioGroupId}: success={aggregate.Successes}/{aggregate.TotalRuns}, avg-score={aggregate.AverageScore:F2}, avg-elapsed={aggregate.AverageElapsedMs}ms");
+        }
+        if (result.Best != null)
+        {
+            Console.WriteLine($"  best={result.Best.ScenarioGroupId} score={result.Best.AverageScore:F2}");
+        }
+    }
+
+    private static void WriteHistoryResult(WorkflowHistoryResult result, bool json)
+    {
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = result.Ok,
+                summary = result.Summary,
+                summaryStats = result.SummaryStats,
+                items = result.Items
+            }, new JsonSerializerOptions { WriteIndented = true }));
+            return;
+        }
+
+        Console.WriteLine($"workflow history: {(result.Ok ? "ok" : "failed")}");
+        Console.WriteLine(result.Summary);
+        if (result.SummaryStats != null)
+        {
+            Console.WriteLine(
+                $"  total={result.SummaryStats.Total}, success={result.SummaryStats.Success}, failed={result.SummaryStats.Failed}, best={result.SummaryStats.BestScenarioId ?? "n/a"}, best-score={result.SummaryStats.BestScore?.ToString("F2") ?? "n/a"}");
+        }
+    }
+
+    private sealed record WorkflowScaffoldResult(bool Ok, string Summary, string? OutputPath = null);
+
+    private sealed record WorkflowStressRunRecord(
+        string ScenarioId,
+        string RequestId,
+        string CompositionId,
+        string ModelProfileId,
+        int Iteration,
+        bool Success,
+        int AgentCount,
+        int ConflictCount,
+        int EscalationCount,
+        long ElapsedMs,
+        double Score,
+        string Summary,
+        DateTimeOffset StartedAtUtc,
+        string BenchmarkSet);
+
+    private sealed record WorkflowStressAggregate(
+        string ScenarioGroupId,
+        string RequestId,
+        string CompositionId,
+        string ModelProfileId,
+        int TotalRuns,
+        int Successes,
+        int Failures,
+        long AverageElapsedMs,
+        double AverageScore);
+
+    private sealed record WorkflowStressResult(
+        bool Ok,
+        string Summary,
+        IReadOnlyList<WorkflowStressRunRecord>? Runs = null,
+        IReadOnlyList<WorkflowStressAggregate>? Aggregates = null,
+        WorkflowStressAggregate? Best = null,
+        string? BenchmarkSet = null,
+        bool? PersistHistory = null);
+
+    private sealed record WorkflowHistorySummary(
+        int Total,
+        int Success,
+        int Failed,
+        string? BestScenarioId,
+        double? BestScore);
+
+    private sealed record WorkflowHistoryResult(
+        bool Ok,
+        string Summary,
+        IReadOnlyList<WorkflowLabStressHistoryRow>? Items = null,
+        WorkflowHistorySummary? SummaryStats = null);
+
+    internal sealed record ScenarioExecutionResult(
+        bool Ok,
+        string Summary,
+        int ConflictCount,
+        int EscalationCount);
+
+    private sealed record ParsedOrchestratePayload(
+        bool Ok,
+        string Summary,
+        int ConflictCount,
+        int EscalationCount);
+}

--- a/src/Nexo.CLI/Commands/WorkflowCommand.cs
+++ b/src/Nexo.CLI/Commands/WorkflowCommand.cs
@@ -807,7 +807,17 @@ public sealed class WorkflowCommand : Command
     private static string RenderReportContent(WorkflowReportResult result, bool preferJson, string outputPath)
     {
         var extension = Path.GetExtension(outputPath).Trim().ToLowerInvariant();
-        if (preferJson || extension == ".json")
+        if (extension == ".md")
+        {
+            return RenderReportMarkdown(result);
+        }
+
+        if (extension == ".txt")
+        {
+            return RenderReportText(result);
+        }
+
+        if (extension == ".json")
         {
             return JsonSerializer.Serialize(new
             {
@@ -817,9 +827,14 @@ public sealed class WorkflowCommand : Command
             }, new JsonSerializerOptions { WriteIndented = true });
         }
 
-        if (extension == ".md")
+        if (preferJson)
         {
-            return RenderReportMarkdown(result);
+            return JsonSerializer.Serialize(new
+            {
+                ok = result.Ok,
+                summary = result.Summary,
+                report = result.Report
+            }, new JsonSerializerOptions { WriteIndented = true });
         }
 
         return RenderReportText(result);

--- a/src/Nexo.CLI/Commands/WorkflowCommand.cs
+++ b/src/Nexo.CLI/Commands/WorkflowCommand.cs
@@ -39,6 +39,7 @@ public sealed class WorkflowCommand : Command
         ConfigureScaffoldCommand();
         ConfigureStressCommand();
         ConfigureHistoryCommand();
+        ConfigureReportCommand();
     }
 
     private void ConfigureScaffoldCommand()
@@ -151,6 +152,32 @@ public sealed class WorkflowCommand : Command
         AddCommand(history);
     }
 
+    private void ConfigureReportCommand()
+    {
+        var report = new Command("report", "Generate benchmark report from workflow stress history.");
+        var repoRootOpt = new Option<string>("--repo-root", () => Environment.CurrentDirectory, "Repository root path.");
+        var limitOpt = new Option<int>("--limit", () => 200, "Maximum history entries to analyze.");
+        var benchmarkSetOpt = new Option<string?>("--benchmark-set", () => null, "Optional benchmark-set filter.");
+        var outputOpt = new Option<string?>("--output", () => null, "Optional report output file path (.json, .md, .txt).");
+        var jsonOpt = new Option<bool>("--json", () => false, "Emit machine-readable JSON output.");
+        report.AddOption(repoRootOpt);
+        report.AddOption(limitOpt);
+        report.AddOption(benchmarkSetOpt);
+        report.AddOption(outputOpt);
+        report.AddOption(jsonOpt);
+        report.SetHandler((InvocationContext ctx) =>
+        {
+            var exitCode = ExecuteReportAsync(
+                ctx.ParseResult.GetValueForOption(repoRootOpt) ?? Environment.CurrentDirectory,
+                ctx.ParseResult.GetValueForOption(limitOpt),
+                ctx.ParseResult.GetValueForOption(benchmarkSetOpt),
+                ctx.ParseResult.GetValueForOption(outputOpt),
+                ctx.ParseResult.GetValueForOption(jsonOpt)).GetAwaiter().GetResult();
+            ctx.ExitCode = exitCode;
+        });
+        AddCommand(report);
+    }
+
     internal Task<int> ExecuteScaffoldAsync(string outputPath, bool force, bool json)
     {
         if (string.IsNullOrWhiteSpace(outputPath))
@@ -209,6 +236,68 @@ public sealed class WorkflowCommand : Command
             rows,
             new WorkflowHistorySummary(total, successCount, total - successCount, best?.ScenarioId, best?.Score)), json);
         return Task.FromResult(0);
+    }
+
+    internal Task<int> ExecuteReportAsync(
+        string repoRoot,
+        int limit,
+        string? benchmarkSet,
+        string? outputPath,
+        bool json)
+    {
+        var fullRepoRoot = Path.GetFullPath(string.IsNullOrWhiteSpace(repoRoot) ? Environment.CurrentDirectory : repoRoot);
+        if (!Directory.Exists(fullRepoRoot))
+        {
+            WriteReportResult(new WorkflowReportResult(
+                false,
+                $"Repo root not found: {fullRepoRoot}",
+                new WorkflowBenchmarkReport(
+                    DateTimeOffset.UtcNow,
+                    0,
+                    0,
+                    0,
+                    0d,
+                    0,
+                    0,
+                    0d,
+                    0d,
+                    0d,
+                    Array.Empty<WorkflowScenarioBenchmark>(),
+                    Array.Empty<WorkflowScenarioBenchmark>())), json);
+            return Task.FromResult(1);
+        }
+
+        var rows = WorkflowLabHistoryStore.ReadRecent(fullRepoRoot, Math.Max(1, limit));
+        if (!string.IsNullOrWhiteSpace(benchmarkSet))
+        {
+            var normalized = benchmarkSet.Trim().ToLowerInvariant();
+            rows = rows
+                .Where(x => string.Equals(x.BenchmarkSet, normalized, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        var report = BuildBenchmarkReport(rows);
+        var result = new WorkflowReportResult(
+            report.TotalRuns > 0,
+            report.TotalRuns > 0
+                ? $"Benchmark report generated from {report.TotalRuns} run(s)."
+                : "No workflow stress history found for the selected filters.",
+            report);
+
+        if (!string.IsNullOrWhiteSpace(outputPath))
+        {
+            var fullOutputPath = Path.GetFullPath(outputPath);
+            var directory = Path.GetDirectoryName(fullOutputPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+
+            var content = RenderReportContent(result, json, fullOutputPath);
+            File.WriteAllText(fullOutputPath, content);
+            result = result with { OutputPath = fullOutputPath };
+        }
+
+        WriteReportResult(result, json);
+        return Task.FromResult(result.Ok ? 0 : 1);
     }
 
     internal async Task<int> ExecuteStressAsync(
@@ -639,6 +728,166 @@ public sealed class WorkflowCommand : Command
         return string.IsNullOrWhiteSpace(normalized) ? "workflow-lab" : normalized;
     }
 
+    private static WorkflowBenchmarkReport BuildBenchmarkReport(IReadOnlyList<WorkflowLabStressHistoryRow> rows)
+    {
+        var items = rows ?? Array.Empty<WorkflowLabStressHistoryRow>();
+        var totalRuns = items.Count;
+        var successRuns = items.Count(x => x.Success);
+        var failedRuns = totalRuns - successRuns;
+        var successRate = totalRuns == 0 ? 0d : Math.Round((double)successRuns / totalRuns, 4);
+        var avgElapsed = totalRuns == 0 ? 0L : (long)Math.Round(items.Select(x => (double)x.ElapsedMs).DefaultIfEmpty(0d).Average());
+        var p95Elapsed = ComputePercentile(items.Select(x => x.ElapsedMs), 0.95);
+        var avgScore = totalRuns == 0 ? 0d : Math.Round(items.Select(x => x.Score).DefaultIfEmpty(0d).Average(), 3);
+        var avgConflicts = totalRuns == 0 ? 0d : Math.Round(items.Select(x => (double)x.ConflictCount).DefaultIfEmpty(0d).Average(), 3);
+        var avgEscalations = totalRuns == 0 ? 0d : Math.Round(items.Select(x => (double)x.EscalationCount).DefaultIfEmpty(0d).Average(), 3);
+
+        var scenarioStats = items
+            .GroupBy(x => $"{x.RequestId}::{x.CompositionId}::{x.ModelProfileId}", StringComparer.OrdinalIgnoreCase)
+            .Select(g =>
+            {
+                var data = g.ToArray();
+                var groupSuccess = data.Count(x => x.Success);
+                return new WorkflowScenarioBenchmark(
+                    ScenarioGroupId: g.Key,
+                    Runs: data.Length,
+                    Successes: groupSuccess,
+                    Failures: data.Length - groupSuccess,
+                    SuccessRate: data.Length == 0 ? 0d : Math.Round((double)groupSuccess / data.Length, 4),
+                    AverageElapsedMs: (long)Math.Round(data.Select(x => (double)x.ElapsedMs).DefaultIfEmpty(0d).Average()),
+                    P95ElapsedMs: ComputePercentile(data.Select(x => x.ElapsedMs), 0.95),
+                    AverageScore: Math.Round(data.Select(x => x.Score).DefaultIfEmpty(0d).Average(), 3),
+                    AverageConflicts: Math.Round(data.Select(x => (double)x.ConflictCount).DefaultIfEmpty(0d).Average(), 3),
+                    AverageEscalations: Math.Round(data.Select(x => (double)x.EscalationCount).DefaultIfEmpty(0d).Average(), 3))
+                {
+                    LastFailureSummary = data
+                        .Where(x => !x.Success && !string.IsNullOrWhiteSpace(x.Summary))
+                        .OrderByDescending(x => x.StartedAtUtc)
+                        .Select(x => x.Summary)
+                        .FirstOrDefault()
+                };
+            })
+            .OrderByDescending(x => x.SuccessRate)
+            .ThenByDescending(x => x.AverageScore)
+            .ThenBy(x => x.AverageElapsedMs)
+            .ToArray();
+
+        var topScenarios = scenarioStats.Take(5).ToArray();
+        var bottlenecks = scenarioStats
+            .Where(x => x.Failures > 0 || x.P95ElapsedMs > avgElapsed * 1.5)
+            .OrderByDescending(x => x.Failures)
+            .ThenByDescending(x => x.P95ElapsedMs)
+            .Take(5)
+            .ToArray();
+
+        return new WorkflowBenchmarkReport(
+            GeneratedAtUtc: DateTimeOffset.UtcNow,
+            TotalRuns: totalRuns,
+            SuccessRuns: successRuns,
+            FailedRuns: failedRuns,
+            SuccessRate: successRate,
+            AverageElapsedMs: avgElapsed,
+            P95ElapsedMs: p95Elapsed,
+            AverageScore: avgScore,
+            AverageConflicts: avgConflicts,
+            AverageEscalations: avgEscalations,
+            TopScenarios: topScenarios,
+            Bottlenecks: bottlenecks);
+    }
+
+    private static long ComputePercentile(IEnumerable<long> source, double percentile)
+    {
+        var ordered = source.OrderBy(x => x).ToArray();
+        if (ordered.Length == 0)
+            return 0;
+        var clamped = Math.Clamp(percentile, 0d, 1d);
+        var index = (int)Math.Ceiling((ordered.Length - 1) * clamped);
+        return ordered[index];
+    }
+
+    private static string RenderReportContent(WorkflowReportResult result, bool preferJson, string outputPath)
+    {
+        var extension = Path.GetExtension(outputPath).Trim().ToLowerInvariant();
+        if (preferJson || extension == ".json")
+        {
+            return JsonSerializer.Serialize(new
+            {
+                ok = result.Ok,
+                summary = result.Summary,
+                report = result.Report
+            }, new JsonSerializerOptions { WriteIndented = true });
+        }
+
+        if (extension == ".md")
+        {
+            return RenderReportMarkdown(result);
+        }
+
+        return RenderReportText(result);
+    }
+
+    private static string RenderReportMarkdown(WorkflowReportResult result)
+    {
+        var report = result.Report;
+        var sb = new StringBuilder();
+        sb.AppendLine("# Workflow Stress Benchmark Report");
+        sb.AppendLine();
+        sb.AppendLine($"Generated: {report.GeneratedAtUtc:O}");
+        sb.AppendLine();
+        sb.AppendLine("## Summary");
+        sb.AppendLine($"- Total runs: {report.TotalRuns}");
+        sb.AppendLine($"- Success runs: {report.SuccessRuns}");
+        sb.AppendLine($"- Failed runs: {report.FailedRuns}");
+        sb.AppendLine($"- Success rate: {report.SuccessRate:P1}");
+        sb.AppendLine($"- Avg latency: {report.AverageElapsedMs} ms");
+        sb.AppendLine($"- P95 latency: {report.P95ElapsedMs} ms");
+        sb.AppendLine($"- Avg score: {report.AverageScore:F2}");
+        sb.AppendLine($"- Avg conflicts: {report.AverageConflicts:F2}");
+        sb.AppendLine($"- Avg escalations: {report.AverageEscalations:F2}");
+        sb.AppendLine();
+        sb.AppendLine("## Top Scenarios");
+        foreach (var scenario in report.TopScenarios)
+        {
+            sb.AppendLine($"- `{scenario.ScenarioGroupId}` | success {scenario.Successes}/{scenario.Runs} ({scenario.SuccessRate:P1}) | score {scenario.AverageScore:F2} | p95 {scenario.P95ElapsedMs} ms");
+        }
+        sb.AppendLine();
+        sb.AppendLine("## Bottlenecks");
+        foreach (var bottleneck in report.Bottlenecks)
+        {
+            sb.AppendLine($"- `{bottleneck.ScenarioGroupId}` | failures {bottleneck.Failures} | p95 {bottleneck.P95ElapsedMs} ms | last failure: {bottleneck.LastFailureSummary ?? "n/a"}");
+        }
+        return sb.ToString();
+    }
+
+    private static string RenderReportText(WorkflowReportResult result)
+    {
+        var report = result.Report;
+        var sb = new StringBuilder();
+        sb.AppendLine("Workflow Stress Benchmark Report");
+        sb.AppendLine($"Generated: {report.GeneratedAtUtc:O}");
+        sb.AppendLine($"Total runs: {report.TotalRuns}");
+        sb.AppendLine($"Success runs: {report.SuccessRuns}");
+        sb.AppendLine($"Failed runs: {report.FailedRuns}");
+        sb.AppendLine($"Success rate: {report.SuccessRate:P1}");
+        sb.AppendLine($"Average latency: {report.AverageElapsedMs} ms");
+        sb.AppendLine($"P95 latency: {report.P95ElapsedMs} ms");
+        sb.AppendLine($"Average score: {report.AverageScore:F2}");
+        sb.AppendLine($"Average conflicts: {report.AverageConflicts:F2}");
+        sb.AppendLine($"Average escalations: {report.AverageEscalations:F2}");
+        sb.AppendLine();
+        sb.AppendLine("Top scenarios:");
+        foreach (var scenario in report.TopScenarios)
+        {
+            sb.AppendLine($"- {scenario.ScenarioGroupId}: success {scenario.Successes}/{scenario.Runs}, score {scenario.AverageScore:F2}, p95 {scenario.P95ElapsedMs} ms");
+        }
+        sb.AppendLine();
+        sb.AppendLine("Bottlenecks:");
+        foreach (var bottleneck in report.Bottlenecks)
+        {
+            sb.AppendLine($"- {bottleneck.ScenarioGroupId}: failures {bottleneck.Failures}, p95 {bottleneck.P95ElapsedMs} ms, last failure={bottleneck.LastFailureSummary ?? "n/a"}");
+        }
+        return sb.ToString();
+    }
+
     private static string? ResolveRoleModel(WorkflowLabModelProfileSpec profile, WorkflowLabAgentRoleSpec role)
     {
         if (!string.IsNullOrWhiteSpace(role.OllamaModel))
@@ -736,6 +985,29 @@ public sealed class WorkflowCommand : Command
         }
     }
 
+    private static void WriteReportResult(WorkflowReportResult result, bool json)
+    {
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = result.Ok,
+                summary = result.Summary,
+                outputPath = result.OutputPath,
+                report = result.Report
+            }, new JsonSerializerOptions { WriteIndented = true }));
+            return;
+        }
+
+        Console.WriteLine($"workflow report: {(result.Ok ? "ok" : "failed")}");
+        Console.WriteLine(result.Summary);
+        if (!string.IsNullOrWhiteSpace(result.OutputPath))
+            Console.WriteLine($"  output={result.OutputPath}");
+        Console.WriteLine($"  success-rate={result.Report.SuccessRate:P1}, avg-latency={result.Report.AverageElapsedMs}ms, p95={result.Report.P95ElapsedMs}ms");
+        if (result.Report.TopScenarios.Count > 0)
+            Console.WriteLine($"  best={result.Report.TopScenarios[0].ScenarioGroupId} score={result.Report.TopScenarios[0].AverageScore:F2}");
+    }
+
     private sealed record WorkflowScaffoldResult(bool Ok, string Summary, string? OutputPath = null);
 
     private sealed record WorkflowStressRunRecord(
@@ -786,6 +1058,41 @@ public sealed class WorkflowCommand : Command
         string Summary,
         IReadOnlyList<WorkflowLabStressHistoryRow>? Items = null,
         WorkflowHistorySummary? SummaryStats = null);
+
+    private sealed record WorkflowScenarioBenchmark(
+        string ScenarioGroupId,
+        int Runs,
+        int Successes,
+        int Failures,
+        double SuccessRate,
+        long AverageElapsedMs,
+        long P95ElapsedMs,
+        double AverageScore,
+        double AverageConflicts,
+        double AverageEscalations)
+    {
+        public string? LastFailureSummary { get; init; }
+    }
+
+    private sealed record WorkflowBenchmarkReport(
+        DateTimeOffset GeneratedAtUtc,
+        int TotalRuns,
+        int SuccessRuns,
+        int FailedRuns,
+        double SuccessRate,
+        long AverageElapsedMs,
+        long P95ElapsedMs,
+        double AverageScore,
+        double AverageConflicts,
+        double AverageEscalations,
+        IReadOnlyList<WorkflowScenarioBenchmark> TopScenarios,
+        IReadOnlyList<WorkflowScenarioBenchmark> Bottlenecks);
+
+    private sealed record WorkflowReportResult(
+        bool Ok,
+        string Summary,
+        WorkflowBenchmarkReport Report,
+        string? OutputPath = null);
 
     internal sealed record ScenarioExecutionResult(
         bool Ok,

--- a/src/Nexo.CLI/Program.cs
+++ b/src/Nexo.CLI/Program.cs
@@ -1118,6 +1118,7 @@ static class Program
         root.AddCommand(new BootstrapCommand());
         root.AddCommand(new DoctorCommand());
         root.AddCommand(new RuntimeCommand());
+        root.AddCommand(new WorkflowCommand(() => ServiceProvider.GetRequiredService<OrchestrateCommand>()));
         root.AddCommand(new ChatCommand(() => ServiceProvider.GetRequiredService<OrchestrateCommand>()));
         root.AddCommand(new SelfExtendCommand(
             () => ServiceProvider.GetRequiredService<Nexo.BackgroundAgents.HostRunners.SelfExtendRunnerAdapter>()));

--- a/src/Nexo.CLI/Runtime/WorkflowLabHistoryStore.cs
+++ b/src/Nexo.CLI/Runtime/WorkflowLabHistoryStore.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+
+namespace Nexo.CLI.Runtime;
+
+public sealed record WorkflowLabStressHistoryRow
+{
+    public string ScenarioId { get; init; } = string.Empty;
+    public string RequestId { get; init; } = string.Empty;
+    public string CompositionId { get; init; } = string.Empty;
+    public string ModelProfileId { get; init; } = string.Empty;
+    public int Iteration { get; init; }
+    public DateTimeOffset StartedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+    public long ElapsedMs { get; init; }
+    public bool Success { get; init; }
+    public int AgentCount { get; init; }
+    public int ConflictCount { get; init; }
+    public int EscalationCount { get; init; }
+    public double Score { get; init; }
+    public string? Summary { get; init; }
+    public string BenchmarkSet { get; init; } = "workflow-lab";
+}
+
+public static class WorkflowLabHistoryStore
+{
+    private const string RelativePath = ".nexo/runtime/workflow_lab_history.jsonl";
+
+    public static string GetPath(string repoRoot)
+        => Path.GetFullPath(Path.Combine(repoRoot, RelativePath));
+
+    public static IReadOnlyList<WorkflowLabStressHistoryRow> ReadRecent(string repoRoot, int maxItems = 300)
+    {
+        if (maxItems <= 0)
+            return Array.Empty<WorkflowLabStressHistoryRow>();
+
+        var path = GetPath(repoRoot);
+        if (!File.Exists(path))
+            return Array.Empty<WorkflowLabStressHistoryRow>();
+
+        var parsed = new List<WorkflowLabStressHistoryRow>();
+        foreach (var line in File.ReadLines(path))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                var item = JsonSerializer.Deserialize<WorkflowLabStressHistoryRow>(line);
+                if (item != null)
+                    parsed.Add(item);
+            }
+            catch
+            {
+                // Keep history resilient to malformed lines.
+            }
+        }
+
+        return parsed
+            .OrderByDescending(p => p.StartedAtUtc)
+            .Take(maxItems)
+            .ToArray();
+    }
+
+    public static void Append(string repoRoot, WorkflowLabStressHistoryRow report)
+    {
+        var path = GetPath(repoRoot);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        var line = JsonSerializer.Serialize(report);
+        File.AppendAllText(path, line + Environment.NewLine);
+    }
+}

--- a/src/Nexo.CLI/Runtime/WorkflowLabRuntimeSpec.cs
+++ b/src/Nexo.CLI/Runtime/WorkflowLabRuntimeSpec.cs
@@ -1,0 +1,170 @@
+using Nexo.Orchestration.Models;
+
+namespace Nexo.CLI.Runtime;
+
+/// <summary>
+/// Runtime specification for scaffolding and stress-testing orchestrated workflow compositions.
+/// </summary>
+public sealed record WorkflowLabRuntimeSpec
+{
+    public WorkflowLabExecutionSpec Execution { get; init; } = new();
+    public IReadOnlyList<WorkflowLabRequestSpec> Requests { get; init; } = Array.Empty<WorkflowLabRequestSpec>();
+    public IReadOnlyList<WorkflowLabCompositionSpec> Compositions { get; init; } = Array.Empty<WorkflowLabCompositionSpec>();
+    public IReadOnlyList<WorkflowLabModelProfileSpec> ModelProfiles { get; init; } = Array.Empty<WorkflowLabModelProfileSpec>();
+
+    public static WorkflowLabRuntimeSpec Default() => new()
+    {
+        Execution = new WorkflowLabExecutionSpec
+        {
+            Iterations = 2,
+            PersistHistory = true,
+            BenchmarkSet = "workflow-lab"
+        },
+        Requests = new[]
+        {
+            new WorkflowLabRequestSpec
+            {
+                Id = "fullstack-feature",
+                Prompt = "Plan and deliver a small full-stack feature with tests, docs, and rollout notes."
+            },
+            new WorkflowLabRequestSpec
+            {
+                Id = "incident-triage",
+                Prompt = "Triage a production incident, identify root cause, propose a fix, and outline risk controls."
+            }
+        },
+        Compositions = new[]
+        {
+            new WorkflowLabCompositionSpec
+            {
+                Id = "single-specialist",
+                Description = "One agent handles planning, implementation, and validation end-to-end.",
+                Roles = new[]
+                {
+                    new WorkflowLabAgentRoleSpec
+                    {
+                        AgentId = "specialist-1",
+                        Role = "builder",
+                        Domain = "engineering",
+                        Goal = "Deliver the objective with complete implementation and validation evidence.",
+                        ClusterId = "solo"
+                    }
+                }
+            },
+            new WorkflowLabCompositionSpec
+            {
+                Id = "hierarchy-squad",
+                Description = "Hierarchical command chain with planner -> implementer -> qa.",
+                Roles = new[]
+                {
+                    new WorkflowLabAgentRoleSpec
+                    {
+                        AgentId = "planner-1",
+                        Role = "planner",
+                        Domain = "coordination",
+                        Goal = "Break the objective into clear execution steps and constraints.",
+                        ClusterId = "core"
+                    },
+                    new WorkflowLabAgentRoleSpec
+                    {
+                        AgentId = "builder-1",
+                        Role = "builder",
+                        Domain = "engineering",
+                        Goal = "Implement the requested change-set with maintainable code.",
+                        ClusterId = "core",
+                        ReportsToAgentId = "planner-1",
+                        CommandChain = new[] { "planner-1" }
+                    },
+                    new WorkflowLabAgentRoleSpec
+                    {
+                        AgentId = "qa-1",
+                        Role = "qa-functional",
+                        Domain = "quality",
+                        Goal = "Run focused tests and provide actionable pass/fail evidence.",
+                        ClusterId = "quality",
+                        ReportsToAgentId = "planner-1",
+                        CommandChain = new[] { "planner-1" }
+                    }
+                }
+            }
+        },
+        ModelProfiles = new[]
+        {
+            new WorkflowLabModelProfileSpec
+            {
+                Id = "ollama-balanced",
+                Description = "Balanced local Ollama setup across all agents.",
+                Default = new ModelRuntimeSpec
+                {
+                    Prefer = "agentic",
+                    Provider = "ollama",
+                    Model = "llama3.1"
+                }
+            },
+            new WorkflowLabModelProfileSpec
+            {
+                Id = "ollama-mixed",
+                Description = "Mix planners/builders/reviewers onto different Ollama models.",
+                Default = new ModelRuntimeSpec
+                {
+                    Prefer = "agentic",
+                    Provider = "ollama",
+                    Model = "llama3.1"
+                },
+                Agents = new Dictionary<string, ModelRuntimeSpec>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["planner-1"] = new ModelRuntimeSpec { Prefer = "agentic", Provider = "ollama", Model = "qwen2.5:7b" },
+                    ["builder-1"] = new ModelRuntimeSpec { Prefer = "agentic", Provider = "ollama", Model = "codellama:13b" },
+                    ["qa-1"] = new ModelRuntimeSpec { Prefer = "deterministic", Provider = "ollama", Model = "mistral:7b" }
+                }
+            }
+        }
+    };
+}
+
+public sealed record WorkflowLabExecutionSpec
+{
+    public int Iterations { get; init; } = 1;
+    public bool PersistHistory { get; init; } = true;
+    public string BenchmarkSet { get; init; } = "workflow-lab";
+}
+
+public sealed record WorkflowLabRequestSpec
+{
+    public string Id { get; init; } = "request-1";
+    public string Prompt { get; init; } = string.Empty;
+}
+
+public sealed record WorkflowLabCompositionSpec
+{
+    public string Id { get; init; } = "composition-1";
+    public string Description { get; init; } = string.Empty;
+    public IReadOnlyList<WorkflowLabAgentRoleSpec> Roles { get; init; } = Array.Empty<WorkflowLabAgentRoleSpec>();
+}
+
+public sealed record WorkflowLabAgentRoleSpec
+{
+    public string AgentId { get; init; } = string.Empty;
+    public string Role { get; init; } = string.Empty;
+    public string Domain { get; init; } = "general";
+    public string Goal { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string? ClusterId { get; init; }
+    public string? ReportsToAgentId { get; init; }
+    public IReadOnlyList<string> CommandChain { get; init; } = Array.Empty<string>();
+    public string? OllamaModel { get; init; }
+    public string? Provider { get; init; }
+    public string? Prefer { get; init; }
+}
+
+public sealed record WorkflowLabModelProfileSpec
+{
+    public string Id { get; init; } = "profile-1";
+    public string Description { get; init; } = string.Empty;
+    public ModelRuntimeSpec Default { get; init; } = new();
+    public Dictionary<string, ModelRuntimeSpec> Domains { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, ModelRuntimeSpec> Agents { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public string? DefaultModelName { get; init; }
+    public Dictionary<string, string> DomainModelNames { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string> AgentModelHints { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Nexo.CLI/Runtime/WorkflowLabRuntimeSpecLoader.cs
+++ b/src/Nexo.CLI/Runtime/WorkflowLabRuntimeSpecLoader.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using Nexo.Infrastructure.IO;
+
+namespace Nexo.CLI.Runtime;
+
+/// <summary>
+/// CLI loader for workflow lab runtime spec files.
+/// </summary>
+public static class WorkflowLabRuntimeSpecLoader
+{
+    public static WorkflowLabRuntimeSpec Load(string? path, string? json)
+    {
+        if (!string.IsNullOrWhiteSpace(json))
+            return Deserialize(json);
+
+        if (!string.IsNullOrWhiteSpace(path))
+            return Deserialize(TextFile.ReadAllText(path));
+
+        return WorkflowLabRuntimeSpec.Default();
+    }
+
+    private static WorkflowLabRuntimeSpec Deserialize(string json)
+    {
+        var cfg = JsonSerializer.Deserialize<WorkflowLabRuntimeSpec>(
+            json,
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            });
+
+        return cfg ?? throw new InvalidOperationException("Failed to parse workflow lab runtime spec JSON.");
+    }
+}

--- a/src/Nexo.Infrastructure/Execution/Models/ProviderBackedModel.cs
+++ b/src/Nexo.Infrastructure/Execution/Models/ProviderBackedModel.cs
@@ -20,7 +20,7 @@ public sealed class ProviderBackedModel : IModel
 
     public async Task<ModelOutput> CompleteAsync(ModelInput input, CancellationToken ct)
     {
-        var (provider, systemPrompt, userPrompt) = Parse(input);
+        var (provider, model, systemPrompt, userPrompt) = Parse(input);
         if (string.IsNullOrWhiteSpace(provider)) provider = "offline";
 
         if (!_providerFactory.IsProviderAvailable(provider))
@@ -32,15 +32,16 @@ public sealed class ProviderBackedModel : IModel
             provider,
             systemPrompt,
             userPrompt,
-            config: new { },
+            config: string.IsNullOrWhiteSpace(model) ? new { } : new { model },
             cancellationToken: ct);
 
         return new ModelOutput(text);
     }
 
-    private static (string? provider, string systemPrompt, string userPrompt) Parse(ModelInput input)
+    private static (string? provider, string? model, string systemPrompt, string userPrompt) Parse(ModelInput input)
     {
         var provider = (string?)null;
+        var model = (string?)null;
         var systemParts = new List<string>();
         var userParts = new List<string>();
 
@@ -58,6 +59,11 @@ public sealed class ProviderBackedModel : IModel
                         provider = trimmed["nexo.model.provider=".Length..].Trim();
                         continue;
                     }
+                    if (trimmed.StartsWith("nexo.model.name=", StringComparison.OrdinalIgnoreCase))
+                    {
+                        model = trimmed["nexo.model.name=".Length..].Trim();
+                        continue;
+                    }
                     systemParts.Add(line);
                 }
             }
@@ -67,7 +73,7 @@ public sealed class ProviderBackedModel : IModel
             }
         }
 
-        return (provider, string.Join('\n', systemParts).Trim(), string.Join('\n', userParts).Trim());
+        return (provider, model, string.Join('\n', systemParts).Trim(), string.Join('\n', userParts).Trim());
     }
 }
 

--- a/src/Nexo.Orchestration/Models/OrchestrationRuntimeSpec.cs
+++ b/src/Nexo.Orchestration/Models/OrchestrationRuntimeSpec.cs
@@ -28,6 +28,8 @@ public sealed record ModelRuntimeSpec
     public string Prefer { get; init; } = "auto";
     /// <summary> Provider name (openai/azure/ollama/offline/mock-json/...) </summary>
     public string? Provider { get; init; }
+    /// <summary> Optional model identifier (for example an Ollama model/tag name). </summary>
+    public string? Model { get; init; }
 }
 
 public interface IOrchestrationRuntimeSpecAccessor
@@ -91,15 +93,16 @@ public sealed class OrchestrationRuntimeModelDecorator : IModel
             return _inner.CompleteAsync(input, ct);
         }
 
-        var routed = InjectDirectives(input, rt.Prefer, rt.Provider);
+        var routed = InjectDirectives(input, rt.Prefer, rt.Provider, rt.Model);
         return _inner.CompleteAsync(routed, ct);
     }
 
-    public static ModelInput InjectDirectives(ModelInput input, string? prefer, string? provider)
+    public static ModelInput InjectDirectives(ModelInput input, string? prefer, string? provider, string? model = null)
     {
         var directives = new List<string>();
         if (!string.IsNullOrWhiteSpace(prefer)) directives.Add($"nexo.model.prefer={prefer}");
         if (!string.IsNullOrWhiteSpace(provider)) directives.Add($"nexo.model.provider={provider}");
+        if (!string.IsNullOrWhiteSpace(model)) directives.Add($"nexo.model.name={model}");
         if (directives.Count == 0) return input;
 
         var header = string.Join("\n", directives);
@@ -141,7 +144,8 @@ public sealed class AgentScopedModel : IModel
         var header = $"nexo.agent.id={_agentId}\n" +
                      $"nexo.agent.domain={_domain}\n" +
                      $"nexo.model.prefer={_runtime.Prefer}\n" +
-                     (string.IsNullOrWhiteSpace(_runtime.Provider) ? "" : $"nexo.model.provider={_runtime.Provider}\n");
+                     (string.IsNullOrWhiteSpace(_runtime.Provider) ? "" : $"nexo.model.provider={_runtime.Provider}\n") +
+                     (string.IsNullOrWhiteSpace(_runtime.Model) ? "" : $"nexo.model.name={_runtime.Model}\n");
 
         var msgs = input.Messages.ToList();
         for (var i = 0; i < msgs.Count; i++)

--- a/src/Nexo.Runtime/RuntimeServiceCollectionExtensions.cs
+++ b/src/Nexo.Runtime/RuntimeServiceCollectionExtensions.cs
@@ -20,6 +20,8 @@ namespace Nexo.Runtime;
 /// </summary>
 public static class RuntimeServiceCollectionExtensions
 {
+    private static readonly string[] DefaultBarrierLevels = ["public", "internal"];
+
     /// <summary>
     /// Registers routing transport composition using explicitly-provided local and remote transport types.
     /// Uses TryAdd so host applications can fully override registration.
@@ -47,7 +49,11 @@ public static class RuntimeServiceCollectionExtensions
         IConfiguration configuration)
     {
         services.AddOptions<BarrierOptions>()
-            .Configure(options => configuration.GetSection("Nexo:Barriers").Bind(options));
+            .Configure(options =>
+            {
+                configuration.GetSection("Nexo:Barriers").Bind(options);
+                EnsureBarrierLevels(options);
+            });
         services.AddOptions<RoutingOptions>()
             .Configure(options => configuration.GetSection("Nexo:Routing").Bind(options));
         services.AddBarrierAuditSinks(configuration);
@@ -66,6 +72,30 @@ public static class RuntimeServiceCollectionExtensions
         services.AddHostedService<EndpointHealthMonitor>();
 #endif
         return services;
+    }
+
+    private static void EnsureBarrierLevels(BarrierOptions options)
+    {
+        var levels = options.Levels;
+        if (levels is null)
+            return;
+
+        var normalized = levels
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        levels.Clear();
+        if (normalized.Length == 0)
+        {
+            foreach (var defaultLevel in DefaultBarrierLevels)
+                levels.Add(defaultLevel);
+            return;
+        }
+
+        foreach (var level in normalized)
+            levels.Add(level);
     }
 
     public static IServiceCollection AddBarrierAuditSinks(

--- a/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
@@ -15,6 +15,7 @@ public sealed class WorkflowCommandTests : UnitTestBase
             await TestHistoryReturnsExpectedSummaryAsync().ConfigureAwait(false);
             await TestStressRunsWithInjectedRequestAndPersistsHistoryAsync(cancellationToken).ConfigureAwait(false);
             await TestStressReturnsFailureWhenExecutorFailsAsync(cancellationToken).ConfigureAwait(false);
+            await TestReportGeneratesMarkdownBenchmarkOutputAsync(cancellationToken).ConfigureAwait(false);
             return new TestResult
             {
                 Name = nameof(WorkflowCommandTests),
@@ -265,6 +266,71 @@ public sealed class WorkflowCommandTests : UnitTestBase
                     cancellationToken)).ConfigureAwait(false);
             AssertEqual(1, exitCode);
             AssertTrue(output.Contains("\"ok\": false", StringComparison.OrdinalIgnoreCase), "Stress should fail when executor fails.");
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previousCurrent;
+            if (Directory.Exists(repoRoot))
+                Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private async Task TestReportGeneratesMarkdownBenchmarkOutputAsync(CancellationToken cancellationToken)
+    {
+        var repoRoot = CreateTempRepoRoot();
+        var previousCurrent = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = repoRoot;
+            WorkflowLabHistoryStore.Append(repoRoot, new WorkflowLabStressHistoryRow
+            {
+                ScenarioId = "request-a::composition-a::profile-a::iter-1",
+                RequestId = "request-a",
+                CompositionId = "composition-a",
+                ModelProfileId = "profile-a",
+                Iteration = 1,
+                Success = true,
+                Score = 91.1,
+                ElapsedMs = 120,
+                AgentCount = 2,
+                ConflictCount = 1,
+                EscalationCount = 0,
+                BenchmarkSet = "workflow-lab"
+            });
+            WorkflowLabHistoryStore.Append(repoRoot, new WorkflowLabStressHistoryRow
+            {
+                ScenarioId = "request-a::composition-a::profile-b::iter-1",
+                RequestId = "request-a",
+                CompositionId = "composition-a",
+                ModelProfileId = "profile-b",
+                Iteration = 1,
+                Success = false,
+                Score = 40.0,
+                ElapsedMs = 320,
+                AgentCount = 2,
+                ConflictCount = 2,
+                EscalationCount = 1,
+                BenchmarkSet = "workflow-lab"
+            });
+
+            var reportPath = Path.Combine(repoRoot, "workflow_report.md");
+            var command = CreateCommand();
+            var (exitCode, output) = await CaptureConsoleAsync(
+                () => command.ExecuteReportAsync(
+                    repoRoot,
+                    limit: 20,
+                    benchmarkSet: "workflow-lab",
+                    outputPath: reportPath,
+                    format: "md",
+                    json: true,
+                    cancellationToken)).ConfigureAwait(false);
+
+            AssertEqual(0, exitCode);
+            AssertTrue(output.Contains("\"bestConfiguration\"", StringComparison.OrdinalIgnoreCase), "Report output should include best configuration.");
+            AssertTrue(File.Exists(reportPath), "Markdown report file should be written.");
+            var markdown = await File.ReadAllTextAsync(reportPath, cancellationToken).ConfigureAwait(false);
+            AssertTrue(markdown.Contains("# Workflow Stress Benchmark Report", StringComparison.Ordinal));
+            AssertTrue(markdown.Contains("Best configuration", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
@@ -1,0 +1,276 @@
+using Nexo.CLI.Commands;
+using Nexo.CLI.Runtime;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+
+namespace Nexo.Tests.CLI.Tests.Commands;
+
+public sealed class WorkflowCommandTests : UnitTestBase
+{
+    public override async Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await TestScaffoldWritesSpecFileAsync().ConfigureAwait(false);
+            await TestHistoryReturnsExpectedSummaryAsync().ConfigureAwait(false);
+            await TestStressRunsWithInjectedRequestAndPersistsHistoryAsync(cancellationToken).ConfigureAwait(false);
+            await TestStressReturnsFailureWhenExecutorFailsAsync(cancellationToken).ConfigureAwait(false);
+            return new TestResult
+            {
+                Name = nameof(WorkflowCommandTests),
+                Category = "CLI",
+                Passed = true,
+                Message = "Workflow command tests passed"
+            };
+        }
+        catch (AssertionException ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(WorkflowCommandTests),
+                Category = "CLI",
+                Passed = false,
+                ErrorMessage = ex.Message,
+                StackTrace = ex.StackTrace
+            };
+        }
+        catch (Exception ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(WorkflowCommandTests),
+                Category = "CLI",
+                Passed = false,
+                ErrorMessage = ex.Message,
+                StackTrace = ex.StackTrace
+            };
+        }
+    }
+
+    private static WorkflowCommand CreateCommand(
+        Func<string, string, string?, bool, bool, CancellationToken, Task<WorkflowCommand.ScenarioExecutionResult>>? scenarioExecutor = null)
+    {
+        return new WorkflowCommand(scenarioExecutor ?? StubScenarioExecutorAsync);
+    }
+
+    private async Task TestScaffoldWritesSpecFileAsync()
+    {
+        var repoRoot = CreateTempRepoRoot();
+        try
+        {
+            var outputPath = Path.Combine(repoRoot, ".nexo", "workflow", "workflow_lab.runtime.json");
+            var command = CreateCommand();
+            var exitCode = await command.ExecuteScaffoldAsync(outputPath, force: false, json: true).ConfigureAwait(false);
+            AssertEqual(0, exitCode);
+            AssertTrue(File.Exists(outputPath), "Expected workflow scaffold file to be created.");
+
+            var content = await File.ReadAllTextAsync(outputPath).ConfigureAwait(false);
+            AssertTrue(content.Contains("\"compositions\"", StringComparison.OrdinalIgnoreCase), "Scaffold should include compositions.");
+            AssertTrue(content.Contains("\"modelProfiles\"", StringComparison.OrdinalIgnoreCase), "Scaffold should include model profiles.");
+        }
+        finally
+        {
+            if (Directory.Exists(repoRoot))
+                Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private async Task TestHistoryReturnsExpectedSummaryAsync()
+    {
+        var repoRoot = CreateTempRepoRoot();
+        try
+        {
+            WorkflowLabHistoryStore.Append(repoRoot, new WorkflowLabStressHistoryRow
+            {
+                ScenarioId = "request-a::composition-a::profile-a::iter-1",
+                RequestId = "request-a",
+                CompositionId = "composition-a",
+                ModelProfileId = "profile-a",
+                Iteration = 1,
+                Success = true,
+                Score = 103.5,
+                ElapsedMs = 128,
+                BenchmarkSet = "workflow-lab"
+            });
+            WorkflowLabHistoryStore.Append(repoRoot, new WorkflowLabStressHistoryRow
+            {
+                ScenarioId = "request-a::composition-a::profile-b::iter-1",
+                RequestId = "request-a",
+                CompositionId = "composition-a",
+                ModelProfileId = "profile-b",
+                Iteration = 1,
+                Success = false,
+                Score = 62.4,
+                ElapsedMs = 172,
+                BenchmarkSet = "workflow-lab"
+            });
+
+            var command = CreateCommand();
+            var (exitCode, output) = await CaptureConsoleAsync(
+                () => command.ExecuteHistoryAsync(repoRoot, limit: 10, benchmarkSet: "workflow-lab", json: true)).ConfigureAwait(false);
+            AssertEqual(0, exitCode);
+            AssertTrue(output.Contains("\"summaryStats\"", StringComparison.OrdinalIgnoreCase), "History output should include summary stats.");
+            AssertTrue(output.Contains("\"bestScenarioId\"", StringComparison.OrdinalIgnoreCase), "History output should include best scenario.");
+        }
+        finally
+        {
+            if (Directory.Exists(repoRoot))
+                Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private async Task TestStressRunsWithInjectedRequestAndPersistsHistoryAsync(CancellationToken cancellationToken)
+    {
+        var repoRoot = CreateTempRepoRoot();
+        var previousCurrent = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = repoRoot;
+            var runtimeSpecJson = """
+{
+  "execution": {
+    "iterations": 1,
+    "persistHistory": true,
+    "benchmarkSet": "workflow-lab"
+  },
+  "requests": [
+    { "id": "incident", "prompt": "Investigate issue and deliver mitigation plan." }
+  ],
+  "compositions": [
+    {
+      "id": "triage-squad",
+      "roles": [
+        { "agentId": "planner-1", "role": "planner", "domain": "coordination", "goal": "Plan execution", "clusterId": "core" },
+        { "agentId": "builder-1", "role": "builder", "domain": "engineering", "goal": "Implement fix", "reportsToAgentId": "planner-1", "commandChain": ["planner-1"] }
+      ]
+    }
+  ],
+  "modelProfiles": [
+    {
+      "id": "profile-a",
+      "default": { "prefer": "agentic", "provider": "ollama", "model": "llama3.1" },
+      "agents": {
+        "planner-1": { "prefer": "agentic", "provider": "ollama", "model": "qwen2.5:7b" },
+        "builder-1": { "prefer": "agentic", "provider": "ollama", "model": "codellama:13b" }
+      }
+    }
+  ]
+}
+""";
+
+            var command = CreateCommand();
+            var (exitCode, output) = await CaptureConsoleAsync(
+                () => command.ExecuteStressAsync(
+                    requestOverride: "Execute this objective using mandatory hierarchy.",
+                    specPath: null,
+                    specJson: runtimeSpecJson,
+                    providerOverride: null,
+                    preferOverride: null,
+                    iterationsOverride: null,
+                    benchmarkSetOverride: "hardware-lab",
+                    persistHistoryOverride: true,
+                    json: true,
+                    verbose: false,
+                    cancellationToken)).ConfigureAwait(false);
+            AssertEqual(0, exitCode);
+            AssertTrue(output.Contains("\"ok\": true", StringComparison.OrdinalIgnoreCase), "Stress output should report success.");
+            AssertTrue(output.Contains("\"aggregates\"", StringComparison.OrdinalIgnoreCase), "Stress output should include aggregate rankings.");
+
+            var historyRows = WorkflowLabHistoryStore.ReadRecent(repoRoot, 10);
+            AssertTrue(historyRows.Count >= 1, "Expected stress run to persist at least one history row.");
+            AssertEqual("hardware-lab", historyRows[0].BenchmarkSet);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previousCurrent;
+            if (Directory.Exists(repoRoot))
+                Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private static string CreateTempRepoRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nexo-workflow-command-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureConsoleAsync(Func<Task<int>> action)
+    {
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        using var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            Console.SetError(writer);
+            var exitCode = await action().ConfigureAwait(false);
+            return (exitCode, writer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+    }
+
+    private static Task<WorkflowCommand.ScenarioExecutionResult> StubScenarioExecutorAsync(
+        string request,
+        string runtimeSpecJson,
+        string? provider,
+        bool json,
+        bool verbose,
+        CancellationToken cancellationToken)
+    {
+        var isValid = !string.IsNullOrWhiteSpace(request) &&
+                      !string.IsNullOrWhiteSpace(runtimeSpecJson) &&
+                      json;
+        return Task.FromResult(
+            new WorkflowCommand.ScenarioExecutionResult(
+                isValid,
+                isValid ? "stub orchestrate success" : "stub orchestrate failure",
+                ConflictCount: 1,
+                EscalationCount: 1));
+    }
+
+    private async Task TestStressReturnsFailureWhenExecutorFailsAsync(CancellationToken cancellationToken)
+    {
+        var repoRoot = CreateTempRepoRoot();
+        var previousCurrent = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = repoRoot;
+            const string runtimeSpecJson = """
+{
+  "execution": { "iterations": 1, "persistHistory": false, "benchmarkSet": "workflow-lab" },
+  "requests": [ { "id": "request", "prompt": "Do thing" } ],
+  "compositions": [ { "id": "comp", "roles": [ { "agentId": "a1", "role": "builder", "goal": "do thing" } ] } ],
+  "modelProfiles": [ { "id": "profile", "default": { "prefer": "agentic", "provider": "ollama", "model": "llama3.1" } } ]
+}
+""";
+            var command = CreateCommand((_, _, _, _, _, _) =>
+                Task.FromResult(new WorkflowCommand.ScenarioExecutionResult(false, "forced failure", 0, 0)));
+            var (exitCode, output) = await CaptureConsoleAsync(
+                () => command.ExecuteStressAsync(
+                    requestOverride: null,
+                    specPath: null,
+                    specJson: runtimeSpecJson,
+                    providerOverride: null,
+                    preferOverride: null,
+                    iterationsOverride: null,
+                    benchmarkSetOverride: null,
+                    persistHistoryOverride: false,
+                    json: true,
+                    verbose: false,
+                    cancellationToken)).ConfigureAwait(false);
+            AssertEqual(1, exitCode);
+            AssertTrue(output.Contains("\"ok\": false", StringComparison.OrdinalIgnoreCase), "Stress should fail when executor fails.");
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previousCurrent;
+            if (Directory.Exists(repoRoot))
+                Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+}

--- a/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
@@ -51,7 +51,10 @@ public sealed class WorkflowCommandTests : UnitTestBase
     private static WorkflowCommand CreateCommand(
         Func<string, string, string?, bool, bool, CancellationToken, Task<WorkflowCommand.ScenarioExecutionResult>>? scenarioExecutor = null)
     {
-        return new WorkflowCommand(scenarioExecutor ?? StubScenarioExecutorAsync);
+        WorkflowCommand.ScenarioExecutor executor = scenarioExecutor is null
+            ? StubScenarioExecutorAsync
+            : new WorkflowCommand.ScenarioExecutor(scenarioExecutor);
+        return new WorkflowCommand(executor);
     }
 
     private async Task TestScaffoldWritesSpecFileAsync()
@@ -321,9 +324,7 @@ public sealed class WorkflowCommandTests : UnitTestBase
                     limit: 20,
                     benchmarkSet: "workflow-lab",
                     outputPath: reportPath,
-                    format: "md",
-                    json: true,
-                    cancellationToken)).ConfigureAwait(false);
+                    json: false)).ConfigureAwait(false);
 
             AssertEqual(0, exitCode);
             AssertTrue(output.Contains("\"bestConfiguration\"", StringComparison.OrdinalIgnoreCase), "Report output should include best configuration.");

--- a/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
@@ -327,11 +327,11 @@ public sealed class WorkflowCommandTests : UnitTestBase
                     json: false)).ConfigureAwait(false);
 
             AssertEqual(0, exitCode);
-            AssertTrue(output.Contains("\"bestConfiguration\"", StringComparison.OrdinalIgnoreCase), "Report output should include best configuration.");
+            AssertTrue(output.Contains("workflow report: ok", StringComparison.OrdinalIgnoreCase), "Report output should indicate success.");
             AssertTrue(File.Exists(reportPath), "Markdown report file should be written.");
             var markdown = await File.ReadAllTextAsync(reportPath, cancellationToken).ConfigureAwait(false);
             AssertTrue(markdown.Contains("# Workflow Stress Benchmark Report", StringComparison.Ordinal));
-            AssertTrue(markdown.Contains("Best configuration", StringComparison.OrdinalIgnoreCase));
+            AssertTrue(markdown.Contains("## Top Scenarios", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/src/Nexo.Tests.Infrastructure/Barriers/Runtime/RuntimeServiceCollectionExtensionsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Barriers/Runtime/RuntimeServiceCollectionExtensionsTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Nexo.Abstractions.Barriers;
+using Nexo.Runtime;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Barriers.Runtime;
+
+public sealed class RuntimeServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddNexoRuntimeRouting_NoBarrierLevelsConfigured_UsesSafeDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>());
+        services.AddNexoRuntimeRouting(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<BarrierOptions>>().Value;
+        var hierarchy = provider.GetRequiredService<BarrierHierarchy>();
+
+        options.Levels.Should().ContainInOrder("public", "internal");
+        hierarchy.Floor.Name.Should().Be("public");
+        hierarchy.Ceiling.Name.Should().Be("internal");
+    }
+
+    [Fact]
+    public void AddNexoRuntimeRouting_CustomBarrierLevelsConfigured_PreservesConfiguredValues()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Nexo:Barriers:Levels:0"] = "team",
+            ["Nexo:Barriers:Levels:1"] = "prod",
+            ["Nexo:Barriers:Levels:2"] = "secret"
+        });
+        services.AddNexoRuntimeRouting(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<BarrierOptions>>().Value;
+        var hierarchy = provider.GetRequiredService<BarrierHierarchy>();
+
+        options.Levels.Should().ContainInOrder("team", "prod", "secret");
+        hierarchy.Floor.Name.Should().Be("team");
+        hierarchy.Ceiling.Name.Should().Be("secret");
+    }
+
+    private static IConfiguration BuildConfiguration(IDictionary<string, string?> values)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/ProviderBackedModelDirectiveTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/ProviderBackedModelDirectiveTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.Abstractions;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+using Nexo.Infrastructure.Execution;
+using Nexo.Infrastructure.Execution.Models;
+
+namespace Nexo.Tests.Infrastructure.Tests.Execution;
+
+public sealed class ProviderBackedModelDirectiveTests : UnitTestBase
+{
+    public override async Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await TestProviderAndModelDirectivesAreForwardedAsync().ConfigureAwait(false);
+            return new TestResult
+            {
+                Name = nameof(ProviderBackedModelDirectiveTests),
+                Category = "Infrastructure",
+                Passed = true,
+                Message = "ProviderBackedModel directive tests passed"
+            };
+        }
+        catch (AssertionException ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(ProviderBackedModelDirectiveTests),
+                Category = "Infrastructure",
+                Passed = false,
+                ErrorMessage = ex.Message,
+                StackTrace = ex.StackTrace
+            };
+        }
+        catch (Exception ex)
+        {
+            return new TestResult
+            {
+                Name = nameof(ProviderBackedModelDirectiveTests),
+                Category = "Infrastructure",
+                Passed = false,
+                ErrorMessage = ex.Message,
+                StackTrace = ex.StackTrace
+            };
+        }
+    }
+
+    private async Task TestProviderAndModelDirectivesAreForwardedAsync()
+    {
+        var providerFactory = new CapturingProviderFactory();
+        var model = new ProviderBackedModel(providerFactory, NullLogger<ProviderBackedModel>.Instance);
+        var input = new ModelInput(new List<(string role, string content)>
+        {
+            ("system", "nexo.model.provider=ollama\nnexo.model.name=qwen2.5:7b\nSystem behavior"),
+            ("user", "Run task")
+        });
+
+        var output = await model.CompleteAsync(input, CancellationToken.None).ConfigureAwait(false);
+
+        AssertEqual("ok", output.Text);
+        AssertEqual("ollama", providerFactory.LastProvider);
+        AssertEqual("qwen2.5:7b", providerFactory.LastModel);
+        AssertTrue((providerFactory.LastSystemPrompt ?? string.Empty).Contains("System behavior", StringComparison.Ordinal));
+    }
+
+    private sealed class CapturingProviderFactory : IProviderFactory
+    {
+        public string? LastProvider { get; private set; }
+        public string? LastSystemPrompt { get; private set; }
+        public string? LastUserPrompt { get; private set; }
+        public string? LastModel { get; private set; }
+
+        public bool IsProviderAvailable(string provider) => true;
+
+        public Task<string> ExecuteLLMAsync(
+            string provider,
+            string systemPrompt,
+            string userPrompt,
+            object config,
+            CancellationToken cancellationToken = default)
+        {
+            LastProvider = provider;
+            LastSystemPrompt = systemPrompt;
+            LastUserPrompt = userPrompt;
+            LastModel = ReadModel(config);
+            return Task.FromResult("ok");
+        }
+
+        public Task<string> ExecuteVisionAsync(
+            string provider,
+            string systemPrompt,
+            string userPrompt,
+            byte[] imageBytes,
+            object config,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult("ok");
+
+        public Task<string> ExecuteVisionMultiFrameAsync(
+            string provider,
+            string systemPrompt,
+            string userPrompt,
+            IReadOnlyList<byte[]> frameBytes,
+            object config,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult("ok");
+
+        public Task<string> ExecuteVideoAsync(
+            string systemPrompt,
+            string userPrompt,
+            IReadOnlyList<byte[]> frameBytes,
+            object config,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult("ok");
+
+        public Task EnsureOllamaReachableAsync(bool requireVisionModel, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        private static string? ReadModel(object config)
+        {
+            var prop = config.GetType().GetProperty("model");
+            return prop?.GetValue(config) as string;
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/scripts/copy-assemblies.cs
+++ b/src/Nexo.Tests.Infrastructure/scripts/copy-assemblies.cs
@@ -90,12 +90,36 @@ foreach (var libProperty in runtime.EnumerateObject())
     
     // Collect runtime assembly paths from both "runtime" and "runtimeTargets".
     // On Windows RID-specific graphs, dependencies are often emitted in runtimeTargets.
-    var runtimeAssetPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    // IMPORTANT: Some packages (e.g. System.Text.Encodings.Web) list both lib/netX and
+    // runtimes/browser/... assets. Copying the browser build last overwrites the desktop DLL
+    // and breaks System.Text.Json (PlatformNotSupportedException in JsonSerializer .cctor).
+    var currentRid = System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier;
+    var candidatesByDll = new Dictionary<string, List<(string RelPath, int Priority)>>(StringComparer.OrdinalIgnoreCase);
+
+    void AddCandidate(string relPath, int priority)
+    {
+        if (!relPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            return;
+        // Never ship browser/wasm builds into desktop test output.
+        if (relPath.Contains("/runtimes/browser/", StringComparison.OrdinalIgnoreCase) ||
+            relPath.Contains("\\runtimes\\browser\\", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var dllName = Path.GetFileName(relPath);
+        if (!candidatesByDll.TryGetValue(dllName, out var list))
+        {
+            list = new List<(string, int)>();
+            candidatesByDll[dllName] = list;
+        }
+        list.Add((relPath, priority));
+    }
+
     if (libProperty.Value.TryGetProperty("runtime", out var runtimePaths))
     {
         foreach (var runtimePathProperty in runtimePaths.EnumerateObject())
-            runtimeAssetPaths.Add(runtimePathProperty.Name);
+            AddCandidate(runtimePathProperty.Name, priority: 0); // lib/ assets win over RID-specific
     }
+
     if (libProperty.Value.TryGetProperty("runtimeTargets", out var runtimeTargets))
     {
         foreach (var runtimeTargetProperty in runtimeTargets.EnumerateObject())
@@ -104,40 +128,41 @@ foreach (var libProperty in runtime.EnumerateObject())
                 !string.Equals(assetType.GetString(), "runtime", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            runtimeAssetPaths.Add(runtimeTargetProperty.Name);
+            var relPath = runtimeTargetProperty.Name;
+            if (runtimeTargetProperty.Value.TryGetProperty("rid", out var ridEl))
+            {
+                var rid = ridEl.GetString() ?? "";
+                if (string.Equals(rid, "browser", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!string.Equals(rid, currentRid, StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
+
+            AddCandidate(relPath, priority: 1);
         }
     }
 
-    // Process each runtime path
-    foreach (var path in runtimeAssetPaths)
+    foreach (var kv in candidatesByDll)
     {
-        // Only process .dll files
-        if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        var best = kv.Value.OrderBy(t => t.Priority).ThenBy(t => t.RelPath, StringComparer.OrdinalIgnoreCase).First();
+        var relPath = best.RelPath;
+        var libPath = relPath.Replace('/', Path.DirectorySeparatorChar);
+        var sourcePath = Path.Combine(nugetRoot, pkgNameLower, pkgVersion, libPath);
+        var destPath = Path.Combine(outputDir, kv.Key);
+
+        if (!File.Exists(sourcePath))
             continue;
 
-        // Build source path - normalize path separators
-        var libPath = path.Replace('/', Path.DirectorySeparatorChar);
-        var sourcePath = Path.Combine(nugetRoot, pkgNameLower, pkgVersion, libPath);
-
-        // Build destination path
-        var dllName = Path.GetFileName(path);
-        var destPath = Path.Combine(outputDir, dllName);
-
-        // Copy if source exists
-        if (File.Exists(sourcePath))
+        try
         {
-            try
-            {
-                File.Copy(sourcePath, destPath, overwrite: true);
-                copied++;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Failed to copy {sourcePath}: {ex.Message}");
-                failed++;
-            }
+            File.Copy(sourcePath, destPath, overwrite: true);
+            copied++;
         }
-        // Don't fail on missing assemblies - some might be in different locations
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to copy {sourcePath}: {ex.Message}");
+            failed++;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- adds a first-class `workflow report` subcommand to generate benchmark summaries from stress history
- computes aggregate benchmark metrics (`success rate`, `avg/p95 latency`, `avg score`, conflict/escalation averages) plus ranked top scenarios and bottlenecks
- supports writing report files in `.md`, `.txt`, or `.json` based on output extension while preserving `--json` console output
- extends `WorkflowCommandTests` with benchmark report coverage and aligns assertions with the new benchmark output schema

## Validation
- `dotnet build /workspace/src/Nexo.CLI/Nexo.CLI.csproj -m:1`
- `dotnet build /workspace/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj -m:1`
- `dotnet run --project /workspace/src/Nexo.CLI -- workflow stress --spec /tmp/workflow_lab.runtime.json --iterations 1 --persist-history true --json`
- `dotnet run --project /workspace/src/Nexo.CLI -- workflow report --repo-root /workspace --limit 60 --benchmark-set workflow-lab --output /opt/cursor/artifacts/workflow_benchmark_report.md --json`

## Walkthrough artifacts
- Benchmark markdown report artifact:
  [workflow_benchmark_report.md](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow_benchmark_report.md)
- CLI build log:
  [workflow_benchmark_build_cli.log](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow_benchmark_build_cli.log)
- CLI tests build log:
  [workflow_benchmark_build_tests.log](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow_benchmark_build_tests.log)
- stress execution log:
  [workflow_benchmark_stress.log](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow_benchmark_stress.log)
- report command log:
  [workflow_benchmark_report_cmd.log](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow_benchmark_report_cmd.log)

## Notes
- stress runs in this cloud environment currently fail due to missing barrier-level runtime configuration (`At least one barrier level must be defined`). this is captured as structured failure data in benchmark output so reporting remains useful for diagnostics.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0eeca6e-19a6-46c8-8490-c245b4c20194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

