### PR TITLE
Phase 2: complete phase-60 roadmap batch

### DIFF
--- a/.docker/Dockerfile.test-caching-alpine
+++ b/.docker/Dockerfile.test-caching-alpine
@@ -9,13 +9,17 @@ RUN apk add --no-cache \
         python3 \
         py3-pip \
         bash \
-        protobuf
+        protobuf \
+        grpc-plugins
 
 # Set working directory
 WORKDIR /workspace
 
 # Skip CopyAssemblies tool in container
 ENV DOTNET_RUNNING_IN_CONTAINER=true
+# Use Alpine-native protobuf/grpc plugins to avoid glibc binary incompatibility in Grpc.Tools.
+ENV PROTOBUF_PROTOC=/usr/bin/protoc
+ENV GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
 
 # Copy project files
 COPY . .

--- a/.docker/Dockerfile.test-caching-alpine
+++ b/.docker/Dockerfile.test-caching-alpine
@@ -8,7 +8,8 @@ RUN apk add --no-cache \
         git \
         python3 \
         py3-pip \
-        bash
+        bash \
+        protobuf
 
 # Set working directory
 WORKDIR /workspace

--- a/.github/workflows/onboarding-quickstart-gate.yml
+++ b/.github/workflows/onboarding-quickstart-gate.yml
@@ -1,6 +1,8 @@
 name: onboarding-quickstart-gate
 
 on:
+  schedule:
+    - cron: "0 7 * * 1"
   push:
     branches:
       - master
@@ -45,23 +47,70 @@ jobs:
       - name: Native lane quickstart commands
         shell: bash
         run: |
+          set -o pipefail
+          mkdir -p "${RUNNER_TEMP}/onboarding"
+          LOG_FILE="${RUNNER_TEMP}/onboarding/native-linux.log"
+          {
+            bash scripts/setup/setup.sh check
+            bash scripts/setup/setup.sh restore
+            dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal
+            dotnet run --project src/Nexo.CLI -- --help
+            dotnet run --project src/Nexo.CLI -- doctor --json
+          } 2>&1 | tee "${LOG_FILE}"
+
+      - name: Build native failure taxonomy
+        if: always()
+        shell: bash
+        run: |
           set -euo pipefail
-          bash scripts/setup/setup.sh check
-          bash scripts/setup/setup.sh restore
-          dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal
-          dotnet run --project src/Nexo.CLI -- --help
-          dotnet run --project src/Nexo.CLI -- doctor --json
+          mkdir -p "${RUNNER_TEMP}/onboarding"
+          LOG_FILE="${RUNNER_TEMP}/onboarding/native-linux.log"
+          TAXONOMY_FILE="${RUNNER_TEMP}/onboarding/native-linux-taxonomy.json"
+          bash scripts/onboarding/failure-taxonomy.sh "quickstart-native-linux" "${LOG_FILE}" > "${TAXONOMY_FILE}"
+
+      - name: Build native trend summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/onboarding"
+          TREND_FILE="${RUNNER_TEMP}/onboarding/onboarding-native-linux-trend.json"
+          TREND_FILE="${TREND_FILE}" python - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+run_attempt = int(os.getenv("GITHUB_RUN_ATTEMPT", "1"))
+run_number = int(os.getenv("GITHUB_RUN_NUMBER", "0"))
+trend = {
+  "workflow": os.getenv("GITHUB_WORKFLOW"),
+  "runId": os.getenv("GITHUB_RUN_ID"),
+  "runNumber": run_number,
+  "runAttempt": run_attempt,
+  "timestampUtc": datetime.now(timezone.utc).isoformat(),
+  "driftSignals": {
+    "isScheduledRun": os.getenv("GITHUB_EVENT_NAME") == "schedule",
+    "isRetry": run_attempt > 1
+  }
+}
+with open(os.environ["TREND_FILE"], "w", encoding="utf-8") as f:
+    json.dump(trend, f, indent=2)
+PY
 
       - name: Emit native quickstart summary
         if: always()
         shell: bash
         run: |
           SUMMARY_FILE="${RUNNER_TEMP}/onboarding-quickstart-native-linux-summary.txt"
+          TAXONOMY_FILE="${RUNNER_TEMP}/onboarding/native-linux-taxonomy.json"
+          TROUBLESHOOTING_DOC="docs/OnboardingAutomation.md#next-recommended-upgrades"
           {
             echo "onboarding-quickstart-gate native linux summary"
             echo "workflow=${GITHUB_WORKFLOW}"
             echo "run_id=${GITHUB_RUN_ID}"
+            echo "event=${GITHUB_EVENT_NAME}"
             echo "status=completed"
+            echo "failure_taxonomy=${TAXONOMY_FILE}"
+            echo "troubleshooting_doc=${TROUBLESHOOTING_DOC}"
           } > "${SUMMARY_FILE}"
 
       - name: Upload native quickstart artifacts
@@ -71,6 +120,9 @@ jobs:
           name: onboarding-quickstart-native-linux
           path: |
             ${{ runner.temp }}/onboarding-quickstart-native-linux-summary.txt
+            ${{ runner.temp }}/onboarding/native-linux.log
+            ${{ runner.temp }}/onboarding/native-linux-taxonomy.json
+            ${{ runner.temp }}/onboarding/onboarding-native-linux-trend.json
           retention-days: 14
 
   quickstart-linux-ephemeral-container:
@@ -87,22 +139,69 @@ jobs:
       - name: Run container lane in ephemeral container
         shell: bash
         run: |
-          set -euo pipefail
+          set -o pipefail
+          mkdir -p "${RUNNER_TEMP}/onboarding"
+          LOG_FILE="${RUNNER_TEMP}/onboarding/container-linux.log"
           IMAGE="ghcr.io/ianfrelinger/nexo-cli:latest"
-          docker pull "${IMAGE}"
-          docker run --rm "${IMAGE}" --help
-          docker run --rm -v "${GITHUB_WORKSPACE}:/work" -w /work "${IMAGE}" --help
+          {
+            docker pull "${IMAGE}"
+            docker run --rm "${IMAGE}" --help
+            docker run --rm -v "${GITHUB_WORKSPACE}:/work" -w /work "${IMAGE}" --help
+          } 2>&1 | tee "${LOG_FILE}"
+
+      - name: Build container failure taxonomy
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/onboarding"
+          LOG_FILE="${RUNNER_TEMP}/onboarding/container-linux.log"
+          TAXONOMY_FILE="${RUNNER_TEMP}/onboarding/container-linux-taxonomy.json"
+          bash scripts/onboarding/failure-taxonomy.sh "quickstart-container-linux" "${LOG_FILE}" > "${TAXONOMY_FILE}"
+
+      - name: Build container trend summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/onboarding"
+          TREND_FILE="${RUNNER_TEMP}/onboarding/onboarding-container-linux-trend.json"
+          TREND_FILE="${TREND_FILE}" python - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+run_attempt = int(os.getenv("GITHUB_RUN_ATTEMPT", "1"))
+run_number = int(os.getenv("GITHUB_RUN_NUMBER", "0"))
+trend = {
+  "workflow": os.getenv("GITHUB_WORKFLOW"),
+  "runId": os.getenv("GITHUB_RUN_ID"),
+  "runNumber": run_number,
+  "runAttempt": run_attempt,
+  "timestampUtc": datetime.now(timezone.utc).isoformat(),
+  "driftSignals": {
+    "isScheduledRun": os.getenv("GITHUB_EVENT_NAME") == "schedule",
+    "isRetry": run_attempt > 1
+  }
+}
+with open(os.environ["TREND_FILE"], "w", encoding="utf-8") as f:
+    json.dump(trend, f, indent=2)
+PY
 
       - name: Emit container quickstart summary
         if: always()
         shell: bash
         run: |
           SUMMARY_FILE="${RUNNER_TEMP}/onboarding-quickstart-container-linux-summary.txt"
+          TAXONOMY_FILE="${RUNNER_TEMP}/onboarding/container-linux-taxonomy.json"
+          TROUBLESHOOTING_DOC="docs/OnboardingAutomation.md#next-recommended-upgrades"
           {
             echo "onboarding-quickstart-gate container linux summary"
             echo "workflow=${GITHUB_WORKFLOW}"
             echo "run_id=${GITHUB_RUN_ID}"
+            echo "event=${GITHUB_EVENT_NAME}"
             echo "status=completed"
+            echo "failure_taxonomy=${TAXONOMY_FILE}"
+            echo "troubleshooting_doc=${TROUBLESHOOTING_DOC}"
           } > "${SUMMARY_FILE}"
 
       - name: Upload container quickstart artifacts
@@ -112,4 +211,7 @@ jobs:
           name: onboarding-quickstart-container-linux
           path: |
             ${{ runner.temp }}/onboarding-quickstart-container-linux-summary.txt
+            ${{ runner.temp }}/onboarding/container-linux.log
+            ${{ runner.temp }}/onboarding/container-linux-taxonomy.json
+            ${{ runner.temp }}/onboarding/onboarding-container-linux-trend.json
           retention-days: 14

--- a/.github/workflows/test-trust-multi-env.yml
+++ b/.github/workflows/test-trust-multi-env.yml
@@ -2,6 +2,11 @@
 # Validates Trust & Information Architecture features (sanitization, knowledge log, access boundary, audit).
 name: Trust Tests (Multi-Env Docker)
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 on:
   push:
     branches: [ master, main ]
@@ -39,9 +44,12 @@ jobs:
              dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj -f net9.0 --filter 'FullyQualifiedName~Trust' --logger 'console;verbosity=minimal' --logger 'trx;LogFileName=trust-bg-ubuntu.trx' --results-directory /workspace/test-results"
       - uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
+        continue-on-error: true
         with:
           files: test-results/trust/**/*.trx
           check_name: Trust Tests - Ubuntu
+          comment_mode: off
+          report_individual_runs: true
 
   trust-alpine:
     name: Trust - Alpine
@@ -58,9 +66,12 @@ jobs:
              dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj -f net9.0 --filter 'FullyQualifiedName~Trust' --logger 'console;verbosity=minimal' --logger 'trx;LogFileName=trust-bg-alpine.trx' --results-directory /workspace/test-results"
       - uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
+        continue-on-error: true
         with:
           files: test-results/trust/**/*.trx
           check_name: Trust Tests - Alpine
+          comment_mode: off
+          report_individual_runs: true
 
   trust-debian:
     name: Trust - Debian
@@ -77,6 +88,9 @@ jobs:
              dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj -f net9.0 --filter 'FullyQualifiedName~Trust' --logger 'console;verbosity=minimal' --logger 'trx;LogFileName=trust-bg-debian.trx' --results-directory /workspace/test-results"
       - uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
+        continue-on-error: true
         with:
           files: test-results/trust/**/*.trx
           check_name: Trust Tests - Debian
+          comment_mode: off
+          report_individual_runs: true

--- a/config/trust-packs/air-gapped.json
+++ b/config/trust-packs/air-gapped.json
@@ -1,0 +1,20 @@
+{
+  "id": "air-gapped",
+  "version": "1.0.0",
+  "displayName": "Air-gapped",
+  "description": "Default-deny profile for isolated environments with minimal observation footprint.",
+  "pauseObservationByDefault": false,
+  "recommendedFor": "air-gapped deployments",
+  "categoryRules": {
+    "file-contents": false,
+    "terminal-output": false,
+    "file-paths": false,
+    "git-metadata": false
+  },
+  "sourceRules": {
+    "shell": false,
+    "git": false,
+    "vscode": false
+  },
+  "projectRules": []
+}

--- a/config/trust-packs/internal-only.json
+++ b/config/trust-packs/internal-only.json
@@ -1,0 +1,20 @@
+{
+  "id": "internal-only",
+  "version": "1.0.0",
+  "displayName": "Internal only",
+  "description": "Allow trusted internal workflows while denying external-facing data classes.",
+  "pauseObservationByDefault": false,
+  "recommendedFor": "internal engineering teams",
+  "categoryRules": {
+    "file-contents": true,
+    "terminal-output": true,
+    "api-keys": false,
+    "behavioral-patterns": false
+  },
+  "sourceRules": {
+    "shell": true,
+    "git": true,
+    "vscode": true
+  },
+  "projectRules": []
+}

--- a/config/trust-packs/strict-enterprise.json
+++ b/config/trust-packs/strict-enterprise.json
@@ -1,0 +1,21 @@
+{
+  "id": "strict-enterprise",
+  "version": "1.0.0",
+  "displayName": "Strict enterprise",
+  "description": "Deny high-risk observation categories and keep shell-level sources blocked by default.",
+  "pauseObservationByDefault": false,
+  "recommendedFor": "regulated enterprise workloads",
+  "categoryRules": {
+    "file-contents": false,
+    "terminal-output": false,
+    "api-keys": false,
+    "file-paths": true,
+    "git-metadata": true
+  },
+  "sourceRules": {
+    "shell": false,
+    "git": true,
+    "vscode": true
+  },
+  "projectRules": []
+}

--- a/docs/OnboardingAutomation.md
+++ b/docs/OnboardingAutomation.md
@@ -56,10 +56,17 @@ These are automated by running container commands directly (or via guided wrappe
    - optional hero flow checks (`--help`, `doctor`, quickstart pipeline).
 2. Added `nexo doctor` command with a single pass/fail onboarding summary (machine-readable via `--json`).
 3. Added CI gate (`onboarding-quickstart-gate`) to validate first-run docs commands end-to-end in ephemeral jobs.
+4. Added `nexo doctor --fix` remediation mode for a safe subset of common onboarding failures.
+   - Requires explicit consent (`--yes`) before any remediation runs.
+   - Emits remediation attempts/results in JSON output for auditability.
+5. Expanded `onboarding-quickstart-gate` with weekly scheduled drift detection and taxonomy artifacts:
+   - `*-taxonomy.json` classifies lane/platform/root-cause class.
+   - `*-trend.json` captures run metadata signals for drift tracking over time.
+   - Summary artifacts now include troubleshooting doc pointers.
 
 ## Next recommended upgrades
 
 1. Add clearer platform-specific troubleshooting pages for missing required tools.
-2. Add a richer `nexo doctor --fix` mode that can execute safe remediations with explicit user confirmation.
-3. Add periodic scheduled onboarding gate runs to detect ecosystem drift early.
+2. Expand remediation catalog with additional safe fixers for platform-specific host issues.
+3. Add trend aggregation/reporting across multiple scheduled runs to surface regressions in one dashboard view.
 

--- a/docs/TrustAndInformationArchitecture.md
+++ b/docs/TrustAndInformationArchitecture.md
@@ -242,6 +242,18 @@ The sections above define the target architecture. The phase list below reflects
 - Implemented compliance export (structured JSON, Markdown, CSV via `TrustCommand.AuditAsync`)
 - Implemented persistent boundary indicator and audit view (`TrustCommand.DashboardAsync`, `BoundaryAsync`)
 
+### Phase 5 — Regulated trust policy packs — Implemented
+- Added versioned trust policy pack schema (`TrustPolicyPack`) and activation status model.
+- Added pack registry + activation persistence (`ITrustPolicyPackRegistry`, `TrustPolicyPackRegistry`).
+- Added one-step operator workflows:
+  - `nexo trust pack list`
+  - `nexo trust pack apply --id <pack-id>`
+- Added default policy packs under `config/trust-packs/`:
+  - `strict-enterprise`
+  - `internal-only`
+  - `air-gapped`
+- Exposed active pack/version in trust status surfaces (`trust boundary/dashboard`, API `GET /api/trust/status`).
+
 ---
 
 ## Dependency Summary

--- a/scripts/onboarding/failure-taxonomy.sh
+++ b/scripts/onboarding/failure-taxonomy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <check-name> <log-file>" >&2
+  exit 1
+fi
+
+CHECK_NAME="$1"
+LOG_FILE="$2"
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  CHECK_NAME="$CHECK_NAME" python - <<'PY'
+import json
+import os
+print(json.dumps({
+    "check": os.environ["CHECK_NAME"],
+    "category": "missing-log",
+    "rootCauseClass": "artifact-missing",
+    "remediation": "Check workflow step wiring and artifact upload paths."
+}))
+PY
+  exit 0
+fi
+
+normalized="$(tr '[:upper:]' '[:lower:]' < "$LOG_FILE")"
+category="unknown"
+root_cause="unknown"
+remediation="Review log details and map to onboarding runbook."
+
+if grep -q "command not found" <<< "$normalized"; then
+  category="missing-dependency"
+  root_cause="tooling-missing"
+  remediation="Run doctor --fix --yes or install required tools listed in onboarding docs."
+elif grep -q "permission denied" <<< "$normalized"; then
+  category="host-permissions"
+  root_cause="permissions"
+  remediation="Grant execute permissions or run with a user that has required access."
+elif grep -q "network is unreachable" <<< "$normalized" || grep -q "could not resolve host" <<< "$normalized"; then
+  category="network"
+  root_cause="connectivity"
+  remediation="Verify DNS/network egress and retry."
+elif grep -q "nuget" <<< "$normalized" || grep -q "restore failed" <<< "$normalized"; then
+  category="dotnet-restore"
+  root_cause="package-restore"
+  remediation="Retry restore; verify NuGet feeds and credentials."
+elif grep -q "docker" <<< "$normalized" && grep -q "cannot connect" <<< "$normalized"; then
+  category="docker-daemon"
+  root_cause="container-runtime"
+  remediation="Start Docker daemon/service before rerunning onboarding gate."
+fi
+
+CHECK_NAME="$CHECK_NAME" CATEGORY="$category" ROOT_CAUSE="$root_cause" REMEDIATION="$remediation" python - <<'PY'
+import json
+import os
+print(json.dumps({
+    "check": os.environ["CHECK_NAME"],
+    "category": os.environ["CATEGORY"],
+    "rootCauseClass": os.environ["ROOT_CAUSE"],
+    "remediation": os.environ["REMEDIATION"]
+}))
+PY

--- a/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -6,6 +6,7 @@ using Nexo.BrickContracts.Capabilities;
 using Nexo.Core.Application.Agent.UseCases.RunAgent;
 using Nexo.Core.Application.NodeCapabilityRuntime.Models;
 using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Core.Application.Trust.Ports;
 using Nexo.Core.Application.Validation.UseCases.RunValidation;
 using Nexo.Infrastructure.Testing.ExecutionPlatform;
 using Nexo.API.Security;
@@ -78,6 +79,11 @@ public static class NexoEndpoints
             .WithName("GetSecurityAdvisory")
             .WithSummary("Operator exposure profile and hints (user-configured; advisory only)")
             .Produces<SecurityAdvisoryResponse>(StatusCodes.Status200OK);
+
+        group.MapGet("/trust/status", GetTrustStatusAsync)
+            .WithName("GetTrustStatus")
+            .WithSummary("Get trust boundary status and active trust policy pack")
+            .Produces<TrustStatusResponse>(StatusCodes.Status200OK);
 
         group.MapPost("/director/run", RunDirectorWorkflowAsync)
             .WithName("RunDirectorWorkflow")
@@ -489,6 +495,21 @@ public static class NexoEndpoints
             custom,
             options.ShowAdvisoryInPortal));
     }
+
+    private static async Task<IResult> GetTrustStatusAsync(
+        [FromServices] IAccessBoundary accessBoundary,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask;
+
+        var activePack = accessBoundary.GetActivePolicyPack();
+        return Results.Ok(new TrustStatusResponse(
+            accessBoundary.IsObservationPaused,
+            accessBoundary.IsObservationPaused ? "Observation paused" : "Observing",
+            activePack?.Id,
+            activePack?.Version));
+    }
 }
 
 // Request/Response DTOs
@@ -508,6 +529,7 @@ public sealed record ExecutionBuildResponse(bool Success, string? ErrorMessage, 
 
 public sealed record ExecutionRunRequest(string ImageTag, string[] Command, Dictionary<string, string>? EnvironmentVariables = null, Dictionary<string, string>? VolumeMounts = null, string? WorkingDirectory = null);
 public sealed record ExecutionRunResponse(bool Success, int ExitCode, string StandardOutput, string StandardError, string? ContainerId, double DurationMs);
+public sealed record TrustStatusResponse(bool IsPaused, string Status, string? ActivePolicyPackId, string? ActivePolicyPackVersion);
 
 public sealed record DirectorRunRequest(
     string Goal,

--- a/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
+++ b/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
@@ -123,6 +123,7 @@ public static class ServiceCollectionExtensions
             var audit = sp.GetService<ISanitizationAuditLog>();
             return new CloudSanitizationProxy(filter, taxonomy, audit);
         });
+        services.TryAddSingleton<ITrustPolicyPackRegistry, TrustPolicyPackRegistry>();
 
         if (useSanitizingProviderFactory && !skipProviderRegistration)
         {

--- a/src/Nexo.CLI/Commands/CiCommand.cs
+++ b/src/Nexo.CLI/Commands/CiCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
+using System.Text.Json;
 using Nexo.Core.Application.Paths;
 
 namespace Nexo.CLI.Commands;
@@ -36,6 +37,20 @@ public sealed class CiCommand : Command
             Environment.Exit(exitCode);
         });
         AddCommand(runtimePromotionCmd);
+
+        var releaseBundleCmd = new Command("release-bundle", "Run a single-shot release gate bundle and emit unified report.");
+        var profileOpt = new Option<string>("--profile", () => "default", "Bundle profile: default | quick.");
+        var outputDirOpt = new Option<string?>("--output-dir", "Optional output directory for unified report artifacts.");
+        releaseBundleCmd.AddOption(profileOpt);
+        releaseBundleCmd.AddOption(outputDirOpt);
+        releaseBundleCmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var profile = ctx.ParseResult.GetValueForOption(profileOpt) ?? "default";
+            var outputDir = ctx.ParseResult.GetValueForOption(outputDirOpt);
+            var exitCode = await ExecuteReleaseBundleAsync(profile, outputDir);
+            Environment.Exit(exitCode);
+        });
+        AddCommand(releaseBundleCmd);
     }
 
     /// <summary>
@@ -138,6 +153,71 @@ public sealed class CiCommand : Command
         return exit;
     }
 
+    public static async Task<int> ExecuteReleaseBundleAsync(string profile = "default", string? outputDirectory = null)
+    {
+        var repoRoot = RepoPathResolver.FindRepoRoot();
+        var cliProject = Path.Combine(repoRoot, "src", "Nexo.CLI", "Nexo.CLI.csproj");
+        if (!File.Exists(cliProject))
+        {
+            Console.Error.WriteLine($"ci release-bundle: Missing CLI project: {cliProject}");
+            return 1;
+        }
+
+        var normalizedProfile = string.IsNullOrWhiteSpace(profile) ? "default" : profile.Trim().ToLowerInvariant();
+        var steps = BuildReleaseBundleSteps(normalizedProfile, cliProject, repoRoot);
+        if (steps.Count == 0)
+        {
+            Console.Error.WriteLine($"ci release-bundle: Unknown profile '{profile}'. Supported profiles: default, quick.");
+            return 1;
+        }
+
+        var results = new List<ReleaseBundleStepResult>();
+        foreach (var step in steps)
+        {
+            Console.WriteLine($"=== Release Bundle: {step.Name} ===");
+            var startedUtc = DateTimeOffset.UtcNow;
+            var exitCode = await RunProcessAsync(step.FileName, step.Arguments, repoRoot);
+            var endedUtc = DateTimeOffset.UtcNow;
+            var artifactHints = step.ArtifactHints
+                .Select(hint => Path.GetFullPath(Path.Combine(repoRoot, hint)))
+                .ToArray();
+            results.Add(new ReleaseBundleStepResult(
+                step.Id,
+                step.Name,
+                step.FileName,
+                step.Arguments,
+                exitCode,
+                startedUtc,
+                endedUtc,
+                artifactHints));
+        }
+
+        var verdict = results.All(result => result.ExitCode == 0) ? "PASS" : "FAIL";
+        var reportDirectory = ResolveReleaseBundleOutputDirectory(repoRoot, outputDirectory);
+        Directory.CreateDirectory(reportDirectory);
+        var jsonPath = Path.Combine(reportDirectory, "release-bundle-report.json");
+        var markdownPath = Path.Combine(reportDirectory, "release-bundle-report.md");
+        var report = new ReleaseBundleReport(
+            normalizedProfile,
+            DateTimeOffset.UtcNow,
+            verdict,
+            results,
+            jsonPath,
+            markdownPath);
+
+        var json = JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(jsonPath, json).ConfigureAwait(false);
+
+        var markdown = BuildReleaseBundleMarkdown(report);
+        await File.WriteAllTextAsync(markdownPath, markdown).ConfigureAwait(false);
+
+        Console.WriteLine($"=== Release Bundle Verdict: {verdict} ===");
+        Console.WriteLine($"JSON report: {jsonPath}");
+        Console.WriteLine($"Markdown report: {markdownPath}");
+
+        return verdict == "PASS" ? 0 : 1;
+    }
+
     private static async Task<int> RunProcessAsync(string fileName, string arguments, string workingDirectory)
     {
         using var process = new Process
@@ -160,4 +240,109 @@ public sealed class CiCommand : Command
         await process.WaitForExitAsync();
         return process.ExitCode;
     }
+
+    private static List<ReleaseBundleStep> BuildReleaseBundleSteps(string profile, string cliProject, string repoRoot)
+    {
+        var defaultSteps = new List<ReleaseBundleStep>
+        {
+            new(
+                "verify",
+                "CI verify",
+                "dotnet",
+                $"run --project \"{cliProject}\" -- ci verify",
+                [
+                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.json",
+                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.md"
+                ]),
+            new(
+                "runtime-gate",
+                "Runtime gate",
+                "dotnet",
+                $"run --project \"{cliProject}\" -- ci runtime-gate",
+                [
+                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.json",
+                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.md"
+                ]),
+            new(
+                "doctor",
+                "Doctor check",
+                "dotnet",
+                $"run --project \"{cliProject}\" -- doctor --json",
+                [
+                    "docs/OnboardingAutomation.md"
+                ])
+        };
+
+        if (profile == "quick")
+            return defaultSteps.Where(step => step.Id != "verify").ToList();
+        if (profile == "default")
+            return defaultSteps;
+        return new List<ReleaseBundleStep>();
+    }
+
+    internal static IReadOnlyList<string> GetReleaseBundleStepIds(string profile)
+    {
+        var repoRoot = RepoPathResolver.FindRepoRoot();
+        var cliProject = Path.Combine(repoRoot, "src", "Nexo.CLI", "Nexo.CLI.csproj");
+        return BuildReleaseBundleSteps(profile.Trim().ToLowerInvariant(), cliProject, repoRoot)
+            .Select(step => step.Id)
+            .ToList();
+    }
+
+    private static string ResolveReleaseBundleOutputDirectory(string repoRoot, string? requestedOutputDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedOutputDirectory))
+            return Path.GetFullPath(requestedOutputDirectory, repoRoot);
+        return Path.Combine(repoRoot, ".nexo", "release-bundle", "last-run");
+    }
+
+    private static string BuildReleaseBundleMarkdown(ReleaseBundleReport report)
+    {
+        var lines = new List<string>
+        {
+            "# Release bundle report",
+            string.Empty,
+            $"Profile: `{report.Profile}`",
+            $"Generated: `{report.GeneratedUtc:O}`",
+            $"Verdict: **{report.Verdict}**",
+            string.Empty,
+            "| Step | Exit code | Started (UTC) | Ended (UTC) | Artifacts |",
+            "|------|-----------|---------------|-------------|-----------|"
+        };
+
+        foreach (var step in report.Steps)
+        {
+            var artifacts = step.ArtifactHints.Length == 0
+                ? "n/a"
+                : string.Join("<br/>", step.ArtifactHints.Select(path => $"`{path}`"));
+            lines.Add($"| {step.Name} | {step.ExitCode} | {step.StartedUtc:O} | {step.EndedUtc:O} | {artifacts} |");
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private sealed record ReleaseBundleStep(
+        string Id,
+        string Name,
+        string FileName,
+        string Arguments,
+        IReadOnlyList<string> ArtifactHints);
+
+    private sealed record ReleaseBundleStepResult(
+        string Id,
+        string Name,
+        string FileName,
+        string Arguments,
+        int ExitCode,
+        DateTimeOffset StartedUtc,
+        DateTimeOffset EndedUtc,
+        string[] ArtifactHints);
+
+    private sealed record ReleaseBundleReport(
+        string Profile,
+        DateTimeOffset GeneratedUtc,
+        string Verdict,
+        IReadOnlyList<ReleaseBundleStepResult> Steps,
+        string JsonReportPath,
+        string MarkdownReportPath);
 }

--- a/src/Nexo.CLI/Commands/ComposeCommand.cs
+++ b/src/Nexo.CLI/Commands/ComposeCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Composition.Models;
 using Nexo.Core.Application.Composition.Ports;
 using Nexo.Infrastructure;
 using Nexo.Infrastructure.Composition;
@@ -19,19 +20,26 @@ public sealed class ComposeCommand : Command
         problemOpt.IsRequired = true;
         var capabilitiesOpt = new Option<string[]>("--capabilities", "Available capabilities (default: perception, validation, reporting)");
         capabilitiesOpt.AllowMultipleArgumentsPerToken = true;
+        var supportLevelOpt = new Option<string[]>(
+            "--support-level",
+            () => new[] { "stable", "experimental", "placeholder" },
+            "Allowed component support levels (stable, experimental, placeholder).");
+        supportLevelOpt.AllowMultipleArgumentsPerToken = true;
 
         AddOption(problemOpt);
         AddOption(capabilitiesOpt);
+        AddOption(supportLevelOpt);
 
         this.SetHandler(async (InvocationContext ctx) =>
         {
             var problem = ctx.ParseResult.GetValueForOption(problemOpt)!;
             var capabilities = ctx.ParseResult.GetValueForOption(capabilitiesOpt) ?? Array.Empty<string>();
-            await ExecuteAsync(problem, capabilities);
+            var supportLevels = ctx.ParseResult.GetValueForOption(supportLevelOpt) ?? Array.Empty<string>();
+            await ExecuteAsync(problem, capabilities, supportLevels);
         });
     }
 
-    private static async Task ExecuteAsync(string problem, string[] capabilities)
+    private static async Task ExecuteAsync(string problem, string[] capabilities, string[] supportLevels)
     {
         var services = new ServiceCollection()
             .AddLogging(b => b.AddConsole())
@@ -41,11 +49,47 @@ public sealed class ComposeCommand : Command
         var engine = services.GetRequiredService<ICompositionEngine>();
         var registry = services.GetRequiredService<ICapabilityComponentRegistry>();
 
+        var parsedSupportLevels = ParseSupportLevels(supportLevels);
+        if (parsedSupportLevels.Count == 0)
+        {
+            Console.Error.WriteLine("No valid support levels selected. Choose from: stable, experimental, placeholder.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var allowedCapabilities = new HashSet<string>(
+            registry.GetAll()
+                .Where(descriptor => parsedSupportLevels.Contains(descriptor.SupportLevel))
+                .Select(descriptor => descriptor.Capability),
+            StringComparer.OrdinalIgnoreCase);
+
         var available = capabilities.Length > 0
             ? capabilities.ToList()
             : new List<string> { "perception", "validation", "reporting", "understanding", "code-analysis" };
+        available = available
+            .Where(capability => allowedCapabilities.Contains(capability))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
-        var composed = await engine.ComposeAsync(problem, available).ConfigureAwait(false);
+        if (available.Count == 0)
+        {
+            Console.Error.WriteLine("No capabilities remain after support-level filtering.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        ComposedAgent? composed;
+        try
+        {
+            composed = await engine.ComposeAsync(problem, available).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine("Composition validation failed:");
+            Console.Error.WriteLine($"  {ex.Message}");
+            Environment.ExitCode = 1;
+            return;
+        }
 
         if (composed == null)
         {
@@ -65,5 +109,17 @@ public sealed class ComposeCommand : Command
             Console.WriteLine($"  - {id}: {desc?.Capability ?? "?"} ({desc?.ImplementationType ?? "?"})");
         }
         Environment.ExitCode = 0;
+    }
+
+    private static HashSet<ComponentSupportLevel> ParseSupportLevels(IEnumerable<string> values)
+    {
+        var parsed = new HashSet<ComponentSupportLevel>();
+        foreach (var value in values)
+        {
+            if (Enum.TryParse<ComponentSupportLevel>(value, ignoreCase: true, out var level))
+                parsed.Add(level);
+        }
+
+        return parsed;
     }
 }

--- a/src/Nexo.CLI/Commands/DoctorCommand.cs
+++ b/src/Nexo.CLI/Commands/DoctorCommand.cs
@@ -22,17 +22,23 @@ public sealed class DoctorCommand : Command
             () => "demo",
             "Doctor profile: demo | self-extend-functional | self-extend-aesthetic | self-extend-visual.");
         var jsonOpt = new Option<bool>("--json", () => false, "Emit JSON output.");
+        var fixOpt = new Option<bool>("--fix", () => false, "Attempt safe remediation for fixable onboarding failures.");
+        var yesOpt = new Option<bool>("--yes", () => false, "Auto-approve remediation actions when --fix is enabled.");
 
         AddOption(includeOptionalOpt);
         AddOption(profileOpt);
         AddOption(jsonOpt);
+        AddOption(fixOpt);
+        AddOption(yesOpt);
 
         this.SetHandler(async (InvocationContext ctx) =>
         {
             var includeOptional = ctx.ParseResult.GetValueForOption(includeOptionalOpt);
             var profile = ctx.ParseResult.GetValueForOption(profileOpt) ?? "demo";
             var json = ctx.ParseResult.GetValueForOption(jsonOpt);
-            ctx.ExitCode = await ExecuteAsync(profile, includeOptional, json, ctx.GetCancellationToken()).ConfigureAwait(false);
+            var fix = ctx.ParseResult.GetValueForOption(fixOpt);
+            var yes = ctx.ParseResult.GetValueForOption(yesOpt);
+            ctx.ExitCode = await ExecuteAsync(profile, includeOptional, json, fix, yes, ctx.GetCancellationToken()).ConfigureAwait(false);
         });
     }
 
@@ -40,6 +46,8 @@ public sealed class DoctorCommand : Command
         string profile,
         bool includeOptional,
         bool json,
+        bool fix,
+        bool autoApproveFixes,
         CancellationToken ct)
     {
         var dependencyAssessment = await BootstrapRuntime.AssessDemoAsync(profile, includeOptional, ct).ConfigureAwait(false);
@@ -58,6 +66,28 @@ public sealed class DoctorCommand : Command
         var containerSmokeError = containerSmokePassed ? string.Empty : containerStderr.Trim();
 
         var overallOk = osSupported && dependencyOk && cliSmokePassed;
+        var remediation = new DoctorRemediationReport();
+        if (fix)
+        {
+            remediation = await DoctorRemediation.RunAsync(
+                dependencyAssessment,
+                osSupported,
+                cliSmokePassed,
+                profile,
+                includeOptional,
+                autoApproveFixes,
+                json,
+                ct).ConfigureAwait(false);
+
+            var postAssessment = await BootstrapRuntime.AssessDemoAsync(profile, includeOptional, ct).ConfigureAwait(false);
+            dependencyAssessment = postAssessment;
+            dependencyOk = postAssessment.Supported && !postAssessment.MissingRequired.Any();
+
+            var (postCliExitCode, _, postCliStderr) = await RunShellCaptureAsync(cliCommand, ct).ConfigureAwait(false);
+            cliSmokePassed = postCliExitCode == 0;
+            cliSmokeError = cliSmokePassed ? string.Empty : postCliStderr.Trim();
+            overallOk = osSupported && dependencyOk && cliSmokePassed;
+        }
 
         if (json)
         {
@@ -86,12 +116,14 @@ public sealed class DoctorCommand : Command
                         passed = containerSmokePassed,
                         command = containerCommand,
                         error = containerSmokeError
-                    }
+                    },
+                    remediation = remediation
                 },
                 nextSteps = new
                 {
                     nativeInstall = "bash scripts/install/install.sh --yes",
-                    containerRun = "docker run --rm ghcr.io/ianfrelinger/nexo-cli:latest --help"
+                    containerRun = "docker run --rm ghcr.io/ianfrelinger/nexo-cli:latest --help",
+                    doctorFix = "dotnet run --project src/Nexo.CLI -- doctor --fix --yes"
                 }
             };
             Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
@@ -115,10 +147,30 @@ public sealed class DoctorCommand : Command
             if (!containerSmokePassed && !string.IsNullOrWhiteSpace(containerSmokeError))
                 Console.WriteLine($"  container smoke error: {containerSmokeError}");
 
+            if (fix)
+            {
+                Console.WriteLine("remediation:");
+                if (remediation.Attempts.Count == 0)
+                {
+                    Console.WriteLine("  no fixable issues were detected.");
+                }
+                else
+                {
+                    foreach (var attempt in remediation.Attempts)
+                    {
+                        Console.WriteLine(
+                            $"  - {attempt.Id}: {(attempt.Success ? "fixed" : "not-fixed")} ({attempt.Status})");
+                        if (!string.IsNullOrWhiteSpace(attempt.Message))
+                            Console.WriteLine($"      {attempt.Message}");
+                    }
+                }
+            }
+
             Console.WriteLine($"overall: {(overallOk ? "PASS" : "FAIL")}");
             Console.WriteLine("recommended next steps:");
             Console.WriteLine("  - native lane: bash scripts/install/install.sh --yes");
             Console.WriteLine("  - container lane: docker run --rm ghcr.io/ianfrelinger/nexo-cli:latest --help");
+            Console.WriteLine("  - remediation lane: dotnet run --project src/Nexo.CLI -- doctor --fix --yes");
         }
 
         return overallOk ? 0 : 1;

--- a/src/Nexo.CLI/Commands/DoctorRemediation.cs
+++ b/src/Nexo.CLI/Commands/DoctorRemediation.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Nexo.CLI.Commands;
+
+internal sealed record DoctorRemediationAttempt(
+    string Id,
+    string Problem,
+    string Command,
+    bool Attempted,
+    bool Success,
+    string Status,
+    string Message,
+    int ExitCode,
+    string FollowUp);
+
+internal sealed class DoctorRemediationReport
+{
+    public bool FixEnabled { get; init; }
+    public bool AutoApproveFixes { get; init; }
+    public IReadOnlyList<DoctorRemediationAttempt> Attempts { get; init; } = Array.Empty<DoctorRemediationAttempt>();
+}
+
+internal static class DoctorRemediation
+{
+    public static async Task<DoctorRemediationReport> RunAsync(
+        BootstrapAssessment assessment,
+        bool osSupported,
+        bool cliSmokePassed,
+        string profile,
+        bool includeOptional,
+        bool autoApproveFixes,
+        bool json,
+        CancellationToken cancellationToken)
+    {
+        var attempts = new List<DoctorRemediationAttempt>();
+        var actions = BuildActionPlan(assessment, osSupported, cliSmokePassed, profile, includeOptional);
+
+        foreach (var action in actions)
+        {
+            if (!autoApproveFixes && json)
+            {
+                attempts.Add(new DoctorRemediationAttempt(
+                    action.Id,
+                    action.Problem,
+                    action.Command,
+                    Attempted: false,
+                    Success: false,
+                    Status: "confirmation-required",
+                    Message: "JSON mode requires --yes to execute remediation commands.",
+                    ExitCode: -1,
+                    FollowUp: action.FollowUp));
+                continue;
+            }
+
+            if (!autoApproveFixes && action.RequiresExplicitConfirmation && !json)
+            {
+                Console.Write($"{action.DisplayName} remediation requires confirmation. Run now? [y/N]: ");
+                var answer = Console.ReadLine();
+                if (!string.Equals(answer?.Trim(), "y", StringComparison.OrdinalIgnoreCase))
+                {
+                    attempts.Add(new DoctorRemediationAttempt(
+                        action.Id,
+                        action.Problem,
+                        action.Command,
+                        Attempted: false,
+                        Success: false,
+                        Status: "skipped",
+                        Message: "Skipped by operator. Re-run with --yes to auto-approve.",
+                        ExitCode: -1,
+                        FollowUp: action.FollowUp));
+                    continue;
+                }
+            }
+
+            var exitCode = await RunShellAsync(action.Command, cancellationToken).ConfigureAwait(false);
+            var success = exitCode == 0;
+            attempts.Add(new DoctorRemediationAttempt(
+                action.Id,
+                action.Problem,
+                action.Command,
+                Attempted: true,
+                Success: success,
+                Status: success ? "fixed" : "failed",
+                Message: success
+                    ? "Remediation command completed successfully."
+                    : $"Remediation command exited with code {exitCode}.",
+                ExitCode: exitCode,
+                FollowUp: action.FollowUp));
+        }
+
+        return new DoctorRemediationReport
+        {
+            FixEnabled = true,
+            AutoApproveFixes = autoApproveFixes,
+            Attempts = attempts
+                .OrderBy(attempt => attempt.Id, StringComparer.Ordinal)
+                .ToList(),
+        };
+    }
+
+    private static IReadOnlyList<DoctorRemediationAction> BuildActionPlan(
+        BootstrapAssessment assessment,
+        bool osSupported,
+        bool cliSmokePassed,
+        string profile,
+        bool includeOptional)
+    {
+        var actions = new List<DoctorRemediationAction>();
+        if (!osSupported)
+        {
+            actions.Add(new DoctorRemediationAction(
+                "unsupported-os",
+                "Unsupported host OS",
+                "Host operating system is unsupported for the bootstrap automation.",
+                "echo \"Unsupported host OS.\"" ,
+                RequiresExplicitConfirmation: false,
+                "Use container lane: docker run --rm ghcr.io/ianfrelinger/nexo-cli:latest --help"));
+            return actions;
+        }
+
+        if (assessment.MissingRequired.Any())
+        {
+            actions.Add(new DoctorRemediationAction(
+                "bootstrap-apply",
+                "Install missing required dependencies",
+                "Required dependencies are missing from the current host profile.",
+                $"dotnet run --project src/Nexo.CLI -- bootstrap apply --profile {profile} {(includeOptional ? "--include-optional " : string.Empty)}--yes",
+                RequiresExplicitConfirmation: true,
+                "Re-run doctor after install to verify dependencies and smoke checks."));
+        }
+
+        if (!cliSmokePassed)
+        {
+            actions.Add(new DoctorRemediationAction(
+                "cli-build",
+                "Build CLI project",
+                "CLI smoke check failed and often indicates stale build outputs or restore issues.",
+                "dotnet build src/Nexo.CLI/Nexo.CLI.csproj",
+                RequiresExplicitConfirmation: true,
+                "Re-run doctor to confirm cli smoke passes."));
+        }
+
+        return actions;
+    }
+
+    private static async Task<int> RunShellAsync(string command, CancellationToken cancellationToken)
+    {
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var psi = new ProcessStartInfo
+        {
+            FileName = isWindows ? "powershell" : "bash",
+            UseShellExecute = false,
+        };
+
+        if (isWindows)
+        {
+            psi.ArgumentList.Add("-NoProfile");
+            psi.ArgumentList.Add("-Command");
+            psi.ArgumentList.Add(command);
+        }
+        else
+        {
+            psi.ArgumentList.Add("-lc");
+            psi.ArgumentList.Add(command);
+        }
+
+        using var process = Process.Start(psi);
+        if (process == null)
+            return 1;
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        return process.ExitCode;
+    }
+
+    private sealed record DoctorRemediationAction(
+        string Id,
+        string DisplayName,
+        string Problem,
+        string Command,
+        bool RequiresExplicitConfirmation,
+        string FollowUp);
+}

--- a/src/Nexo.CLI/Commands/TrustCommand.cs
+++ b/src/Nexo.CLI/Commands/TrustCommand.cs
@@ -10,15 +10,18 @@ public class TrustCommand
 {
     private readonly IDataDecisionAuditLog? _auditLog;
     private readonly IAccessBoundary? _accessBoundary;
+    private readonly ITrustPolicyPackRegistry? _policyPackRegistry;
     private readonly ILogger<TrustCommand> _logger;
 
     public TrustCommand(
         IDataDecisionAuditLog? auditLog,
         IAccessBoundary? accessBoundary,
+        ITrustPolicyPackRegistry? policyPackRegistry,
         ILogger<TrustCommand> logger)
     {
         _auditLog = auditLog;
         _accessBoundary = accessBoundary;
+        _policyPackRegistry = policyPackRegistry;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -91,10 +94,18 @@ public class TrustCommand
                 var dashboard = new Dictionary<string, object>();
                 if (_accessBoundary != null)
                 {
-                    dashboard["boundary"] = new Dictionary<string, object>
+                    var activePack = _accessBoundary.GetActivePolicyPack();
+                    dashboard["boundary"] = new Dictionary<string, object?>
                     {
                         ["isPaused"] = _accessBoundary.IsObservationPaused,
-                        ["status"] = _accessBoundary.IsObservationPaused ? "Observation paused" : "Observing"
+                        ["status"] = _accessBoundary.IsObservationPaused ? "Observation paused" : "Observing",
+                        ["activePolicyPack"] = activePack is null
+                            ? (object?)null
+                            : new Dictionary<string, object?>
+                            {
+                                ["id"] = activePack.Id,
+                                ["version"] = activePack.Version
+                            }
                     };
                 }
                 else
@@ -121,9 +132,11 @@ public class TrustCommand
             {
                 if (_accessBoundary != null)
                 {
+                    var activePack = _accessBoundary.GetActivePolicyPack();
                     Console.Out.WriteLine("Access Boundary:");
                     Console.Out.WriteLine($"  Paused: {(_accessBoundary.IsObservationPaused ? "Yes" : "No")}");
                     Console.Out.WriteLine($"  Status: {(_accessBoundary.IsObservationPaused ? "Observation halted" : "Observing")}");
+                    Console.Out.WriteLine($"  Active policy pack: {(activePack is null ? "none" : $"{activePack.Id}@{activePack.Version}")}");
                     Console.Out.WriteLine();
                 }
                 if (_auditLog != null)
@@ -314,18 +327,22 @@ public class TrustCommand
 
             if (formatJson)
             {
+                var activePack = _accessBoundary.GetActivePolicyPack();
                 var payload = new
                 {
                     isPaused = _accessBoundary.IsObservationPaused,
                     status = _accessBoundary.IsObservationPaused ? "Observation paused" : "Observing",
+                    activePolicyPack = activePack is null ? null : new { activePack.Id, activePack.Version },
                 };
                 Console.Out.WriteLine(System.Text.Json.JsonSerializer.Serialize(payload, new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
             }
             else
             {
+                var activePack = _accessBoundary.GetActivePolicyPack();
                 Console.Out.WriteLine("Access Boundary:");
                 Console.Out.WriteLine($"  Paused: {(_accessBoundary.IsObservationPaused ? "Yes" : "No")}");
                 Console.Out.WriteLine($"  Status: {(_accessBoundary.IsObservationPaused ? "Observation halted" : "Observing (subject to category/source rules)")}");
+                Console.Out.WriteLine($"  Active policy pack: {(activePack is null ? "none" : $"{activePack.Id}@{activePack.Version}")}");
             }
 
             return Task.FromResult(0);
@@ -372,5 +389,127 @@ public class TrustCommand
         if (DateTimeOffset.TryParse(until, out var dt))
             return dt;
         return null;
+    }
+
+    public Task<int> ListPolicyPacksAsync(bool formatJson, CancellationToken ct = default)
+    {
+        try
+        {
+            if (_policyPackRegistry == null)
+            {
+                if (formatJson)
+                    Console.Out.WriteLine("{\"ok\":false,\"error\":\"Trust policy pack registry not registered\"}");
+                else
+                    Console.Error.WriteLine("Trust policy pack registry not registered.");
+                return Task.FromResult(1);
+            }
+
+            var packs = _policyPackRegistry.ListPacks();
+            if (formatJson)
+            {
+                Console.Out.WriteLine(System.Text.Json.JsonSerializer.Serialize(
+                    new
+                    {
+                        ok = true,
+                        count = packs.Count,
+                        packs = packs.Select(pack => new
+                        {
+                            pack.Id,
+                            pack.Version,
+                            pack.DisplayName,
+                            pack.Description
+                        }).ToArray()
+                    },
+                    new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+            }
+            else
+            {
+                Console.Out.WriteLine($"Trust policy packs ({packs.Count}):");
+                foreach (var pack in packs)
+                    Console.Out.WriteLine($"  - {pack.Id}@{pack.Version}: {pack.DisplayName}");
+            }
+
+            return Task.FromResult(0);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Trust pack list failed");
+            if (formatJson)
+                Console.Out.WriteLine($"{{\"ok\":false,\"error\":\"{ex.Message}\"}}");
+            else
+                Console.Error.WriteLine(ex.Message);
+            return Task.FromResult(1);
+        }
+    }
+
+    public Task<int> ApplyPolicyPackAsync(string packId, bool formatJson, CancellationToken ct = default)
+    {
+        try
+        {
+            if (_policyPackRegistry == null)
+            {
+                if (formatJson)
+                    Console.Out.WriteLine("{\"ok\":false,\"error\":\"Trust policy pack registry not registered\"}");
+                else
+                    Console.Error.WriteLine("Trust policy pack registry not registered.");
+                return Task.FromResult(1);
+            }
+
+            if (_accessBoundary == null)
+            {
+                if (formatJson)
+                    Console.Out.WriteLine("{\"ok\":false,\"error\":\"Access boundary not registered\"}");
+                else
+                    Console.Error.WriteLine("Access boundary not registered.");
+                return Task.FromResult(1);
+            }
+
+            if (string.IsNullOrWhiteSpace(packId))
+            {
+                if (formatJson)
+                    Console.Out.WriteLine("{\"ok\":false,\"error\":\"pack id is required\"}");
+                else
+                    Console.Error.WriteLine("pack id is required");
+                return Task.FromResult(1);
+            }
+
+            var pack = _policyPackRegistry.GetById(packId.Trim());
+            if (pack == null)
+            {
+                if (formatJson)
+                    Console.Out.WriteLine($"{{\"ok\":false,\"error\":\"unknown pack '{packId.Trim()}'\"}}");
+                else
+                    Console.Error.WriteLine($"unknown pack '{packId.Trim()}'");
+                return Task.FromResult(1);
+            }
+
+            _accessBoundary.ApplyPolicyPack(pack);
+            var activated = _policyPackRegistry.ActivateAsync(pack.Id, ct).GetAwaiter().GetResult();
+            if (formatJson)
+            {
+                Console.Out.WriteLine(System.Text.Json.JsonSerializer.Serialize(
+                    new
+                    {
+                        ok = true,
+                        applied = new { activated.Id, activated.Version, activated.ActivatedAtUtc, pack.DisplayName }
+                    },
+                    new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+            }
+            else
+            {
+                Console.Out.WriteLine($"Applied trust policy pack {activated.Id}@{activated.Version}.");
+            }
+
+            return Task.FromResult(0);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Trust pack apply failed");
+            if (formatJson)
+                Console.Out.WriteLine($"{{\"ok\":false,\"error\":\"{ex.Message}\"}}");
+            else
+                Console.Error.WriteLine(ex.Message);
+            return Task.FromResult(1);
+        }
     }
 }

--- a/src/Nexo.CLI/Commands/TrustCommand.cs
+++ b/src/Nexo.CLI/Commands/TrustCommand.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Trust.Models;
 using Nexo.Core.Application.Trust.Ports;
 
 namespace Nexo.CLI.Commands;
@@ -483,8 +484,27 @@ public class TrustCommand
                 return Task.FromResult(1);
             }
 
+            var previousActive = _accessBoundary.GetActivePolicyPack();
+            var previousPackDefinition = previousActive is null
+                ? null
+                : _policyPackRegistry.GetById(previousActive.Id);
+
             _accessBoundary.ApplyPolicyPack(pack);
-            var activated = _policyPackRegistry.ActivateAsync(pack.Id, ct).GetAwaiter().GetResult();
+
+            ActiveTrustPolicyPack activated;
+            try
+            {
+                activated = _policyPackRegistry.ActivateAsync(pack.Id, ct).GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // Keep runtime boundary aligned with persisted registry state on activation failures.
+                if (previousPackDefinition is not null)
+                    _accessBoundary.ApplyPolicyPack(previousPackDefinition);
+                else
+                    _accessBoundary.Reset();
+                throw;
+            }
             if (formatJson)
             {
                 Console.Out.WriteLine(System.Text.Json.JsonSerializer.Serialize(

--- a/src/Nexo.CLI/Program.cs
+++ b/src/Nexo.CLI/Program.cs
@@ -683,6 +683,34 @@ static class Program
             trustDashboardCmd.Options[0] as Option<int> ?? throw new InvalidOperationException(),
             trustDashboardCmd.Options[1] as Option<bool> ?? throw new InvalidOperationException());
         trustCmd.AddCommand(trustDashboardCmd);
+
+        var trustPackCmd = new Command("pack", "Manage regulated trust policy packs");
+        var trustPackListCmd = new Command("list", "List available trust policy packs");
+        trustPackListCmd.AddOption(jsonOpt);
+        trustPackListCmd.SetHandler(
+            async (bool formatJson) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<TrustCommand>();
+                Environment.Exit(await cmd.ListPolicyPacksAsync(formatJson));
+            },
+            jsonOpt);
+        trustPackCmd.AddCommand(trustPackListCmd);
+
+        var trustPackApplyCmd = new Command("apply", "Apply a trust policy pack by id");
+        var trustPackIdOpt = new Option<string>("--id", "Policy pack id (strict-enterprise, internal-only, air-gapped)");
+        trustPackIdOpt.IsRequired = true;
+        trustPackApplyCmd.AddOption(trustPackIdOpt);
+        trustPackApplyCmd.AddOption(jsonOpt);
+        trustPackApplyCmd.SetHandler(
+            async (string id, bool formatJson) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<TrustCommand>();
+                Environment.Exit(await cmd.ApplyPolicyPackAsync(id, formatJson));
+            },
+            trustPackIdOpt,
+            jsonOpt);
+        trustPackCmd.AddCommand(trustPackApplyCmd);
+        trustCmd.AddCommand(trustPackCmd);
         root.AddCommand(trustCmd);
 
         // nexo test - Multi-platform test execution

--- a/src/Nexo.Core.Application/Composition/Models/ComponentDescriptor.cs
+++ b/src/Nexo.Core.Application/Composition/Models/ComponentDescriptor.cs
@@ -7,8 +7,20 @@ public record ComponentDescriptor
 {
     public required string Id { get; init; }
     public required string Capability { get; init; }
+    public required string DisplayName { get; init; }
+    public required string Summary { get; init; }
     public string? InputSchema { get; init; }
     public string? OutputSchema { get; init; }
     public required string ImplementationType { get; init; }
     public string Version { get; init; } = "1.0.0";
+    public ComponentSupportLevel SupportLevel { get; init; } = ComponentSupportLevel.Stable;
+    public IReadOnlyList<string> RequiredCapabilities { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> IncompatibleWith { get; init; } = Array.Empty<string>();
+}
+
+public enum ComponentSupportLevel
+{
+    Stable = 0,
+    Experimental = 1,
+    Placeholder = 2,
 }

--- a/src/Nexo.Core.Application/Composition/Models/ComponentValidationIssue.cs
+++ b/src/Nexo.Core.Application/Composition/Models/ComponentValidationIssue.cs
@@ -1,0 +1,9 @@
+namespace Nexo.Core.Application.Composition.Models;
+
+/// <summary>
+/// Deterministic validation issue surfaced by registry metadata or selection checks.
+/// </summary>
+public sealed record ComponentValidationIssue(
+    string Code,
+    string ComponentId,
+    string Message);

--- a/src/Nexo.Core.Application/Composition/Ports/ICapabilityComponentRegistry.cs
+++ b/src/Nexo.Core.Application/Composition/Ports/ICapabilityComponentRegistry.cs
@@ -10,4 +10,6 @@ public interface ICapabilityComponentRegistry
     void Register(ComponentDescriptor descriptor);
     IReadOnlyList<ComponentDescriptor> GetByCapability(string capability);
     ComponentDescriptor? GetById(string id);
+    IReadOnlyList<ComponentDescriptor> GetAll();
+    IReadOnlyList<ComponentValidationIssue> ValidateSelection(IReadOnlyList<string> componentIds, IReadOnlyCollection<string> availableCapabilities);
 }

--- a/src/Nexo.Core.Application/Trust/Models/TrustPolicyPackModels.cs
+++ b/src/Nexo.Core.Application/Trust/Models/TrustPolicyPackModels.cs
@@ -1,0 +1,48 @@
+namespace Nexo.Core.Application.Trust.Models;
+
+/// <summary>
+/// Describes a versioned trust policy pack that can be applied in one step.
+/// </summary>
+public sealed record TrustPolicyPack(
+    string Id,
+    string Version,
+    string DisplayName,
+    string Description,
+    bool PauseObservationByDefault,
+    IReadOnlyDictionary<string, bool> CategoryRules,
+    IReadOnlyDictionary<string, bool> SourceRules,
+    IReadOnlyList<TrustPolicyPackProjectRule> ProjectRules,
+    string? RecommendedFor = null);
+
+/// <summary>
+/// Per-project source overrides for a trust policy pack.
+/// </summary>
+public sealed record TrustPolicyPackProjectRule(
+    string ProjectPath,
+    IReadOnlyDictionary<string, bool> SourceRules);
+
+/// <summary>
+/// Lightweight list item for CLI/API status surfaces.
+/// </summary>
+public sealed record TrustPolicyPackInfo(
+    string Id,
+    string Version,
+    string DisplayName,
+    string Description,
+    string? RecommendedFor = null);
+
+/// <summary>
+/// Tracks the currently active trust policy pack.
+/// </summary>
+public sealed record TrustPolicyPackStatus(
+    string? ActivePackId = null,
+    string? ActivePackVersion = null,
+    DateTimeOffset? ActivatedAtUtc = null);
+
+/// <summary>
+/// Runtime view of the currently active policy pack.
+/// </summary>
+public sealed record ActiveTrustPolicyPack(
+    string Id,
+    string Version,
+    DateTimeOffset ActivatedAtUtc);

--- a/src/Nexo.Core.Application/Trust/Ports/IAccessBoundary.cs
+++ b/src/Nexo.Core.Application/Trust/Ports/IAccessBoundary.cs
@@ -33,4 +33,19 @@ public interface IAccessBoundary
 
     /// <summary>Raised when any boundary setting changes.</summary>
     event Action<BoundaryChangeEvent>? BoundaryChanged;
+
+    /// <summary>Reset all boundary rules and pause state to defaults (observe-all, not paused).</summary>
+    void Reset();
+
+    /// <summary>Apply a versioned trust policy pack in one step.</summary>
+    void ApplyPolicyPack(TrustPolicyPack pack);
+
+    /// <summary>Get the currently active trust policy pack, if any.</summary>
+    ActiveTrustPolicyPack? GetActivePolicyPack();
+
+    /// <summary>Snapshot of current category allow/deny rules.</summary>
+    IReadOnlyDictionary<string, bool> GetCategoryAllowlistSnapshot();
+
+    /// <summary>Snapshot of current source allow/deny rules.</summary>
+    IReadOnlyDictionary<string, bool> GetSourceAllowlistSnapshot();
 }

--- a/src/Nexo.Core.Application/Trust/Ports/ITrustPolicyPackRegistry.cs
+++ b/src/Nexo.Core.Application/Trust/Ports/ITrustPolicyPackRegistry.cs
@@ -1,0 +1,14 @@
+using Nexo.Core.Application.Trust.Models;
+
+namespace Nexo.Core.Application.Trust.Ports;
+
+/// <summary>
+/// Registry for versioned trust policy packs and activation status.
+/// </summary>
+public interface ITrustPolicyPackRegistry
+{
+    IReadOnlyList<TrustPolicyPackInfo> ListPacks();
+    TrustPolicyPack? GetById(string id);
+    ActiveTrustPolicyPack? GetActivePack();
+    Task<ActiveTrustPolicyPack> ActivateAsync(string id, CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Infrastructure/Composition/CapabilityComponentRegistry.cs
+++ b/src/Nexo.Infrastructure/Composition/CapabilityComponentRegistry.cs
@@ -22,12 +22,31 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
     /// <inheritdoc />
     public void Register(ComponentDescriptor descriptor)
     {
+        var metadataIssues = ComponentDescriptorValidator.Validate(descriptor);
+        if (metadataIssues.Count > 0)
+        {
+            var ordered = metadataIssues
+                .OrderBy(issue => issue.Code, StringComparer.Ordinal)
+                .ThenBy(issue => issue.ComponentId, StringComparer.Ordinal)
+                .ThenBy(issue => issue.Message, StringComparer.Ordinal)
+                .Select(issue => $"{issue.Code}: {issue.Message}");
+            throw new ArgumentException(
+                $"Component descriptor '{descriptor.Id}' is invalid. {string.Join(" | ", ordered)}",
+                nameof(descriptor));
+        }
+
         _byId[descriptor.Id] = descriptor;
         var list = _byCapability.GetOrAdd(descriptor.Capability, _ => new List<ComponentDescriptor>());
         lock (list)
         {
             if (!list.Any(x => string.Equals(x.Id, descriptor.Id, StringComparison.OrdinalIgnoreCase)))
                 list.Add(descriptor);
+            else
+            {
+                var existingIndex = list.FindIndex(x => string.Equals(x.Id, descriptor.Id, StringComparison.OrdinalIgnoreCase));
+                if (existingIndex >= 0)
+                    list[existingIndex] = descriptor;
+            }
         }
     }
 
@@ -45,14 +64,95 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
         return _byId.TryGetValue(id, out var d) ? d : null;
     }
 
+    /// <inheritdoc />
+    public IReadOnlyList<ComponentDescriptor> GetAll()
+    {
+        return _byId.Values
+            .OrderBy(descriptor => descriptor.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ComponentValidationIssue> ValidateSelection(IReadOnlyList<string> componentIds, IReadOnlyCollection<string> availableCapabilities)
+    {
+        var issues = new List<ComponentValidationIssue>();
+        var orderedIds = componentIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var available = new HashSet<string>(
+            availableCapabilities.Where(capability => !string.IsNullOrWhiteSpace(capability)),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var id in orderedIds)
+        {
+            var descriptor = GetById(id);
+            if (descriptor == null)
+            {
+                issues.Add(new ComponentValidationIssue("selection.missing-component", id, $"Component '{id}' is not registered."));
+                continue;
+            }
+
+            var metadataIssues = ComponentDescriptorValidator.Validate(descriptor);
+            issues.AddRange(metadataIssues);
+
+            foreach (var requiredCapability in descriptor.RequiredCapabilities
+                         .Where(capability => !string.IsNullOrWhiteSpace(capability))
+                         .Distinct(StringComparer.OrdinalIgnoreCase)
+                         .OrderBy(capability => capability, StringComparer.OrdinalIgnoreCase))
+            {
+                if (available.Contains(requiredCapability))
+                    continue;
+
+                issues.Add(new ComponentValidationIssue(
+                    "selection.missing-required-capability",
+                    descriptor.Id,
+                    $"Component '{descriptor.Id}' requires capability '{requiredCapability}', but it is unavailable."));
+            }
+        }
+
+        foreach (var id in orderedIds)
+        {
+            var descriptor = GetById(id);
+            if (descriptor == null)
+                continue;
+
+            foreach (var incompatibleComponent in descriptor.IncompatibleWith
+                         .Where(component => !string.IsNullOrWhiteSpace(component))
+                         .Distinct(StringComparer.OrdinalIgnoreCase)
+                         .OrderBy(component => component, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!orderedIds.Any(selected => string.Equals(selected, incompatibleComponent, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+
+                issues.Add(new ComponentValidationIssue(
+                    "selection.incompatible-components",
+                    descriptor.Id,
+                    $"Component '{descriptor.Id}' is incompatible with '{incompatibleComponent}'."));
+            }
+        }
+
+        return issues
+            .Distinct()
+            .OrderBy(issue => issue.Code, StringComparer.Ordinal)
+            .ThenBy(issue => issue.ComponentId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(issue => issue.Message, StringComparer.Ordinal)
+            .ToList();
+    }
+
     private void SeedFromCodeAnalysis()
     {
         Register(new ComponentDescriptor
         {
             Id = "code-analysis",
             Capability = "code-analysis",
+            DisplayName = "Code analysis",
+            Summary = "Static code analysis and architecture scoring.",
             ImplementationType = "Nexo.Infrastructure.Analysis.BrickAnalyzer.RoslynBrickStaticAnalyzer, Nexo.Infrastructure",
             Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
         });
     }
 
@@ -66,22 +166,33 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
         {
             Id = "test-discovery",
             Capability = "test-discovery",
+            DisplayName = "Test discovery",
+            Summary = "Discovers test matrices and parameter combinations.",
             ImplementationType = "Nexo.Core.Application.ParallelTesting.Ports.IParameterMatrixGenerator",
             Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
         });
         Register(new ComponentDescriptor
         {
             Id = "test-execution",
             Capability = "test-execution",
+            DisplayName = "Test execution",
+            Summary = "Spawns execution workers for test runs.",
             ImplementationType = "Nexo.Core.Application.ParallelTesting.Ports.IInstanceSpawner",
             Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
+            RequiredCapabilities = ["test-discovery"],
         });
         Register(new ComponentDescriptor
         {
             Id = "result-aggregation",
             Capability = "result-aggregation",
+            DisplayName = "Result aggregation",
+            Summary = "Collects test outcomes into deterministic summaries.",
             ImplementationType = "Nexo.Core.Application.ParallelTesting.Ports.IResultCollector",
             Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
+            RequiredCapabilities = ["test-execution"],
         });
     }
 
@@ -94,24 +205,127 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
     private void SeedPlaceholderComponents()
     {
         // Pipeline IDs used by CompositionEngine rules (perception, validation, reporting, understanding)
-        Register(new ComponentDescriptor { Id = "perception", Capability = "perception", ImplementationType = "Nexo.Infrastructure.Observation.ObservationContextBrick, Nexo.Infrastructure", Version = "1.0.0" });
-        Register(new ComponentDescriptor { Id = "validation", Capability = "validation", ImplementationType = "Nexo.Infrastructure.Analysis.BrickAnalyzer.RoslynBrickStaticAnalyzer, Nexo.Infrastructure", Version = "1.0.0" });
-        Register(new ComponentDescriptor { Id = "reporting", Capability = "reporting", ImplementationType = "Nexo.Infrastructure.SelfContext.ChangelogGenerator, Nexo.Infrastructure", Version = "1.0.0" });
-        Register(new ComponentDescriptor { Id = "understanding", Capability = "understanding", ImplementationType = "Nexo.Infrastructure.Observation.ObservationContextBrick, Nexo.Infrastructure", Version = "1.0.0" });
+        Register(new ComponentDescriptor
+        {
+            Id = "perception",
+            Capability = "perception",
+            DisplayName = "Perception",
+            Summary = "Collects observation context used by downstream stages.",
+            ImplementationType = "Nexo.Infrastructure.Observation.ObservationContextBrick, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
+        });
+        Register(new ComponentDescriptor
+        {
+            Id = "validation",
+            Capability = "validation",
+            DisplayName = "Validation",
+            Summary = "Validates generated outputs for policy and correctness.",
+            ImplementationType = "Nexo.Infrastructure.Analysis.BrickAnalyzer.RoslynBrickStaticAnalyzer, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
+            RequiredCapabilities = ["perception"],
+        });
+        Register(new ComponentDescriptor
+        {
+            Id = "reporting",
+            Capability = "reporting",
+            DisplayName = "Reporting",
+            Summary = "Publishes composed workflow results to operators.",
+            ImplementationType = "Nexo.Infrastructure.SelfContext.ChangelogGenerator, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
+            RequiredCapabilities = ["validation"],
+        });
+        Register(new ComponentDescriptor
+        {
+            Id = "understanding",
+            Capability = "understanding",
+            DisplayName = "Understanding",
+            Summary = "Interprets context before analysis and adaptation.",
+            ImplementationType = "Nexo.Infrastructure.Observation.ObservationContextBrick, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Stable,
+        });
 
         // Perception (specialized)
-        Register(new ComponentDescriptor { Id = "vision-input", Capability = "vision-input", ImplementationType = "TBD", Version = "0.0.0" });
-        Register(new ComponentDescriptor { Id = "audio-input", Capability = "audio-input", ImplementationType = "TBD", Version = "0.0.0" });
-        Register(new ComponentDescriptor { Id = "data-parsing", Capability = "data-parsing", ImplementationType = "TBD", Version = "0.0.0" });
+        Register(new ComponentDescriptor
+        {
+            Id = "vision-input",
+            Capability = "vision-input",
+            DisplayName = "Vision input",
+            Summary = "Placeholder for specialized image/video ingestion.",
+            ImplementationType = "Nexo.Infrastructure.Composition.PlaceholderCapabilityComponent, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Placeholder,
+        });
+        Register(new ComponentDescriptor
+        {
+            Id = "audio-input",
+            Capability = "audio-input",
+            DisplayName = "Audio input",
+            Summary = "Placeholder for speech and audio ingestion.",
+            ImplementationType = "Nexo.Infrastructure.Composition.PlaceholderCapabilityComponent, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Placeholder,
+        });
+        Register(new ComponentDescriptor
+        {
+            Id = "data-parsing",
+            Capability = "data-parsing",
+            DisplayName = "Data parsing",
+            Summary = "Placeholder for structured/unstructured data parsing.",
+            ImplementationType = "Nexo.Infrastructure.Composition.PlaceholderCapabilityComponent, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Placeholder,
+        });
 
         // Action
-        Register(new ComponentDescriptor { Id = "ui-interaction", Capability = "ui-interaction", ImplementationType = "TBD", Version = "0.0.0" });
-        Register(new ComponentDescriptor { Id = "process-control", Capability = "process-control", ImplementationType = "TBD", Version = "0.0.0" });
+        Register(new ComponentDescriptor
+        {
+            Id = "ui-interaction",
+            Capability = "ui-interaction",
+            DisplayName = "UI interaction",
+            Summary = "Placeholder for deterministic UI automation components.",
+            ImplementationType = "Nexo.Infrastructure.Composition.PlaceholderCapabilityComponent, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Placeholder,
+            IncompatibleWith = ["process-control"],
+        });
+        Register(new ComponentDescriptor
+        {
+            Id = "process-control",
+            Capability = "process-control",
+            DisplayName = "Process control",
+            Summary = "Placeholder for shell and process orchestration.",
+            ImplementationType = "Nexo.Infrastructure.Composition.PlaceholderCapabilityComponent, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Placeholder,
+            IncompatibleWith = ["ui-interaction"],
+        });
 
         // Memory
-        Register(new ComponentDescriptor { Id = "episodic-memory", Capability = "episodic-memory", ImplementationType = "TBD", Version = "0.0.0" });
+        Register(new ComponentDescriptor
+        {
+            Id = "episodic-memory",
+            Capability = "episodic-memory",
+            DisplayName = "Episodic memory",
+            Summary = "Placeholder for long-horizon memory indexing.",
+            ImplementationType = "Nexo.Infrastructure.Composition.PlaceholderCapabilityComponent, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Placeholder,
+        });
 
         // Reporting
-        Register(new ComponentDescriptor { Id = "suggestion-surface", Capability = "suggestion-surface", ImplementationType = "TBD", Version = "0.0.0" });
+        Register(new ComponentDescriptor
+        {
+            Id = "suggestion-surface",
+            Capability = "suggestion-surface",
+            DisplayName = "Suggestion surface",
+            Summary = "Placeholder for operator-facing recommendation rendering.",
+            ImplementationType = "Nexo.Infrastructure.Composition.PlaceholderCapabilityComponent, Nexo.Infrastructure",
+            Version = "1.0.0",
+            SupportLevel = ComponentSupportLevel.Placeholder,
+        });
     }
 }

--- a/src/Nexo.Infrastructure/Composition/ComponentDescriptorValidator.cs
+++ b/src/Nexo.Infrastructure/Composition/ComponentDescriptorValidator.cs
@@ -1,0 +1,32 @@
+using Nexo.Core.Application.Composition.Models;
+
+namespace Nexo.Infrastructure.Composition;
+
+internal static class ComponentDescriptorValidator
+{
+    public static IReadOnlyList<ComponentValidationIssue> Validate(ComponentDescriptor descriptor)
+    {
+        var issues = new List<ComponentValidationIssue>();
+        if (string.IsNullOrWhiteSpace(descriptor.Id))
+            issues.Add(new ComponentValidationIssue("metadata.missing-id", "(unknown)", "Component id is required."));
+
+        if (string.IsNullOrWhiteSpace(descriptor.Capability))
+            issues.Add(new ComponentValidationIssue("metadata.missing-capability", descriptor.Id, "Capability is required."));
+
+        if (string.IsNullOrWhiteSpace(descriptor.DisplayName))
+            issues.Add(new ComponentValidationIssue("metadata.missing-display-name", descriptor.Id, "DisplayName is required."));
+
+        if (string.IsNullOrWhiteSpace(descriptor.Summary))
+            issues.Add(new ComponentValidationIssue("metadata.missing-summary", descriptor.Id, "Summary is required."));
+
+        if (string.IsNullOrWhiteSpace(descriptor.ImplementationType))
+            issues.Add(new ComponentValidationIssue("metadata.missing-implementation", descriptor.Id, "ImplementationType is required."));
+        else if (string.Equals(descriptor.ImplementationType.Trim(), "TBD", StringComparison.OrdinalIgnoreCase))
+            issues.Add(new ComponentValidationIssue("metadata.placeholder-implementation", descriptor.Id, "ImplementationType cannot be 'TBD'."));
+
+        if (!Version.TryParse(descriptor.Version, out _))
+            issues.Add(new ComponentValidationIssue("metadata.invalid-version", descriptor.Id, $"Version '{descriptor.Version}' is not a valid semantic version."));
+
+        return issues;
+    }
+}

--- a/src/Nexo.Infrastructure/Composition/CompositionEngine.cs
+++ b/src/Nexo.Infrastructure/Composition/CompositionEngine.cs
@@ -118,6 +118,15 @@ public sealed class CompositionEngine : ICompositionEngine
         if (componentIds.Count == 0)
             return Task.FromResult<ComposedAgent?>(null);
 
+        var validationIssues = _registry.ValidateSelection(componentIds, available);
+        if (validationIssues.Count > 0)
+        {
+            var message = string.Join(
+                "; ",
+                validationIssues.Select(issue => $"{issue.Code} ({issue.ComponentId}): {issue.Message}"));
+            throw new InvalidOperationException($"Composition validation failed: {message}");
+        }
+
         return Task.FromResult<ComposedAgent?>(new ComposedAgent
         {
             Id = Guid.NewGuid().ToString("N"),

--- a/src/Nexo.Infrastructure/Composition/PlaceholderCapabilityComponent.cs
+++ b/src/Nexo.Infrastructure/Composition/PlaceholderCapabilityComponent.cs
@@ -1,0 +1,8 @@
+namespace Nexo.Infrastructure.Composition;
+
+/// <summary>
+/// Marker type used for capability descriptors that are intentionally placeholders.
+/// </summary>
+public sealed class PlaceholderCapabilityComponent
+{
+}

--- a/src/Nexo.Infrastructure/Trust/AccessBoundary.cs
+++ b/src/Nexo.Infrastructure/Trust/AccessBoundary.cs
@@ -12,6 +12,7 @@ public sealed class AccessBoundary : IAccessBoundary
 {
     private readonly string? _configPath;
     private readonly SemaphoreSlim _saveLock = new(1, 1);
+    private ActiveTrustPolicyPack? _activePolicyPack;
 
     private volatile bool _isPaused;
     private readonly ConcurrentDictionary<string, bool> _categoryAllowed = new(StringComparer.OrdinalIgnoreCase);
@@ -146,9 +147,90 @@ public sealed class AccessBoundary : IAccessBoundary
     /// <inheritdoc />
     public event Action<BoundaryChangeEvent>? BoundaryChanged;
 
+    /// <inheritdoc />
+    public void Reset()
+    {
+        _isPaused = false;
+        _categoryAllowed.Clear();
+        _sourceAllowed.Clear();
+        _projectOverrides.Clear();
+        _activePolicyPack = null;
+        RaiseBoundaryChanged(new BoundaryChangeEvent
+        {
+            ChangeType = "reset",
+            NewState = "default"
+        });
+        _ = SaveToFileAsync();
+    }
+
+    /// <inheritdoc />
+    public ActiveTrustPolicyPack? GetActivePolicyPack()
+    {
+        return _activePolicyPack;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, bool> GetCategoryAllowlistSnapshot()
+    {
+        return new Dictionary<string, bool>(_categoryAllowed, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, bool> GetSourceAllowlistSnapshot()
+    {
+        return new Dictionary<string, bool>(_sourceAllowed, StringComparer.OrdinalIgnoreCase);
+    }
+
     private void RaiseBoundaryChanged(BoundaryChangeEvent evt)
     {
         BoundaryChanged?.Invoke(evt);
+    }
+
+    /// <inheritdoc />
+    public void ApplyPolicyPack(TrustPolicyPack pack)
+    {
+        if (pack == null)
+            throw new ArgumentNullException(nameof(pack));
+
+        var normalizedId = pack.Id.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedId))
+            throw new ArgumentException("Trust policy pack id is required.", nameof(pack));
+
+        var previousPack = _activePolicyPack;
+
+        _isPaused = pack.PauseObservationByDefault;
+        _categoryAllowed.Clear();
+        _sourceAllowed.Clear();
+        _projectOverrides.Clear();
+
+        foreach (var kv in pack.CategoryRules)
+            _categoryAllowed[kv.Key] = kv.Value;
+
+        foreach (var kv in pack.SourceRules)
+            _sourceAllowed[kv.Key] = kv.Value;
+
+        foreach (var projectRule in pack.ProjectRules)
+        {
+            _projectOverrides[projectRule.ProjectPath] = new Dictionary<string, bool>(
+                projectRule.SourceRules,
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        _activePolicyPack = new ActiveTrustPolicyPack(
+            normalizedId,
+            string.IsNullOrWhiteSpace(pack.Version) ? "1.0.0" : pack.Version.Trim(),
+            DateTimeOffset.UtcNow);
+
+        RaiseBoundaryChanged(new BoundaryChangeEvent
+        {
+            ChangeType = "policy-pack",
+            PreviousState = previousPack is null
+                ? null
+                : $"{previousPack.Id}@{previousPack.Version}",
+            NewState = $"{_activePolicyPack.Id}@{_activePolicyPack.Version}",
+        });
+
+        _ = SaveToFileAsync();
     }
 
     private void LoadFromFile()
@@ -166,6 +248,13 @@ public sealed class AccessBoundary : IAccessBoundary
                 _sourceAllowed[kv.Key] = kv.Value;
             foreach (var kv in model.ProjectOverrides ?? new Dictionary<string, Dictionary<string, bool>>())
                 _projectOverrides[kv.Key] = kv.Value;
+            if (!string.IsNullOrWhiteSpace(model.ActivePolicyPackId))
+            {
+                _activePolicyPack = new ActiveTrustPolicyPack(
+                    model.ActivePolicyPackId.Trim(),
+                    string.IsNullOrWhiteSpace(model.ActivePolicyPackVersion) ? "1.0.0" : model.ActivePolicyPackVersion.Trim(),
+                    DateTimeOffset.UtcNow);
+            }
         }
         catch
         {
@@ -186,6 +275,8 @@ public sealed class AccessBoundary : IAccessBoundary
                 CategoryAllowed = new Dictionary<string, bool>(_categoryAllowed),
                 SourceAllowed = new Dictionary<string, bool>(_sourceAllowed),
                 ProjectOverrides = _projectOverrides.ToDictionary(kv => kv.Key, kv => new Dictionary<string, bool>(kv.Value ?? new Dictionary<string, bool>()), StringComparer.OrdinalIgnoreCase),
+                ActivePolicyPackId = _activePolicyPack?.Id,
+                ActivePolicyPackVersion = _activePolicyPack?.Version
             };
             var json = JsonSerializer.Serialize(model, JsonOptions);
             await File.WriteAllTextAsync(_configPath!, json).ConfigureAwait(false);
@@ -206,5 +297,7 @@ public sealed class AccessBoundary : IAccessBoundary
         public Dictionary<string, bool>? CategoryAllowed { get; set; }
         public Dictionary<string, bool>? SourceAllowed { get; set; }
         public Dictionary<string, Dictionary<string, bool>>? ProjectOverrides { get; set; }
+        public string? ActivePolicyPackId { get; set; }
+        public string? ActivePolicyPackVersion { get; set; }
     }
 }

--- a/src/Nexo.Infrastructure/Trust/TrustPolicyPackRegistry.cs
+++ b/src/Nexo.Infrastructure/Trust/TrustPolicyPackRegistry.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Paths;
+using Nexo.Core.Application.Trust.Models;
+using Nexo.Core.Application.Trust.Ports;
+
+namespace Nexo.Infrastructure.Trust;
+
+/// <summary>
+/// Loads versioned trust policy packs and applies them to the access boundary.
+/// </summary>
+public sealed class TrustPolicyPackRegistry : ITrustPolicyPackRegistry
+{
+    private readonly string _packsRootPath;
+    private readonly SemaphoreSlim _stateLock = new(1, 1);
+    private readonly string _statePath;
+    private readonly ILogger<TrustPolicyPackRegistry>? _logger;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true
+    };
+    private static readonly JsonSerializerOptions ReadJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private ActiveTrustPolicyPack? _activePack;
+    private IReadOnlyDictionary<string, TrustPolicyPack> _packs = new Dictionary<string, TrustPolicyPack>(StringComparer.OrdinalIgnoreCase);
+
+    public TrustPolicyPackRegistry(string? packsRootPath = null, ILogger<TrustPolicyPackRegistry>? logger = null)
+    {
+        _packsRootPath = ResolvePacksRootPath(packsRootPath);
+        _statePath = ResolveStatePath(_packsRootPath);
+        _logger = logger;
+        Reload();
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<TrustPolicyPackInfo> ListPacks()
+    {
+        return _packs.Values
+            .OrderBy(pack => pack.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(pack => new TrustPolicyPackInfo(pack.Id, pack.Version, pack.DisplayName, pack.Description))
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public TrustPolicyPack? GetById(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+        return _packs.TryGetValue(id.Trim(), out var pack) ? pack : null;
+    }
+
+    /// <inheritdoc />
+    public ActiveTrustPolicyPack? GetActivePack() => _activePack;
+
+    /// <inheritdoc />
+    public async Task<ActiveTrustPolicyPack> ActivateAsync(string id, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            throw new ArgumentException("Trust policy pack id is required.", nameof(id));
+
+        var normalizedId = id.Trim();
+        if (!_packs.TryGetValue(normalizedId, out var pack))
+            throw new InvalidOperationException($"Trust policy pack '{normalizedId}' was not found.");
+
+        var active = new ActiveTrustPolicyPack(
+            pack.Id,
+            string.IsNullOrWhiteSpace(pack.Version) ? "1.0.0" : pack.Version.Trim(),
+            DateTimeOffset.UtcNow);
+
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _activePack = active;
+            var json = JsonSerializer.Serialize(active, _jsonOptions);
+            await File.WriteAllTextAsync(_statePath, json, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+
+        return active;
+    }
+
+    public void Reload()
+    {
+        Directory.CreateDirectory(_packsRootPath);
+        _packs = LoadPacks(_packsRootPath);
+        _activePack = LoadStatus(_statePath);
+    }
+
+    private static IReadOnlyDictionary<string, TrustPolicyPack> LoadPacks(string rootPath)
+    {
+        var packs = new Dictionary<string, TrustPolicyPack>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in Directory.EnumerateFiles(rootPath, "*.json", SearchOption.TopDirectoryOnly))
+        {
+            if (string.Equals(Path.GetFileName(path), "active-pack.json", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var text = File.ReadAllText(path);
+            var pack = JsonSerializer.Deserialize<TrustPolicyPack>(text, ReadJsonOptions);
+            if (pack == null || string.IsNullOrWhiteSpace(pack.Id))
+                continue;
+            packs[pack.Id] = pack;
+        }
+
+        return packs;
+    }
+
+    private static ActiveTrustPolicyPack? LoadStatus(string statePath)
+    {
+        if (!File.Exists(statePath))
+            return null;
+
+        try
+        {
+            var text = File.ReadAllText(statePath);
+            return JsonSerializer.Deserialize<ActiveTrustPolicyPack>(text, ReadJsonOptions);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static string ResolvePacksRootPath(string? configuredPath)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+            return Path.GetFullPath(configuredPath);
+
+        var envPath = Environment.GetEnvironmentVariable("NEXO_TRUST_POLICY_PACKS_PATH");
+        if (!string.IsNullOrWhiteSpace(envPath))
+            return Path.GetFullPath(envPath);
+
+        var repoRoot = RepoPathResolver.FindRepoRoot();
+        return Path.Combine(repoRoot, "config", "trust-packs");
+    }
+
+    private static string ResolveStatePath(string packsRootPath)
+    {
+        var envPath = Environment.GetEnvironmentVariable("NEXO_ACTIVE_TRUST_POLICY_PACK_PATH");
+        if (!string.IsNullOrWhiteSpace(envPath))
+            return Path.GetFullPath(envPath);
+        return Path.Combine(packsRootPath, "active-pack.json");
+    }
+}

--- a/src/Nexo.Infrastructure/Trust/TrustServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Trust/TrustServiceCollectionExtensions.cs
@@ -32,10 +32,20 @@ public static class TrustServiceCollectionExtensions
     /// <param name="configPath">Optional path to persist boundary config (JSON). If null, in-memory only.</param>
     public static IServiceCollection AddAccessBoundary(this IServiceCollection services, string? configPath = null)
     {
+        services.TryAddSingleton<ITrustPolicyPackRegistry>(sp =>
+            new TrustPolicyPackRegistry(Environment.GetEnvironmentVariable("NEXO_TRUST_POLICY_PACKS_PATH")));
         services.TryAddSingleton<IAccessBoundary>(sp =>
         {
             var boundary = new AccessBoundary(configPath);
             var auditLog = sp.GetService<Nexo.Core.Application.Trust.Ports.IDataDecisionAuditLog>();
+            var packRegistry = sp.GetService<ITrustPolicyPackRegistry>();
+            var activePack = packRegistry?.GetActivePack();
+            if (activePack != null)
+            {
+                var packDefinition = packRegistry?.GetById(activePack.Id);
+                if (packDefinition != null)
+                    boundary.ApplyPolicyPack(packDefinition);
+            }
             if (auditLog != null)
                 boundary.BoundaryChanged += evt => auditLog.LogBoundaryChange(evt);
             return boundary;

--- a/src/Nexo.Tests.CLI/Tests/Commands/DoctorCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/DoctorCommandTests.cs
@@ -12,6 +12,7 @@ public sealed class DoctorCommandTests : UnitTestBase
         {
             await TestRunAsyncReturnsExitCode().ConfigureAwait(false);
             await TestJsonOutputContainsOkField().ConfigureAwait(false);
+            await TestJsonOutputIncludesRemediationSection().ConfigureAwait(false);
             return new TestResult
             {
                 Name = nameof(DoctorCommandTests),
@@ -46,7 +47,13 @@ public sealed class DoctorCommandTests : UnitTestBase
 
     private async Task TestRunAsyncReturnsExitCode()
     {
-        var exitCode = await DoctorCommand.ExecuteAsync("demo", includeOptional: false, json: false, CancellationToken.None).ConfigureAwait(false);
+        var exitCode = await DoctorCommand.ExecuteAsync(
+            "demo",
+            includeOptional: false,
+            json: false,
+            fix: false,
+            autoApproveFixes: false,
+            CancellationToken.None).ConfigureAwait(false);
         AssertTrue(exitCode == 0 || exitCode == 1, "Doctor exit code should be deterministic (0 or 1).");
     }
 
@@ -57,11 +64,42 @@ public sealed class DoctorCommandTests : UnitTestBase
         Console.SetOut(writer);
         try
         {
-            var exitCode = await DoctorCommand.ExecuteAsync("demo", includeOptional: false, json: true, CancellationToken.None).ConfigureAwait(false);
+            var exitCode = await DoctorCommand.ExecuteAsync(
+                "demo",
+                includeOptional: false,
+                json: true,
+                fix: false,
+                autoApproveFixes: false,
+                CancellationToken.None).ConfigureAwait(false);
             AssertTrue(exitCode == 0 || exitCode == 1, "Doctor JSON exit code should be deterministic (0 or 1).");
             var output = writer.ToString();
             AssertTrue(output.Contains("\"ok\"", StringComparison.OrdinalIgnoreCase), "Doctor JSON output should include 'ok'.");
             AssertTrue(output.Contains("\"checks\"", StringComparison.OrdinalIgnoreCase), "Doctor JSON output should include 'checks'.");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    private async Task TestJsonOutputIncludesRemediationSection()
+    {
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            var exitCode = await DoctorCommand.ExecuteAsync(
+                "demo",
+                includeOptional: false,
+                json: true,
+                fix: true,
+                autoApproveFixes: false,
+                CancellationToken.None).ConfigureAwait(false);
+            AssertTrue(exitCode == 0 || exitCode == 1, "Doctor JSON fix exit code should be deterministic (0 or 1).");
+            var output = writer.ToString();
+            AssertTrue(output.Contains("\"remediation\"", StringComparison.OrdinalIgnoreCase), "Doctor JSON output should include remediation section.");
+            AssertTrue(output.Contains("\"fixEnabled\"", StringComparison.OrdinalIgnoreCase), "Doctor JSON remediation should include fixEnabled.");
         }
         finally
         {

--- a/src/Nexo.Tests.CLI/Tests/Commands/TrustCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/TrustCommandTests.cs
@@ -56,7 +56,7 @@ public class TrustCommandTests : UnitTestBase
     {
         var auditLog = new Nexo.BackgroundAgents.Trust.DataDecisionAuditLog();
         var logger = new Mock<ILogger<TrustCommand>>();
-        var command = new TrustCommand(auditLog, null, logger.Object);
+        var command = new TrustCommand(auditLog, null, null, logger.Object);
 
         var exitCode = await command.AuditAsync(10, null, null, null, false, false, false);
 
@@ -66,7 +66,7 @@ public class TrustCommandTests : UnitTestBase
     private async Task TestAuditAsync_WithoutAuditLog_ReturnsOne()
     {
         var logger = new Mock<ILogger<TrustCommand>>();
-        var command = new TrustCommand(null, null, logger.Object);
+        var command = new TrustCommand(null, null, null, logger.Object);
 
         var exitCode = await command.AuditAsync(10, null, null, null, false, false, false);
 
@@ -77,7 +77,7 @@ public class TrustCommandTests : UnitTestBase
     {
         var boundary = new AccessBoundary();
         var logger = new Mock<ILogger<TrustCommand>>();
-        var command = new TrustCommand(null, boundary, logger.Object);
+        var command = new TrustCommand(null, boundary, null, logger.Object);
 
         var exitCode = await command.PauseAsync(false);
 
@@ -90,7 +90,7 @@ public class TrustCommandTests : UnitTestBase
         var boundary = new AccessBoundary();
         boundary.SetPause(true);
         var logger = new Mock<ILogger<TrustCommand>>();
-        var command = new TrustCommand(null, boundary, logger.Object);
+        var command = new TrustCommand(null, boundary, null, logger.Object);
 
         var exitCode = await command.ResumeAsync(false);
 
@@ -103,7 +103,7 @@ public class TrustCommandTests : UnitTestBase
         var mockBoundary = new Mock<IAccessBoundary>();
         mockBoundary.Setup(x => x.IsObservationPaused).Returns(false);
         var logger = new Mock<ILogger<TrustCommand>>();
-        var command = new TrustCommand(null, mockBoundary.Object, logger.Object);
+        var command = new TrustCommand(null, mockBoundary.Object, null, logger.Object);
 
         var exitCode = await command.AllowAsync("file-paths", null, null, false);
 
@@ -115,7 +115,7 @@ public class TrustCommandTests : UnitTestBase
     {
         var boundary = new AccessBoundary();
         var logger = new Mock<ILogger<TrustCommand>>();
-        var command = new TrustCommand(null, boundary, logger.Object);
+        var command = new TrustCommand(null, boundary, null, logger.Object);
 
         var exitCode = await command.BoundaryAsync(false);
 

--- a/src/Nexo.Tests.Infrastructure/Tests/Composition/CompositionRegistryValidationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Composition/CompositionRegistryValidationTests.cs
@@ -1,0 +1,52 @@
+using Nexo.Infrastructure.Composition;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Composition;
+
+public sealed class CompositionRegistryValidationTests
+{
+    [Fact]
+    public void ValidateSelection_DefaultPipelineDescriptors_ReturnsNoIssues()
+    {
+        var registry = new CapabilityComponentRegistry();
+        var issues = registry.ValidateSelection(
+            new[] { "perception", "validation", "reporting" },
+            new[] { "perception", "validation", "reporting" });
+
+        Assert.Empty(issues);
+    }
+
+    [Fact]
+    public void ValidateSelection_MissingRequiredCapability_ReturnsActionableIssue()
+    {
+        var registry = new CapabilityComponentRegistry();
+        var issues = registry.ValidateSelection(
+            new[] { "validation" },
+            new[] { "validation" });
+
+        Assert.Contains(issues, issue => issue.Code == "selection.missing-required-capability");
+    }
+
+    [Fact]
+    public void ValidateSelection_IncompatibleComponents_ReturnsActionableIssue()
+    {
+        var registry = new CapabilityComponentRegistry();
+        var issues = registry.ValidateSelection(
+            new[] { "ui-interaction", "process-control" },
+            new[] { "ui-interaction", "process-control" });
+
+        Assert.Contains(issues, issue => issue.Code == "selection.incompatible-components");
+    }
+
+    [Fact]
+    public async Task ComposeAsync_MissingDependencyAfterFiltering_ThrowsInvalidOperationException()
+    {
+        var registry = new CapabilityComponentRegistry();
+        var engine = new CompositionEngine(registry);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => engine.ComposeAsync(
+                "miscellaneous request with no strong keywords",
+                new[] { "validation", "reporting" }));
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Safety/FailClosedTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Safety/FailClosedTests.cs
@@ -258,6 +258,11 @@ public sealed class FailClosedTests : IDisposable
         public void SetCategoryAllowed(string category, bool allowed) => throw new InvalidOperationException("boundary unavailable");
         public void SetSourceAllowed(string sourceId, bool allowed) => throw new InvalidOperationException("boundary unavailable");
         public void SetProjectOverride(string projectPath, IReadOnlyDictionary<string, bool>? overrides) => throw new InvalidOperationException("boundary unavailable");
+        public void Reset() => throw new InvalidOperationException("boundary unavailable");
+        public void ApplyPolicyPack(TrustPolicyPack pack) => throw new InvalidOperationException("boundary unavailable");
+        public ActiveTrustPolicyPack? GetActivePolicyPack() => throw new InvalidOperationException("boundary unavailable");
+        public IReadOnlyDictionary<string, bool> GetCategoryAllowlistSnapshot() => throw new InvalidOperationException("boundary unavailable");
+        public IReadOnlyDictionary<string, bool> GetSourceAllowlistSnapshot() => throw new InvalidOperationException("boundary unavailable");
 #pragma warning disable CS0067
         public event Action<BoundaryChangeEvent>? BoundaryChanged;
 #pragma warning restore CS0067
@@ -273,6 +278,11 @@ public sealed class FailClosedTests : IDisposable
         public void SetCategoryAllowed(string category, bool allowed) { }
         public void SetSourceAllowed(string sourceId, bool allowed) { }
         public void SetProjectOverride(string projectPath, IReadOnlyDictionary<string, bool>? overrides) { }
+        public void Reset() { }
+        public void ApplyPolicyPack(TrustPolicyPack pack) { }
+        public ActiveTrustPolicyPack? GetActivePolicyPack() => null;
+        public IReadOnlyDictionary<string, bool> GetCategoryAllowlistSnapshot() => new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        public IReadOnlyDictionary<string, bool> GetSourceAllowlistSnapshot() => new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 #pragma warning disable CS0067
         public event Action<BoundaryChangeEvent>? BoundaryChanged;
 #pragma warning restore CS0067

--- a/src/Nexo.Tests.Infrastructure/Tests/Trust/TrustPolicyPackRegistryTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Trust/TrustPolicyPackRegistryTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Nexo.Infrastructure.Trust;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Trust;
+
+public sealed class TrustPolicyPackRegistryTests
+{
+    [Fact]
+    public async Task ActivateAsync_PersistsActivePack_AndAccessBoundaryAppliesRules()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"nexo-trust-packs-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var pack = """
+{
+  "id": "strict-enterprise",
+  "version": "1.0.0",
+  "displayName": "Strict enterprise",
+  "description": "Strict profile",
+  "pauseObservationByDefault": false,
+  "categoryRules": { "terminal-output": false },
+  "sourceRules": { "shell": false },
+  "projectRules": []
+}
+""";
+            await File.WriteAllTextAsync(Path.Combine(tempRoot, "strict-enterprise.json"), pack);
+
+            var boundary = new AccessBoundary();
+            var registry = new TrustPolicyPackRegistry(tempRoot);
+            var available = registry.ListPacks();
+            available.Should().ContainSingle(x => x.Id == "strict-enterprise");
+
+            var activated = await registry.ActivateAsync("strict-enterprise");
+            activated.Id.Should().Be("strict-enterprise");
+
+            var activeDefinition = registry.GetById("strict-enterprise");
+            activeDefinition.Should().NotBeNull();
+            boundary.ApplyPolicyPack(activeDefinition!);
+
+            boundary.IsCategoryAllowed("terminal-output").Should().BeFalse();
+            boundary.IsSourceAllowed("shell").Should().BeFalse();
+            boundary.GetActivePolicyPack().Should().NotBeNull();
+            boundary.GetActivePolicyPack()!.Id.Should().Be("strict-enterprise");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+            catch
+            {
+                // ignore cleanup failures in tests
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- complete Phase 2 (phase-60) execution end-to-end across all five roadmap issues:
  1. capability component registry completion
  2. `doctor --fix` safe remediation mode
  3. onboarding reliability gate scheduled drift expansion
  4. single-shot release gate orchestration command
  5. regulated trust policy packs
- follow-up hardening fix: make `trust pack apply` rollback-safe when registry activation fails, and improve trust CI reliability by setting explicit workflow permissions, making unit-test publication non-blocking, and installing protobuf tooling in alpine test image
- additional Alpine compatibility fix: force Trust Alpine docker lane to use native musl binaries for protobuf/gRPC codegen (`PROTOBUF_PROTOC` + `GRPC_PROTOC_PLUGIN`), preventing glibc-linked `grpc.tools` execution failures

## What shipped

### 1) Capability component registry completion
- extend component metadata with required fields and support-level/constraint metadata:
  - `DisplayName`, `Summary`, `SupportLevel`, `RequiredCapabilities`, `IncompatibleWith`
- add deterministic metadata validation issues (`ComponentValidationIssue`) and validator (`ComponentDescriptorValidator`)
- enforce validation at registry registration + composition-time selection validation
- add compose filtering option `--support-level` and actionable failure diagnostics
- add placeholder implementation marker type and remove invalid `TBD` metadata shape
- add targeted tests for metadata completeness and selection behavior

### 2) `doctor --fix` safe remediation mode
- implement `doctor --fix` and `--yes` path with explicit-consent semantics
- add remediation taxonomy + execution/reporting via `DoctorRemediation`
- include remediation result payload in doctor JSON output
- update onboarding automation docs with remediation flow

### 3) Onboarding reliability gate scheduled drift expansion
- add weekly scheduled trigger to onboarding quickstart gate
- add onboarding failure taxonomy script and artifacts (`*-taxonomy.json`)
- add drift signal trend artifacts (`*-trend.json`) for scheduled/regression analysis
- include troubleshooting pointers in workflow summaries

### 4) Single-shot release gate orchestration command
- add `ci release-bundle` command with profile presets and unified PASS/FAIL verdict
- generate standardized report artifacts:
  - JSON: `release-bundle-report.json`
  - Markdown: `release-bundle-report.md`
- include sub-gate status + artifact hints in unified report output

### 5) Regulated trust policy packs
- add trust policy pack model/contracts and registry:
  - `TrustPolicyPack`, `TrustPolicyPackInfo`, `ActiveTrustPolicyPack`
  - `ITrustPolicyPackRegistry`, `TrustPolicyPackRegistry`
- extend access boundary to apply/report active policy packs
- add CLI pack activation/visibility:
  - `nexo trust pack list`
  - `nexo trust pack apply --id <pack>`
  - boundary/dashboard now include active pack metadata
- add API trust status visibility for active pack via `GET /api/trust/status`
- ship predefined packs:
  - `strict-enterprise`
  - `internal-only`
  - `air-gapped`
- add trust pack integration tests and update trust architecture docs

### Follow-up hardening fixes
- `trust pack apply` now restores previous boundary state if activation persistence fails (prevents boundary/registry divergence)
- trust multi-env workflow now declares explicit check-write permissions and makes publish-unit-test step non-blocking with reduced comment noise
- alpine trust test image now includes protobuf package to support protoc-dependent builds
- alpine trust test image now sets:
  - `PROTOBUF_PROTOC=/usr/bin/protoc`
  - `GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin`
  so gRPC codegen uses Alpine-native binaries compatible with musl

## Validation performed
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net9.0 --filter "FullyQualifiedName~Trust" --logger "console;verbosity=minimal"`
- `dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj -f net9.0 --filter "FullyQualifiedName~Trust" --logger "console;verbosity=minimal"`
- prior phase-2 validation commands remain applicable

## Commits
- `a0e7a974` Complete capability registry metadata validation and compose filtering
- `eca28133` Add doctor fix remediation and scheduled onboarding drift taxonomy
- `a2373fbf` Add ci release-bundle orchestrator with unified reports
- `029c116c` Ship regulated trust policy packs with CLI and API status
- `f8614dd8` Harden trust pack apply and trust CI reliability
- `065a6515` Fix Alpine grpc tools compatibility in trust Docker image
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e2cf93c-2952-4768-b1d1-cf6315940f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e2cf93c-2952-4768-b1d1-cf6315940f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

