### PR TITLE
Harden workflow benchmark reliability and failure taxonomy

### DIFF
--- a/src/Nexo.CLI/Commands/WorkflowCommand.cs
+++ b/src/Nexo.CLI/Commands/WorkflowCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Nexo.CLI.Runtime;
 using Nexo.Orchestration.Models;
 
@@ -27,6 +28,16 @@ public sealed class WorkflowCommand : Command
         : this(async (request, runtimeSpecJson, provider, outputJson, verbose, ct) =>
         {
             var orchestrate = orchestrateFactory();
+            return await ExecuteScenarioAsync(orchestrate, request, runtimeSpecJson, provider, outputJson, verbose, ct).ConfigureAwait(false);
+        })
+    {
+    }
+
+    public WorkflowCommand(Func<IServiceScope> orchestrationScopeFactory)
+        : this(async (request, runtimeSpecJson, provider, outputJson, verbose, ct) =>
+        {
+            using var scope = orchestrationScopeFactory();
+            var orchestrate = scope.ServiceProvider.GetRequiredService<OrchestrateCommand>();
             return await ExecuteScenarioAsync(orchestrate, request, runtimeSpecJson, provider, outputJson, verbose, ct).ConfigureAwait(false);
         })
     {
@@ -263,7 +274,8 @@ public sealed class WorkflowCommand : Command
                     0d,
                     0d,
                     Array.Empty<WorkflowScenarioBenchmark>(),
-                    Array.Empty<WorkflowScenarioBenchmark>())), json);
+                    Array.Empty<WorkflowScenarioBenchmark>(),
+                    Array.Empty<WorkflowFailureCategoryStat>())), json);
             return Task.FromResult(1);
         }
 
@@ -375,7 +387,8 @@ public sealed class WorkflowCommand : Command
                                 Ok: false,
                                 Summary: $"Scenario executor failed: {ex.Message}",
                                 ConflictCount: 0,
-                                EscalationCount: 0);
+                                EscalationCount: 0,
+                                FailureCategory: "executor_failure");
                         }
                         var elapsedMs = sw.ElapsedMilliseconds;
                         var score = ComputeScore(scenario.Ok, elapsedMs, composition, profile);
@@ -392,6 +405,7 @@ public sealed class WorkflowCommand : Command
                             elapsedMs,
                             score,
                             scenario.Summary,
+                            scenario.FailureCategory,
                             startedAt,
                             benchmarkSet));
                     }
@@ -444,6 +458,7 @@ public sealed class WorkflowCommand : Command
                         EscalationCount = run.EscalationCount,
                         Score = run.Score,
                         Summary = run.Summary,
+                        FailureCategory = run.FailureCategory,
                         BenchmarkSet = run.BenchmarkSet
                     });
             }
@@ -500,7 +515,7 @@ public sealed class WorkflowCommand : Command
         bool verbose,
         CancellationToken ct)
     {
-        var (stdOut, stdErr) = await CaptureConsoleAsync(
+        var (exitCode, stdOut, stdErr) = await CaptureConsoleAsync(
             () => orchestrate.ExecuteAsync(
                 request,
                 runtimeSpecPath: null,
@@ -518,21 +533,34 @@ public sealed class WorkflowCommand : Command
         var parsed = TryParseOrchestratePayload(combined);
         if (parsed is null)
         {
+            var category = ClassifyFailureCategory(combined);
             return new ScenarioExecutionResult(
                 false,
                 "Scenario failed: orchestrate output did not contain JSON payload.",
                 0,
-                0);
+                0,
+                category);
+        }
+
+        var failureCategory = parsed.Ok
+            ? "none"
+            : ClassifyFailureCategory(combined, parsed.ErrorCode);
+
+        var summary = parsed.Summary;
+        if (!parsed.Ok && exitCode != 0 && !summary.Contains("errorCode", StringComparison.OrdinalIgnoreCase))
+        {
+            summary = $"{summary} (exitCode={exitCode})";
         }
 
         return new ScenarioExecutionResult(
             parsed.Ok,
-            parsed.Summary,
+            summary,
             parsed.ConflictCount,
-            parsed.EscalationCount);
+            parsed.EscalationCount,
+            failureCategory);
     }
 
-    private static async Task<(string StdOut, string StdErr)> CaptureConsoleAsync(
+    private static async Task<(int ExitCode, string StdOut, string StdErr)> CaptureConsoleAsync(
         Func<Task<int>> run,
         CancellationToken ct)
     {
@@ -545,15 +573,14 @@ public sealed class WorkflowCommand : Command
         {
             Console.SetOut(outWriter);
             Console.SetError(errWriter);
-            await run().ConfigureAwait(false);
+            var exitCode = await run().ConfigureAwait(false);
+            return (exitCode, outWriter.ToString(), errWriter.ToString());
         }
         finally
         {
             Console.SetOut(originalOut);
             Console.SetError(originalErr);
         }
-
-        return (outWriter.ToString(), errWriter.ToString());
     }
 
     private static ParsedOrchestratePayload? TryParseOrchestratePayload(string output)
@@ -571,13 +598,24 @@ public sealed class WorkflowCommand : Command
                 var root = doc.RootElement;
                 var ok = root.TryGetProperty("ok", out var okNode) && okNode.ValueKind == JsonValueKind.True;
                 if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
-                    return new ParsedOrchestratePayload(ok, "Orchestrate response missing data payload.", 0, 0);
+                {
+                    var errorCode = root.TryGetProperty("errorCode", out var errorCodeNode)
+                        ? errorCodeNode.GetString()
+                        : null;
+                    var error = root.TryGetProperty("error", out var errorNode)
+                        ? errorNode.GetString()
+                        : null;
+                    var fallbackSummary = string.IsNullOrWhiteSpace(errorCode)
+                        ? "Orchestrate response missing data payload."
+                        : $"Orchestration failed with errorCode={errorCode}: {error ?? "no error details"}";
+                    return new ParsedOrchestratePayload(ok, fallbackSummary, 0, 0, errorCode);
+                }
                 var summary = data.TryGetProperty("success", out var successNode) && successNode.ValueKind == JsonValueKind.True
                     ? "Orchestration run completed successfully."
                     : "Orchestration reported failure.";
                 var conflictCount = data.TryGetProperty("conflicts", out var conflictsNode) ? conflictsNode.GetInt32() : 0;
                 var escalationCount = data.TryGetProperty("escalations", out var escalationsNode) ? escalationsNode.GetInt32() : 0;
-                return new ParsedOrchestratePayload(ok, summary, conflictCount, escalationCount);
+                return new ParsedOrchestratePayload(ok, summary, conflictCount, escalationCount, null);
             }
             catch
             {
@@ -586,6 +624,29 @@ public sealed class WorkflowCommand : Command
         }
 
         return null;
+    }
+
+    private static string ClassifyFailureCategory(string output, string? parsedErrorCode = null)
+    {
+        if (!string.IsNullOrWhiteSpace(parsedErrorCode))
+        {
+            if (parsedErrorCode.Contains("BARRIER", StringComparison.OrdinalIgnoreCase))
+                return "runtime_context_failure";
+            if (parsedErrorCode.Contains("ENDPOINT", StringComparison.OrdinalIgnoreCase))
+                return "infra_unavailable";
+        }
+
+        var text = output ?? string.Empty;
+        if (text.Contains("BarrierContext has already been initialized", StringComparison.OrdinalIgnoreCase))
+            return "runtime_context_failure";
+        if (text.Contains("At least one barrier level must be defined", StringComparison.OrdinalIgnoreCase))
+            return "runtime_context_failure";
+        if (text.Contains("Connection refused", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("Could not list Ollama models", StringComparison.OrdinalIgnoreCase))
+            return "infra_unavailable";
+        if (text.Contains("Orchestrate response missing data payload", StringComparison.OrdinalIgnoreCase))
+            return "orchestration_failure";
+        return "model_execution_failure";
     }
 
     private static OrchestrationRuntimeSpec BuildRuntimeSpec(
@@ -740,6 +801,17 @@ public sealed class WorkflowCommand : Command
         var avgScore = totalRuns == 0 ? 0d : Math.Round(items.Select(x => x.Score).DefaultIfEmpty(0d).Average(), 3);
         var avgConflicts = totalRuns == 0 ? 0d : Math.Round(items.Select(x => (double)x.ConflictCount).DefaultIfEmpty(0d).Average(), 3);
         var avgEscalations = totalRuns == 0 ? 0d : Math.Round(items.Select(x => (double)x.EscalationCount).DefaultIfEmpty(0d).Average(), 3);
+        var failuresByCategory = items
+            .Where(x => !x.Success)
+            .GroupBy(
+                x => string.IsNullOrWhiteSpace(x.FailureCategory) || string.Equals(x.FailureCategory, "none", StringComparison.OrdinalIgnoreCase)
+                    ? ClassifyFailureCategory(x.Summary ?? string.Empty)
+                    : x.FailureCategory!,
+                StringComparer.OrdinalIgnoreCase)
+            .Select(g => new WorkflowFailureCategoryStat(g.Key, g.Count()))
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Category, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         var scenarioStats = items
             .GroupBy(x => $"{x.RequestId}::{x.CompositionId}::{x.ModelProfileId}", StringComparer.OrdinalIgnoreCase)
@@ -791,7 +863,8 @@ public sealed class WorkflowCommand : Command
             AverageConflicts: avgConflicts,
             AverageEscalations: avgEscalations,
             TopScenarios: topScenarios,
-            Bottlenecks: bottlenecks);
+            Bottlenecks: bottlenecks,
+            FailureCategories: failuresByCategory);
     }
 
     private static long ComputePercentile(IEnumerable<long> source, double percentile)
@@ -859,6 +932,12 @@ public sealed class WorkflowCommand : Command
         sb.AppendLine($"- Avg conflicts: {report.AverageConflicts:F2}");
         sb.AppendLine($"- Avg escalations: {report.AverageEscalations:F2}");
         sb.AppendLine();
+        sb.AppendLine("## Failure Categories");
+        foreach (var category in report.FailureCategories)
+        {
+            sb.AppendLine($"- `{category.Category}`: {category.Count}");
+        }
+        sb.AppendLine();
         sb.AppendLine("## Top Scenarios");
         foreach (var scenario in report.TopScenarios)
         {
@@ -888,6 +967,12 @@ public sealed class WorkflowCommand : Command
         sb.AppendLine($"Average score: {report.AverageScore:F2}");
         sb.AppendLine($"Average conflicts: {report.AverageConflicts:F2}");
         sb.AppendLine($"Average escalations: {report.AverageEscalations:F2}");
+        sb.AppendLine();
+        sb.AppendLine("Failure categories:");
+        foreach (var category in report.FailureCategories)
+        {
+            sb.AppendLine($"- {category.Category}: {category.Count}");
+        }
         sb.AppendLine();
         sb.AppendLine("Top scenarios:");
         foreach (var scenario in report.TopScenarios)
@@ -1038,6 +1123,7 @@ public sealed class WorkflowCommand : Command
         long ElapsedMs,
         double Score,
         string Summary,
+        string FailureCategory,
         DateTimeOffset StartedAtUtc,
         string BenchmarkSet);
 
@@ -1089,6 +1175,10 @@ public sealed class WorkflowCommand : Command
         public string? LastFailureSummary { get; init; }
     }
 
+    private sealed record WorkflowFailureCategoryStat(
+        string Category,
+        int Count);
+
     private sealed record WorkflowBenchmarkReport(
         DateTimeOffset GeneratedAtUtc,
         int TotalRuns,
@@ -1101,7 +1191,8 @@ public sealed class WorkflowCommand : Command
         double AverageConflicts,
         double AverageEscalations,
         IReadOnlyList<WorkflowScenarioBenchmark> TopScenarios,
-        IReadOnlyList<WorkflowScenarioBenchmark> Bottlenecks);
+        IReadOnlyList<WorkflowScenarioBenchmark> Bottlenecks,
+        IReadOnlyList<WorkflowFailureCategoryStat> FailureCategories);
 
     private sealed record WorkflowReportResult(
         bool Ok,
@@ -1113,11 +1204,13 @@ public sealed class WorkflowCommand : Command
         bool Ok,
         string Summary,
         int ConflictCount,
-        int EscalationCount);
+        int EscalationCount,
+        string FailureCategory = "none");
 
     private sealed record ParsedOrchestratePayload(
         bool Ok,
         string Summary,
         int ConflictCount,
-        int EscalationCount);
+        int EscalationCount,
+        string? ErrorCode = null);
 }

--- a/src/Nexo.CLI/Program.cs
+++ b/src/Nexo.CLI/Program.cs
@@ -1118,7 +1118,7 @@ static class Program
         root.AddCommand(new BootstrapCommand());
         root.AddCommand(new DoctorCommand());
         root.AddCommand(new RuntimeCommand());
-        root.AddCommand(new WorkflowCommand(() => ServiceProvider.GetRequiredService<OrchestrateCommand>()));
+        root.AddCommand(new WorkflowCommand(() => ServiceProvider.CreateScope()));
         root.AddCommand(new ChatCommand(() => ServiceProvider.GetRequiredService<OrchestrateCommand>()));
         root.AddCommand(new SelfExtendCommand(
             () => ServiceProvider.GetRequiredService<Nexo.BackgroundAgents.HostRunners.SelfExtendRunnerAdapter>()));

--- a/src/Nexo.CLI/Runtime/WorkflowLabHistoryStore.cs
+++ b/src/Nexo.CLI/Runtime/WorkflowLabHistoryStore.cs
@@ -17,6 +17,7 @@ public sealed record WorkflowLabStressHistoryRow
     public int EscalationCount { get; init; }
     public double Score { get; init; }
     public string? Summary { get; init; }
+    public string FailureCategory { get; init; } = "none";
     public string BenchmarkSet { get; init; } = "workflow-lab";
 }
 

--- a/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
@@ -183,6 +183,7 @@ public sealed class WorkflowCommandTests : UnitTestBase
             var historyRows = WorkflowLabHistoryStore.ReadRecent(repoRoot, 10);
             AssertTrue(historyRows.Count >= 1, "Expected stress run to persist at least one history row.");
             AssertEqual("hardware-lab", historyRows[0].BenchmarkSet);
+            AssertEqual("none", historyRows[0].FailureCategory);
         }
         finally
         {
@@ -269,6 +270,7 @@ public sealed class WorkflowCommandTests : UnitTestBase
                     cancellationToken)).ConfigureAwait(false);
             AssertEqual(1, exitCode);
             AssertTrue(output.Contains("\"ok\": false", StringComparison.OrdinalIgnoreCase), "Stress should fail when executor fails.");
+            AssertTrue(output.Contains("\"failureCategory\": \"executor_failure\"", StringComparison.OrdinalIgnoreCase), "Stress should classify executor failures.");
         }
         finally
         {
@@ -313,6 +315,7 @@ public sealed class WorkflowCommandTests : UnitTestBase
                 AgentCount = 2,
                 ConflictCount = 2,
                 EscalationCount = 1,
+                FailureCategory = "orchestration_failure",
                 BenchmarkSet = "workflow-lab"
             });
 
@@ -332,6 +335,62 @@ public sealed class WorkflowCommandTests : UnitTestBase
             var markdown = await File.ReadAllTextAsync(reportPath, cancellationToken).ConfigureAwait(false);
             AssertTrue(markdown.Contains("# Workflow Stress Benchmark Report", StringComparison.Ordinal));
             AssertTrue(markdown.Contains("## Top Scenarios", StringComparison.OrdinalIgnoreCase));
+            AssertTrue(markdown.Contains("## Failure Categories", StringComparison.OrdinalIgnoreCase));
+            AssertTrue(markdown.Contains("orchestration_failure", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previousCurrent;
+            if (Directory.Exists(repoRoot))
+                Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private async Task TestStressClassifiesRuntimeContextFailureFromErrorCodeAsync(CancellationToken cancellationToken)
+    {
+        var repoRoot = CreateTempRepoRoot();
+        var previousCurrent = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = repoRoot;
+            const string runtimeSpecJson = """
+{
+  "execution": { "iterations": 1, "persistHistory": true, "benchmarkSet": "workflow-lab" },
+  "requests": [ { "id": "request", "prompt": "Do thing" } ],
+  "compositions": [ { "id": "comp", "roles": [ { "agentId": "a1", "role": "builder", "goal": "do thing" } ] } ],
+  "modelProfiles": [ { "id": "profile", "default": { "prefer": "agentic", "provider": "ollama", "model": "llama3.1" } } ]
+}
+""";
+            var command = CreateCommand((_, _, _, _, _, _) =>
+            {
+                Console.WriteLine("""
+{
+  "ok": false,
+  "errorCode": "BARRIER_VALIDATION_FAILED",
+  "error": "barrier context rejected"
+}
+""");
+                return Task.FromResult(new WorkflowCommand.ScenarioExecutionResult(false, "forced failure", 0, 0, "model_execution_failure"));
+            });
+            var (exitCode, output) = await CaptureConsoleAsync(
+                () => command.ExecuteStressAsync(
+                    requestOverride: null,
+                    specPath: null,
+                    specJson: runtimeSpecJson,
+                    providerOverride: null,
+                    preferOverride: null,
+                    iterationsOverride: null,
+                    benchmarkSetOverride: null,
+                    persistHistoryOverride: true,
+                    json: true,
+                    verbose: false,
+                    cancellationToken)).ConfigureAwait(false);
+            AssertEqual(1, exitCode);
+            AssertTrue(output.Contains("\"failureCategory\": \"runtime_context_failure\"", StringComparison.OrdinalIgnoreCase), "Barrier errors should classify as runtime context failures.");
+
+            var historyRows = WorkflowLabHistoryStore.ReadRecent(repoRoot, 5);
+            AssertTrue(historyRows.Count >= 1, "Expected failure row to be persisted.");
+            AssertEqual("runtime_context_failure", historyRows[0].FailureCategory);
         }
         finally
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- ensures each workflow stress scenario runs with a fresh orchestration DI scope so request-scoped barrier context does not leak between scenarios
- enriches scenario execution parsing to consume orchestrate `errorCode` payloads and classify failures into actionable categories (`runtime_context_failure`, `infra_unavailable`, `orchestration_failure`, `model_execution_failure`, `executor_failure`)
- persists `FailureCategory` in workflow stress history rows and includes failure-category aggregation in benchmark report output (json/txt/markdown)
- updates workflow command tests to assert failure-category persistence and report rendering for category sections

## Validation
- `dotnet build /workspace/src/Nexo.CLI/Nexo.CLI.csproj -m:1`
- `dotnet build /workspace/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj -m:1`
- `dotnet test /workspace/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --filter FullyQualifiedName~RuntimeServiceCollectionExtensionsTests --framework net8.0 -m:1`
- `dotnet run --project /workspace/src/Nexo.CLI -- workflow stress --spec /tmp/workflow_lab.runtime.json --iterations 1 --persist-history true --json`
- `dotnet run --project /workspace/src/Nexo.CLI -- workflow report --repo-root /workspace --limit 80 --benchmark-set workflow-lab --output /opt/cursor/artifacts/phase2_workflow_report.md --json`

## Artifacts
- Stress run after scope isolation:
  [phase2_workflow_stress.log](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_workflow_stress.log)
- Updated benchmark report with failure categories:
  [phase2_workflow_report.md](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_workflow_report.md)
- Report command JSON output:
  [phase2_workflow_report_cmd.log](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_workflow_report_cmd.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0eeca6e-19a6-46c8-8490-c245b4c20194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

