### PR TITLE
Phase 3: benchmark fidelity, sessionization, and decision reporting

### DIFF
--- a/src/Nexo.CLI/Commands/OrchestrateCommand.cs
+++ b/src/Nexo.CLI/Commands/OrchestrateCommand.cs
@@ -27,6 +27,16 @@ namespace Nexo.CLI.Commands;
 /// </summary>
 public class OrchestrateCommand
 {
+    public sealed record StructuredOrchestrationResult(
+        bool Ok,
+        string CorrelationId,
+        string? Error,
+        string? ErrorCode,
+        bool? Success = null,
+        int? AgentCount = null,
+        int? Conflicts = null,
+        int? Escalations = null);
+
     private readonly Orchestrator _orchestrator;
     private readonly IConsoleRenderer _renderer;
     private readonly ILogger<OrchestrateCommand> _logger;
@@ -82,6 +92,99 @@ public class OrchestrateCommand
             preferredRegion: null,
             json,
             verbose);
+
+    public async Task<StructuredOrchestrationResult> ExecuteStructuredAsync(
+        string request,
+        string? runtimeSpecPath,
+        string? runtimeSpecJson,
+        string? preferModel,
+        string? provider,
+        string? barrierLevel,
+        string? preferredRegion,
+        CancellationToken cancellationToken,
+        string? jwt = null,
+        IReadOnlyDictionary<string, string>? headers = null)
+    {
+        var correlationId = Guid.NewGuid().ToString();
+        using var scope = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId
+        });
+
+        try
+        {
+            var spec = OrchestrationRuntimeSpecLoader.Load(runtimeSpecPath, runtimeSpecJson);
+            if (!string.IsNullOrWhiteSpace(preferModel))
+            {
+                spec = spec with { Model = spec.Model with { Prefer = preferModel!.Trim() } };
+            }
+            if (!string.IsNullOrWhiteSpace(provider))
+            {
+                spec = spec with { Model = spec.Model with { Provider = provider!.Trim() } };
+            }
+            if (!string.IsNullOrWhiteSpace(barrierLevel))
+            {
+                spec = spec with { BarrierLevel = barrierLevel.Trim() };
+            }
+            if (!string.IsNullOrWhiteSpace(preferredRegion))
+            {
+                spec = spec with { PreferredRegion = preferredRegion.Trim() };
+            }
+
+            await InitializeBarrierContextAsync(
+                barrierLevel: spec.BarrierLevel,
+                jwt: jwt,
+                headers: headers,
+                correlationId: correlationId,
+                cancellationToken: cancellationToken);
+
+            var modelPrefer = spec.Model?.Prefer;
+            OrchestrationResult result;
+            if (_ephemeralLifecycle != null)
+            {
+                await using var session = await _ephemeralLifecycle.StartSessionAsync(modelPrefer);
+                using var _ = _runtime.Begin(spec);
+                result = await _orchestrator.OrchestrateAsync(request);
+            }
+            else
+            {
+                using var _ = _runtime.Begin(spec);
+                result = await _orchestrator.OrchestrateAsync(request);
+            }
+
+            return new StructuredOrchestrationResult(
+                Ok: result.Success,
+                CorrelationId: correlationId,
+                Error: null,
+                ErrorCode: null,
+                Success: result.Success,
+                AgentCount: result.Decomposition?.Agents.Count ?? 0,
+                Conflicts: result.Conflicts.Count,
+                Escalations: result.Escalations.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Orchestration failed");
+            var errorCode = ex switch
+            {
+                BarrierContextMissingException b => b.ErrorCode,
+                BarrierElevationException b => b.ErrorCode,
+                BarrierCeilingExceededException b => b.ErrorCode,
+                ArgumentException a when string.Equals(a.ParamName, "level", StringComparison.Ordinal) => "BARRIER_VALIDATION_FAILED",
+                EndpointUnavailableException => "ENDPOINT_UNAVAILABLE",
+                _ => "UNEXPECTED_ERROR"
+            };
+            return new StructuredOrchestrationResult(
+                Ok: false,
+                CorrelationId: correlationId,
+                Error: ex.Message,
+                ErrorCode: errorCode,
+                Success: false,
+                AgentCount: 0,
+                Conflicts: 0,
+                Escalations: 0);
+        }
+    }
 
     public async Task<int> ExecuteAsync(
         string request,

--- a/src/Nexo.CLI/Commands/WorkflowCommand.cs
+++ b/src/Nexo.CLI/Commands/WorkflowCommand.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Nexo.CLI.Runtime;
+using Nexo.Infrastructure.Execution;
 using Nexo.Orchestration.Models;
 
 namespace Nexo.CLI.Commands;
@@ -23,30 +24,50 @@ public sealed class WorkflowCommand : Command
         CancellationToken cancellationToken);
 
     private readonly ScenarioExecutor _scenarioExecutor;
+    private readonly Func<string, CancellationToken, Task<PreflightResult>> _providerPreflight;
 
     public WorkflowCommand(Func<OrchestrateCommand> orchestrateFactory)
-        : this(async (request, runtimeSpecJson, provider, outputJson, verbose, ct) =>
-        {
-            var orchestrate = orchestrateFactory();
-            return await ExecuteScenarioAsync(orchestrate, request, runtimeSpecJson, provider, outputJson, verbose, ct).ConfigureAwait(false);
-        })
+        : this(
+            async (request, runtimeSpecJson, provider, outputJson, verbose, ct) =>
+            {
+                var orchestrate = orchestrateFactory();
+                return await ExecuteScenarioAsync(orchestrate, request, runtimeSpecJson, provider, outputJson, verbose, ct).ConfigureAwait(false);
+            },
+            (provider, ct) => PreflightProviderAsync(provider, ct))
     {
     }
 
     public WorkflowCommand(Func<IServiceScope> orchestrationScopeFactory)
-        : this(async (request, runtimeSpecJson, provider, outputJson, verbose, ct) =>
-        {
-            using var scope = orchestrationScopeFactory();
-            var orchestrate = scope.ServiceProvider.GetRequiredService<OrchestrateCommand>();
-            return await ExecuteScenarioAsync(orchestrate, request, runtimeSpecJson, provider, outputJson, verbose, ct).ConfigureAwait(false);
-        })
+        : this(
+            async (request, runtimeSpecJson, provider, outputJson, verbose, ct) =>
+            {
+                using var scope = orchestrationScopeFactory();
+                var orchestrate = scope.ServiceProvider.GetRequiredService<OrchestrateCommand>();
+                return await ExecuteScenarioAsync(orchestrate, request, runtimeSpecJson, provider, outputJson, verbose, ct).ConfigureAwait(false);
+            },
+            async (provider, ct) =>
+            {
+                using var scope = orchestrationScopeFactory();
+                return await PreflightProviderAsync(
+                    provider,
+                    ct,
+                    scope.ServiceProvider.GetService<IProviderFactory>()).ConfigureAwait(false);
+            })
     {
     }
 
     internal WorkflowCommand(ScenarioExecutor scenarioExecutor)
+        : this(scenarioExecutor, (provider, ct) => PreflightProviderAsync(provider, ct))
+    {
+    }
+
+    private WorkflowCommand(
+        ScenarioExecutor scenarioExecutor,
+        Func<string, CancellationToken, Task<PreflightResult>> providerPreflight)
         : base("workflow", "Scaffold and stress-test agentic workflow compositions.")
     {
         _scenarioExecutor = scenarioExecutor ?? throw new ArgumentNullException(nameof(scenarioExecutor));
+        _providerPreflight = providerPreflight ?? throw new ArgumentNullException(nameof(providerPreflight));
         ConfigureScaffoldCommand();
         ConfigureStressCommand();
         ConfigureHistoryCommand();
@@ -169,11 +190,15 @@ public sealed class WorkflowCommand : Command
         var repoRootOpt = new Option<string>("--repo-root", () => Environment.CurrentDirectory, "Repository root path.");
         var limitOpt = new Option<int>("--limit", () => 200, "Maximum history entries to analyze.");
         var benchmarkSetOpt = new Option<string?>("--benchmark-set", () => null, "Optional benchmark-set filter.");
+        var runIdOpt = new Option<string?>("--run-id", () => null, "Optional run-id filter for a single benchmark session.");
+        var sinceOpt = new Option<string?>("--since", () => null, "Optional ISO-8601 UTC timestamp filter (e.g. 2026-04-11T00:00:00Z).");
         var outputOpt = new Option<string?>("--output", () => null, "Optional report output file path (.json, .md, .txt).");
         var jsonOpt = new Option<bool>("--json", () => false, "Emit machine-readable JSON output.");
         report.AddOption(repoRootOpt);
         report.AddOption(limitOpt);
         report.AddOption(benchmarkSetOpt);
+        report.AddOption(runIdOpt);
+        report.AddOption(sinceOpt);
         report.AddOption(outputOpt);
         report.AddOption(jsonOpt);
         report.SetHandler((InvocationContext ctx) =>
@@ -182,6 +207,8 @@ public sealed class WorkflowCommand : Command
                 ctx.ParseResult.GetValueForOption(repoRootOpt) ?? Environment.CurrentDirectory,
                 ctx.ParseResult.GetValueForOption(limitOpt),
                 ctx.ParseResult.GetValueForOption(benchmarkSetOpt),
+                ctx.ParseResult.GetValueForOption(runIdOpt),
+                ctx.ParseResult.GetValueForOption(sinceOpt),
                 ctx.ParseResult.GetValueForOption(outputOpt),
                 ctx.ParseResult.GetValueForOption(jsonOpt)).GetAwaiter().GetResult();
             ctx.ExitCode = exitCode;
@@ -253,6 +280,8 @@ public sealed class WorkflowCommand : Command
         string repoRoot,
         int limit,
         string? benchmarkSet,
+        string? runId,
+        string? since,
         string? outputPath,
         bool json)
     {
@@ -275,7 +304,13 @@ public sealed class WorkflowCommand : Command
                     0d,
                     Array.Empty<WorkflowScenarioBenchmark>(),
                     Array.Empty<WorkflowScenarioBenchmark>(),
-                    Array.Empty<WorkflowFailureCategoryStat>())), json);
+                    Array.Empty<WorkflowFailureCategoryStat>(),
+                    Array.Empty<string>(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    Array.Empty<WorkflowRecommendation>())), json);
             return Task.FromResult(1);
         }
 
@@ -286,6 +321,15 @@ public sealed class WorkflowCommand : Command
             rows = rows
                 .Where(x => string.Equals(x.BenchmarkSet, normalized, StringComparison.OrdinalIgnoreCase))
                 .ToArray();
+        }
+        if (!string.IsNullOrWhiteSpace(runId))
+        {
+            var normalizedRunId = runId.Trim();
+            rows = rows.Where(x => string.Equals(x.RunId, normalizedRunId, StringComparison.OrdinalIgnoreCase)).ToArray();
+        }
+        if (!string.IsNullOrWhiteSpace(since) && DateTimeOffset.TryParse(since, out var sinceUtc))
+        {
+            rows = rows.Where(x => x.StartedAtUtc >= sinceUtc).ToArray();
         }
 
         var report = BuildBenchmarkReport(rows);
@@ -353,6 +397,20 @@ public sealed class WorkflowCommand : Command
         var persistHistory = persistHistoryOverride ?? spec.Execution.PersistHistory;
         var iterations = Math.Max(1, iterationsOverride ?? spec.Execution.Iterations);
         var sharedRequest = string.IsNullOrWhiteSpace(requestOverride) ? null : requestOverride.Trim();
+        var runId = BuildRunId();
+        var specHash = ComputeSpecHash(JsonSerializer.Serialize(spec));
+        var gitSha = ResolveGitSha();
+        var providerSnapshot = BuildProviderSnapshot(profiles);
+
+        var preflightByProvider = new Dictionary<string, PreflightResult>(StringComparer.OrdinalIgnoreCase);
+        foreach (var provider in profiles
+                     .Select(x => x.Default.Provider)
+                     .Where(x => !string.IsNullOrWhiteSpace(x))
+                     .Select(x => x!.Trim())
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            preflightByProvider[provider] = await _providerPreflight(provider, ct).ConfigureAwait(false);
+        }
 
         var runs = new List<WorkflowStressRunRecord>();
         foreach (var request in requests)
@@ -368,31 +426,51 @@ public sealed class WorkflowCommand : Command
                         var runtime = BuildRuntimeSpec(composition, profile);
                         var runtimeJson = JsonSerializer.Serialize(runtime);
                         var runtimeExecutionRequest = BuildExecutionRequest(request, composition, profile, sharedRequest);
+                        var profileProvider = profile.Default.Provider?.Trim();
                         var startedAt = DateTimeOffset.UtcNow;
                         var sw = Stopwatch.StartNew();
                         ScenarioExecutionResult scenario;
-                        try
-                        {
-                            scenario = await _scenarioExecutor(
-                                runtimeExecutionRequest,
-                                runtimeJson,
-                                profile.Default.Provider,
-                                true,
-                                verbose,
-                                ct).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
+                        if (!string.IsNullOrWhiteSpace(profileProvider) &&
+                            preflightByProvider.TryGetValue(profileProvider, out var preflight) &&
+                            !preflight.Ok)
                         {
                             scenario = new ScenarioExecutionResult(
-                                Ok: false,
-                                Summary: $"Scenario executor failed: {ex.Message}",
+                                Ok: true,
+                                Summary: $"Skipped due to provider preflight failure ({profileProvider}): {preflight.Detail}",
                                 ConflictCount: 0,
                                 EscalationCount: 0,
-                                FailureCategory: "executor_failure");
+                                FailureCategory: "skipped_infra",
+                                Skipped: true);
+                        }
+                        else
+                        {
+                            try
+                            {
+                                scenario = await _scenarioExecutor(
+                                    runtimeExecutionRequest,
+                                    runtimeJson,
+                                    profile.Default.Provider,
+                                    true,
+                                    verbose,
+                                    ct).ConfigureAwait(false);
+                            }
+                            catch (Exception ex)
+                            {
+                                scenario = new ScenarioExecutionResult(
+                                    Ok: false,
+                                    Summary: $"Scenario executor failed: {ex.Message}",
+                                    ConflictCount: 0,
+                                    EscalationCount: 0,
+                                    FailureCategory: "executor_failure");
+                            }
                         }
                         var elapsedMs = sw.ElapsedMilliseconds;
                         var score = ComputeScore(scenario.Ok, elapsedMs, composition, profile);
                         runs.Add(new WorkflowStressRunRecord(
+                            runId,
+                            gitSha,
+                            specHash,
+                            providerSnapshot,
                             scenarioId,
                             request.Id,
                             composition.Id,
@@ -406,6 +484,7 @@ public sealed class WorkflowCommand : Command
                             score,
                             scenario.Summary,
                             scenario.FailureCategory,
+                            scenario.Skipped,
                             startedAt,
                             benchmarkSet));
                     }
@@ -445,6 +524,10 @@ public sealed class WorkflowCommand : Command
                     repoRoot,
                     new WorkflowLabStressHistoryRow
                     {
+                        RunId = run.RunId,
+                        GitSha = run.GitSha,
+                        SpecHash = run.SpecHash,
+                        ProviderSnapshot = run.ProviderSnapshot,
                         ScenarioId = run.ScenarioId,
                         RequestId = run.RequestId,
                         CompositionId = run.CompositionId,
@@ -458,23 +541,26 @@ public sealed class WorkflowCommand : Command
                         EscalationCount = run.EscalationCount,
                         Score = run.Score,
                         Summary = run.Summary,
+                        Skipped = run.Skipped,
                         FailureCategory = run.FailureCategory,
                         BenchmarkSet = run.BenchmarkSet
                     });
             }
         }
 
-        var allPassed = runs.All(run => run.Success);
-        var failureCount = runs.Count(run => !run.Success);
+        var allPassed = runs.All(run => run.Success || run.Skipped);
+        var failureCount = runs.Count(run => !run.Success && !run.Skipped);
+        var skippedCount = runs.Count(run => run.Skipped);
         var best = aggregates.FirstOrDefault(x => x.Successes > 0);
         var result = new WorkflowStressResult(
             allPassed,
             allPassed
-                ? $"Workflow stress completed: {runs.Count} run(s) across {aggregates.Length} scenario groups."
-                : $"Workflow stress completed with {failureCount} failing run(s) out of {runs.Count}.",
+                ? $"Workflow stress completed: {runs.Count} run(s) across {aggregates.Length} scenario groups (run-id={runId})."
+                : $"Workflow stress completed with {failureCount} failing run(s), {skippedCount} skipped run(s), out of {runs.Count} (run-id={runId}).",
             runs,
             aggregates,
             best,
+            runId,
             benchmarkSet,
             persistHistory);
         WriteStressResult(result, json);
@@ -515,115 +601,36 @@ public sealed class WorkflowCommand : Command
         bool verbose,
         CancellationToken ct)
     {
-        var (exitCode, stdOut, stdErr) = await CaptureConsoleAsync(
-            () => orchestrate.ExecuteAsync(
-                request,
-                runtimeSpecPath: null,
-                runtimeSpecJson,
-                preferModel: null,
-                provider,
-                barrierLevel: null,
-                preferredRegion: null,
-                json,
-                verbose),
-            ct).ConfigureAwait(false);
-        var combined = string.Join(
-            Environment.NewLine,
-            new[] { stdOut, stdErr }.Where(x => !string.IsNullOrWhiteSpace(x)));
-        var parsed = TryParseOrchestratePayload(combined);
-        if (parsed is null)
+        var result = await orchestrate.ExecuteStructuredAsync(
+            request,
+            runtimeSpecPath: null,
+            runtimeSpecJson,
+            preferModel: null,
+            provider,
+            barrierLevel: null,
+            preferredRegion: null,
+            cancellationToken: ct).ConfigureAwait(false);
+
+        if (result.Ok)
         {
-            var category = ClassifyFailureCategory(combined);
             return new ScenarioExecutionResult(
-                false,
-                "Scenario failed: orchestrate output did not contain JSON payload.",
-                0,
-                0,
-                category);
+                Ok: true,
+                Summary: "Orchestration run completed successfully.",
+                ConflictCount: result.Conflicts ?? 0,
+                EscalationCount: result.Escalations ?? 0,
+                FailureCategory: "none");
         }
 
-        var failureCategory = parsed.Ok
-            ? "none"
-            : ClassifyFailureCategory(combined, parsed.ErrorCode);
-
-        var summary = parsed.Summary;
-        if (!parsed.Ok && exitCode != 0 && !summary.Contains("errorCode", StringComparison.OrdinalIgnoreCase))
-        {
-            summary = $"{summary} (exitCode={exitCode})";
-        }
-
+        var summary = string.IsNullOrWhiteSpace(result.ErrorCode)
+            ? $"Orchestration failed: {result.Error ?? "unknown error"}"
+            : $"Orchestration failed with errorCode={result.ErrorCode}: {result.Error ?? "no error details"}";
+        var category = ClassifyFailureCategory(result.Error ?? string.Empty, result.ErrorCode);
         return new ScenarioExecutionResult(
-            parsed.Ok,
-            summary,
-            parsed.ConflictCount,
-            parsed.EscalationCount,
-            failureCategory);
-    }
-
-    private static async Task<(int ExitCode, string StdOut, string StdErr)> CaptureConsoleAsync(
-        Func<Task<int>> run,
-        CancellationToken ct)
-    {
-        ct.ThrowIfCancellationRequested();
-        var originalOut = Console.Out;
-        var originalErr = Console.Error;
-        using var outWriter = new StringWriter();
-        using var errWriter = new StringWriter();
-        try
-        {
-            Console.SetOut(outWriter);
-            Console.SetError(errWriter);
-            var exitCode = await run().ConfigureAwait(false);
-            return (exitCode, outWriter.ToString(), errWriter.ToString());
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-            Console.SetError(originalErr);
-        }
-    }
-
-    private static ParsedOrchestratePayload? TryParseOrchestratePayload(string output)
-    {
-        if (string.IsNullOrWhiteSpace(output))
-            return null;
-
-        var idx = output.LastIndexOf('{');
-        while (idx >= 0)
-        {
-            var candidate = output[idx..].Trim();
-            try
-            {
-                using var doc = JsonDocument.Parse(candidate);
-                var root = doc.RootElement;
-                var ok = root.TryGetProperty("ok", out var okNode) && okNode.ValueKind == JsonValueKind.True;
-                if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
-                {
-                    var errorCode = root.TryGetProperty("errorCode", out var errorCodeNode)
-                        ? errorCodeNode.GetString()
-                        : null;
-                    var error = root.TryGetProperty("error", out var errorNode)
-                        ? errorNode.GetString()
-                        : null;
-                    var fallbackSummary = string.IsNullOrWhiteSpace(errorCode)
-                        ? "Orchestrate response missing data payload."
-                        : $"Orchestration failed with errorCode={errorCode}: {error ?? "no error details"}";
-                    return new ParsedOrchestratePayload(ok, fallbackSummary, 0, 0, errorCode);
-                }
-                var summary = data.TryGetProperty("success", out var successNode) && successNode.ValueKind == JsonValueKind.True
-                    ? "Orchestration run completed successfully."
-                    : "Orchestration reported failure.";
-                var conflictCount = data.TryGetProperty("conflicts", out var conflictsNode) ? conflictsNode.GetInt32() : 0;
-                var escalationCount = data.TryGetProperty("escalations", out var escalationsNode) ? escalationsNode.GetInt32() : 0;
-                return new ParsedOrchestratePayload(ok, summary, conflictCount, escalationCount, null);
-            }
-            catch
-            {
-                idx = idx > 0 ? output.LastIndexOf('{', idx - 1) : -1;
-            }
-        }
-
-        return null;
+            Ok: false,
+            Summary: summary,
+            ConflictCount: result.Conflicts ?? 0,
+            EscalationCount: result.Escalations ?? 0,
+            FailureCategory: category);
     }
 
     private static string ClassifyFailureCategory(string output, string? parsedErrorCode = null)
@@ -779,6 +786,78 @@ public sealed class WorkflowCommand : Command
         return Path.Combine(Environment.CurrentDirectory, ".nexo", "workflow", "workflow_lab.runtime.json");
     }
 
+    private static string BuildRunId()
+        => DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss") + "-" + Guid.NewGuid().ToString("N")[..8];
+
+    private static string ResolveGitSha()
+    {
+        try
+        {
+            var head = Path.Combine(Environment.CurrentDirectory, ".git", "HEAD");
+            if (!File.Exists(head))
+                return "unknown";
+            var headRef = File.ReadAllText(head).Trim();
+            if (!headRef.StartsWith("ref:", StringComparison.OrdinalIgnoreCase))
+                return headRef.Length >= 12 ? headRef[..12] : headRef;
+            var refPath = headRef["ref:".Length..].Trim();
+            var fullRefPath = Path.Combine(Environment.CurrentDirectory, ".git", refPath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullRefPath))
+                return "unknown";
+            var sha = File.ReadAllText(fullRefPath).Trim();
+            return sha.Length >= 12 ? sha[..12] : sha;
+        }
+        catch
+        {
+            return "unknown";
+        }
+    }
+
+    private static string ComputeSpecHash(string raw)
+    {
+        var text = raw ?? string.Empty;
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(text);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToHexString(hash)[..12].ToLowerInvariant();
+    }
+
+    private static string BuildProviderSnapshot(IReadOnlyList<WorkflowLabModelProfileSpec> profiles)
+    {
+        var providers = profiles
+            .Select(x => x.Default.Provider)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return providers.Length == 0 ? "none" : string.Join(",", providers);
+    }
+
+    private static Task<PreflightResult> PreflightProviderAsync(
+        string provider,
+        CancellationToken ct,
+        IProviderFactory? providerFactory = null)
+    {
+        var normalized = string.IsNullOrWhiteSpace(provider) ? "unset" : provider.Trim().ToLowerInvariant();
+        if (normalized is "unset" or "offline" or "mock-json")
+            return Task.FromResult(new PreflightResult(true, normalized, "Provider does not require runtime connectivity check."));
+
+        if (providerFactory is null)
+            return Task.FromResult(new PreflightResult(false, normalized, "Provider factory unavailable for preflight."));
+
+        try
+        {
+            var available = providerFactory.IsProviderAvailable(normalized);
+            return Task.FromResult(available
+                ? new PreflightResult(true, normalized, "Provider available.")
+                : new PreflightResult(false, normalized, "Provider unavailable."));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new PreflightResult(false, normalized, ex.Message));
+        }
+    }
+
     private static string BuildScenarioId(string requestId, string compositionId, string profileId, int iteration)
         => $"{requestId}::{compositionId}::{profileId}::iter-{iteration}";
 
@@ -851,6 +930,22 @@ public sealed class WorkflowCommand : Command
             .Take(5)
             .ToArray();
 
+        var runIds = items
+            .Select(x => x.RunId)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var recommendations = CreateRecommendations(
+            scenarioStats,
+            failuresByCategory,
+            successRate,
+            avgElapsed,
+            topScenarios);
+
+        var latest = items.OrderByDescending(x => x.StartedAtUtc).FirstOrDefault();
+
         return new WorkflowBenchmarkReport(
             GeneratedAtUtc: DateTimeOffset.UtcNow,
             TotalRuns: totalRuns,
@@ -864,7 +959,81 @@ public sealed class WorkflowCommand : Command
             AverageEscalations: avgEscalations,
             TopScenarios: topScenarios,
             Bottlenecks: bottlenecks,
-            FailureCategories: failuresByCategory);
+            FailureCategories: failuresByCategory,
+            RunIds: runIds,
+            LatestRunId: latest?.RunId,
+            GitSha: latest?.GitSha,
+            SpecHash: latest?.SpecHash,
+            ProviderSnapshot: latest?.ProviderSnapshot,
+            Recommendations: recommendations);
+    }
+
+    private static IReadOnlyList<WorkflowRecommendation> CreateRecommendations(
+        IReadOnlyList<WorkflowScenarioBenchmark> scenarioStats,
+        IReadOnlyList<WorkflowFailureCategoryStat> failuresByCategory,
+        double successRate,
+        long avgElapsedMs,
+        IReadOnlyList<WorkflowScenarioBenchmark> topScenarios)
+    {
+        var output = new List<WorkflowRecommendation>();
+        var stable = scenarioStats
+            .Where(x => x.SuccessRate >= 0.8)
+            .OrderByDescending(x => x.SuccessRate)
+            .ThenBy(x => x.P95ElapsedMs)
+            .ThenByDescending(x => x.AverageScore)
+            .FirstOrDefault();
+
+        if (stable != null)
+        {
+            output.Add(new WorkflowRecommendation(
+                "best_stable_config",
+                "use",
+                stable.ScenarioGroupId,
+                $"Stable success-rate {stable.SuccessRate:P1} with p95 {stable.P95ElapsedMs} ms."));
+        }
+        else if (topScenarios.Count > 0)
+        {
+            var candidate = topScenarios[0];
+            output.Add(new WorkflowRecommendation(
+                "candidate_best_config",
+                "investigate",
+                candidate.ScenarioGroupId,
+                $"No stable config yet; top candidate success-rate {candidate.SuccessRate:P1}, p95 {candidate.P95ElapsedMs} ms."));
+        }
+
+        var infraFailures = failuresByCategory
+            .FirstOrDefault(x => string.Equals(x.Category, "infra_unavailable", StringComparison.OrdinalIgnoreCase));
+        if (infraFailures != null && infraFailures.Count > 0)
+        {
+            output.Add(new WorkflowRecommendation(
+                "infra_dependency",
+                "fix",
+                null,
+                $"Detected {infraFailures.Count} infra_unavailable failures; stabilize provider/runtime dependencies before comparing models."));
+        }
+
+        var badConfigs = scenarioStats
+            .Where(x => x.Failures >= Math.Max(2, (int)Math.Ceiling(x.Runs * 0.7)))
+            .OrderByDescending(x => x.Failures)
+            .ThenByDescending(x => x.P95ElapsedMs)
+            .Take(3)
+            .ToArray();
+        foreach (var bad in badConfigs)
+        {
+            output.Add(new WorkflowRecommendation(
+                "do_not_use_config",
+                "avoid",
+                bad.ScenarioGroupId,
+                $"High failure rate ({bad.Failures}/{bad.Runs}) and p95 {bad.P95ElapsedMs} ms."));
+        }
+
+        output.Add(new WorkflowRecommendation(
+            "global_baseline",
+            "monitor",
+            null,
+            $"Current benchmark baseline success-rate {successRate:P1}, average latency {avgElapsedMs} ms."));
+
+        return output;
     }
 
     private static long ComputePercentile(IEnumerable<long> source, double percentile)
@@ -920,6 +1089,14 @@ public sealed class WorkflowCommand : Command
         sb.AppendLine("# Workflow Stress Benchmark Report");
         sb.AppendLine();
         sb.AppendLine($"Generated: {report.GeneratedAtUtc:O}");
+        if (!string.IsNullOrWhiteSpace(report.LatestRunId))
+            sb.AppendLine($"Run ID: {report.LatestRunId}");
+        if (!string.IsNullOrWhiteSpace(report.GitSha))
+            sb.AppendLine($"Git SHA: {report.GitSha}");
+        if (!string.IsNullOrWhiteSpace(report.SpecHash))
+            sb.AppendLine($"Spec hash: {report.SpecHash}");
+        if (!string.IsNullOrWhiteSpace(report.ProviderSnapshot))
+            sb.AppendLine($"Provider snapshot: {report.ProviderSnapshot}");
         sb.AppendLine();
         sb.AppendLine("## Summary");
         sb.AppendLine($"- Total runs: {report.TotalRuns}");
@@ -949,6 +1126,12 @@ public sealed class WorkflowCommand : Command
         {
             sb.AppendLine($"- `{bottleneck.ScenarioGroupId}` | failures {bottleneck.Failures} | p95 {bottleneck.P95ElapsedMs} ms | last failure: {bottleneck.LastFailureSummary ?? "n/a"}");
         }
+        sb.AppendLine();
+        sb.AppendLine("## Recommendations");
+        foreach (var rec in report.Recommendations)
+        {
+            sb.AppendLine($"- `{rec.Kind}` [{rec.Action}] {(string.IsNullOrWhiteSpace(rec.Target) ? "" : rec.Target + " — ")}{rec.Rationale}");
+        }
         return sb.ToString();
     }
 
@@ -958,6 +1141,14 @@ public sealed class WorkflowCommand : Command
         var sb = new StringBuilder();
         sb.AppendLine("Workflow Stress Benchmark Report");
         sb.AppendLine($"Generated: {report.GeneratedAtUtc:O}");
+        if (!string.IsNullOrWhiteSpace(report.LatestRunId))
+            sb.AppendLine($"Run ID: {report.LatestRunId}");
+        if (!string.IsNullOrWhiteSpace(report.GitSha))
+            sb.AppendLine($"Git SHA: {report.GitSha}");
+        if (!string.IsNullOrWhiteSpace(report.SpecHash))
+            sb.AppendLine($"Spec hash: {report.SpecHash}");
+        if (!string.IsNullOrWhiteSpace(report.ProviderSnapshot))
+            sb.AppendLine($"Provider snapshot: {report.ProviderSnapshot}");
         sb.AppendLine($"Total runs: {report.TotalRuns}");
         sb.AppendLine($"Success runs: {report.SuccessRuns}");
         sb.AppendLine($"Failed runs: {report.FailedRuns}");
@@ -984,6 +1175,13 @@ public sealed class WorkflowCommand : Command
         foreach (var bottleneck in report.Bottlenecks)
         {
             sb.AppendLine($"- {bottleneck.ScenarioGroupId}: failures {bottleneck.Failures}, p95 {bottleneck.P95ElapsedMs} ms, last failure={bottleneck.LastFailureSummary ?? "n/a"}");
+        }
+        sb.AppendLine();
+        sb.AppendLine("Recommendations:");
+        foreach (var rec in report.Recommendations)
+        {
+            var target = string.IsNullOrWhiteSpace(rec.Target) ? string.Empty : $"{rec.Target}: ";
+            sb.AppendLine($"- [{rec.Action}] {rec.Kind} {target}{rec.Rationale}");
         }
         return sb.ToString();
     }
@@ -1038,6 +1236,7 @@ public sealed class WorkflowCommand : Command
             {
                 ok = result.Ok,
                 summary = result.Summary,
+                runId = result.RunId,
                 benchmarkSet = result.BenchmarkSet,
                 persistHistory = result.PersistHistory,
                 runs = result.Runs,
@@ -1050,7 +1249,7 @@ public sealed class WorkflowCommand : Command
         Console.WriteLine($"workflow stress: {(result.Ok ? "ok" : "failed")}");
         Console.WriteLine(result.Summary);
         if (!string.IsNullOrWhiteSpace(result.BenchmarkSet))
-            Console.WriteLine($"  benchmark-set={result.BenchmarkSet} (persist-history={result.PersistHistory})");
+            Console.WriteLine($"  run-id={result.RunId ?? "n/a"}, benchmark-set={result.BenchmarkSet} (persist-history={result.PersistHistory})");
         foreach (var aggregate in (result.Aggregates ?? Array.Empty<WorkflowStressAggregate>()).Take(5))
         {
             Console.WriteLine(
@@ -1106,11 +1305,21 @@ public sealed class WorkflowCommand : Command
         Console.WriteLine($"  success-rate={result.Report.SuccessRate:P1}, avg-latency={result.Report.AverageElapsedMs}ms, p95={result.Report.P95ElapsedMs}ms");
         if (result.Report.TopScenarios.Count > 0)
             Console.WriteLine($"  best={result.Report.TopScenarios[0].ScenarioGroupId} score={result.Report.TopScenarios[0].AverageScore:F2}");
+        if (result.Report.Recommendations.Count > 0)
+        {
+            Console.WriteLine("  recommendations:");
+            foreach (var rec in result.Report.Recommendations.Take(5))
+                Console.WriteLine($"    - [{rec.Action}] {rec.Kind}: {rec.Rationale}");
+        }
     }
 
     private sealed record WorkflowScaffoldResult(bool Ok, string Summary, string? OutputPath = null);
 
     private sealed record WorkflowStressRunRecord(
+        string RunId,
+        string GitSha,
+        string SpecHash,
+        string ProviderSnapshot,
         string ScenarioId,
         string RequestId,
         string CompositionId,
@@ -1124,6 +1333,7 @@ public sealed class WorkflowCommand : Command
         double Score,
         string Summary,
         string FailureCategory,
+        bool Skipped,
         DateTimeOffset StartedAtUtc,
         string BenchmarkSet);
 
@@ -1144,6 +1354,7 @@ public sealed class WorkflowCommand : Command
         IReadOnlyList<WorkflowStressRunRecord>? Runs = null,
         IReadOnlyList<WorkflowStressAggregate>? Aggregates = null,
         WorkflowStressAggregate? Best = null,
+        string? RunId = null,
         string? BenchmarkSet = null,
         bool? PersistHistory = null);
 
@@ -1192,7 +1403,19 @@ public sealed class WorkflowCommand : Command
         double AverageEscalations,
         IReadOnlyList<WorkflowScenarioBenchmark> TopScenarios,
         IReadOnlyList<WorkflowScenarioBenchmark> Bottlenecks,
-        IReadOnlyList<WorkflowFailureCategoryStat> FailureCategories);
+        IReadOnlyList<WorkflowFailureCategoryStat> FailureCategories,
+        IReadOnlyList<string> RunIds,
+        string? LatestRunId,
+        string? GitSha,
+        string? SpecHash,
+        string? ProviderSnapshot,
+        IReadOnlyList<WorkflowRecommendation> Recommendations);
+
+    private sealed record WorkflowRecommendation(
+        string Kind,
+        string Action,
+        string? Target,
+        string Rationale);
 
     private sealed record WorkflowReportResult(
         bool Ok,
@@ -1205,12 +1428,11 @@ public sealed class WorkflowCommand : Command
         string Summary,
         int ConflictCount,
         int EscalationCount,
+        bool Skipped = false,
         string FailureCategory = "none");
 
-    private sealed record ParsedOrchestratePayload(
+    private sealed record PreflightResult(
         bool Ok,
-        string Summary,
-        int ConflictCount,
-        int EscalationCount,
-        string? ErrorCode = null);
+        string Provider,
+        string Detail);
 }

--- a/src/Nexo.CLI/Runtime/WorkflowLabHistoryStore.cs
+++ b/src/Nexo.CLI/Runtime/WorkflowLabHistoryStore.cs
@@ -4,6 +4,10 @@ namespace Nexo.CLI.Runtime;
 
 public sealed record WorkflowLabStressHistoryRow
 {
+    public string RunId { get; init; } = string.Empty;
+    public string GitSha { get; init; } = string.Empty;
+    public string SpecHash { get; init; } = string.Empty;
+    public string ProviderSnapshot { get; init; } = string.Empty;
     public string ScenarioId { get; init; } = string.Empty;
     public string RequestId { get; init; } = string.Empty;
     public string CompositionId { get; init; } = string.Empty;
@@ -17,6 +21,7 @@ public sealed record WorkflowLabStressHistoryRow
     public int EscalationCount { get; init; }
     public double Score { get; init; }
     public string? Summary { get; init; }
+    public bool Skipped { get; init; }
     public string FailureCategory { get; init; } = "none";
     public string BenchmarkSet { get; init; } = "workflow-lab";
 }

--- a/src/Nexo.CLI/Runtime/WorkflowLabRuntimeSpec.cs
+++ b/src/Nexo.CLI/Runtime/WorkflowLabRuntimeSpec.cs
@@ -127,6 +127,7 @@ public sealed record WorkflowLabExecutionSpec
     public int Iterations { get; init; } = 1;
     public bool PersistHistory { get; init; } = true;
     public string BenchmarkSet { get; init; } = "workflow-lab";
+    public bool SkipScenariosWhenProviderUnavailable { get; init; } = true;
 }
 
 public sealed record WorkflowLabRequestSpec

--- a/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/WorkflowCommandTests.cs
@@ -326,6 +326,8 @@ public sealed class WorkflowCommandTests : UnitTestBase
                     repoRoot,
                     limit: 20,
                     benchmarkSet: "workflow-lab",
+                    runId: null,
+                    since: null,
                     outputPath: reportPath,
                     json: false)).ConfigureAwait(false);
 
@@ -337,6 +339,75 @@ public sealed class WorkflowCommandTests : UnitTestBase
             AssertTrue(markdown.Contains("## Top Scenarios", StringComparison.OrdinalIgnoreCase));
             AssertTrue(markdown.Contains("## Failure Categories", StringComparison.OrdinalIgnoreCase));
             AssertTrue(markdown.Contains("orchestration_failure", StringComparison.OrdinalIgnoreCase));
+            AssertTrue(markdown.Contains("## Recommendations", StringComparison.OrdinalIgnoreCase));
+            AssertTrue(markdown.Contains("global_baseline", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previousCurrent;
+            if (Directory.Exists(repoRoot))
+                Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private async Task TestReportFiltersByRunIdAsync(CancellationToken cancellationToken)
+    {
+        var repoRoot = CreateTempRepoRoot();
+        var previousCurrent = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = repoRoot;
+            WorkflowLabHistoryStore.Append(repoRoot, new WorkflowLabStressHistoryRow
+            {
+                RunId = "run-a",
+                GitSha = "abc123",
+                SpecHash = "spec-a",
+                ProviderSnapshot = "ollama",
+                ScenarioId = "request-a::composition-a::profile-a::iter-1",
+                RequestId = "request-a",
+                CompositionId = "composition-a",
+                ModelProfileId = "profile-a",
+                Iteration = 1,
+                Success = true,
+                Score = 90.0,
+                ElapsedMs = 100,
+                BenchmarkSet = "workflow-lab"
+            });
+            WorkflowLabHistoryStore.Append(repoRoot, new WorkflowLabStressHistoryRow
+            {
+                RunId = "run-b",
+                GitSha = "def456",
+                SpecHash = "spec-b",
+                ProviderSnapshot = "ollama",
+                ScenarioId = "request-b::composition-b::profile-b::iter-1",
+                RequestId = "request-b",
+                CompositionId = "composition-b",
+                ModelProfileId = "profile-b",
+                Iteration = 1,
+                Success = false,
+                Score = 10.0,
+                ElapsedMs = 300,
+                FailureCategory = "orchestration_failure",
+                BenchmarkSet = "workflow-lab"
+            });
+
+            var reportPath = Path.Combine(repoRoot, "workflow_report_run_a.md");
+            var command = CreateCommand();
+            var (exitCode, output) = await CaptureConsoleAsync(
+                () => command.ExecuteReportAsync(
+                    repoRoot,
+                    limit: 20,
+                    benchmarkSet: "workflow-lab",
+                    runId: "run-a",
+                    since: null,
+                    outputPath: reportPath,
+                    json: false)).ConfigureAwait(false);
+
+            AssertEqual(0, exitCode);
+            AssertTrue(output.Contains("workflow report: ok", StringComparison.OrdinalIgnoreCase));
+            var markdown = await File.ReadAllTextAsync(reportPath, cancellationToken).ConfigureAwait(false);
+            AssertTrue(markdown.Contains("Run ID: run-a", StringComparison.Ordinal));
+            AssertTrue(!markdown.Contains("run-b", StringComparison.OrdinalIgnoreCase), "Report should filter out run-b data.");
         }
         finally
         {
@@ -370,7 +441,7 @@ public sealed class WorkflowCommandTests : UnitTestBase
   "error": "barrier context rejected"
 }
 """);
-                return Task.FromResult(new WorkflowCommand.ScenarioExecutionResult(false, "forced failure", 0, 0, "model_execution_failure"));
+                return Task.FromResult(new WorkflowCommand.ScenarioExecutionResult(false, "forced failure", 0, 0, false, "model_execution_failure"));
             });
             var (exitCode, output) = await CaptureConsoleAsync(
                 () => command.ExecuteStressAsync(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- adds benchmark session metadata to stress history rows (`runId`, `gitSha`, `specHash`, `providerSnapshot`) and report filters (`--run-id`, `--since`) so runs are comparable without mixed-history noise
- replaces workflow scenario console scraping with structured orchestration execution (`OrchestrateCommand.ExecuteStructuredAsync`) for resilient machine-consumable stress results
- adds provider preflight + skip semantics: scenarios for unavailable providers are marked `skipped_infra` (skipped) instead of hard failures
- upgrades benchmark report into decision output with metadata section, failure taxonomy aggregation, and actionable recommendations (best stable config / avoid configs / infra fixes)

## Validation
- `dotnet build /workspace/src/Nexo.CLI/Nexo.CLI.csproj -m:1`
- `dotnet build /workspace/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj -m:1`
- `dotnet test /workspace/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --filter FullyQualifiedName~RuntimeServiceCollectionExtensionsTests --framework net8.0 -m:1`
- `dotnet run --project /workspace/src/Nexo.CLI -- workflow stress --spec /tmp/workflow_lab.runtime.json --iterations 1 --persist-history true --json`
- `dotnet run --project /workspace/src/Nexo.CLI -- workflow report --repo-root /workspace --limit 120 --benchmark-set workflow-lab --run-id 20260411-031724-53be25b0 --output /opt/cursor/artifacts/phase3_workflow_report.md --json`
- `dotnet run --project /workspace/src/Nexo.CLI -- workflow report --repo-root /workspace --limit 120 --benchmark-set workflow-lab --since 2026-04-11T03:17:00Z --output /opt/cursor/artifacts/phase3_workflow_report_since.md --json`

## Artifacts
- stress run showing run-id + per-scenario skip/failure-category fields:
  [phase3_workflow_stress.log](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase3_workflow_stress.log)
- run-id filtered benchmark report:
  [phase3_workflow_report.md](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase3_workflow_report.md)
- since-filter benchmark report:
  [phase3_workflow_report_since.md](https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase3_workflow_report_since.md)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0eeca6e-19a6-46c8-8490-c245b4c20194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0eeca6e-19a6-46c8-8490-c245b4c20194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

