### PR TITLE
Reduce redundancy across CLI command flow, workflow skip semantics, and generated templates

### DIFF
--- a/src/Nexo.CLI/Commands/AnalyzeCommand.cs
+++ b/src/Nexo.CLI/Commands/AnalyzeCommand.cs
@@ -3,7 +3,6 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Nexo.CLI.Formatting;
 using Nexo.Core.Application.Analysis.UseCases.AnalyzeCode;
-using Nexo.Core.Application.Common.Models;
 using Nexo.Core.Domain.Exceptions;
 
 namespace Nexo.CLI.Commands;
@@ -58,26 +57,11 @@ public class AnalyzeCommand
 
         try
         {
-            Progress<ProgressReport>? progress = null;
-            if (verbose || !json)
-            {
-                progress = new Progress<ProgressReport>(report =>
-                {
-                    if (json)
-                    {
-                        // In JSON mode, only log to stderr
-                        _logger.LogInformation(
-                            "Progress: {Percentage}% - {Message}",
-                            report.Percentage,
-                            report.Message);
-                    }
-                    else
-                    {
-                        // In normal mode, show progress on stdout
-                        _renderer.RenderProgress(report);
-                    }
-                });
-            }
+            var progress = CommandExecutionSupport.CreateProgressReporter(
+                verbose,
+                json,
+                _logger,
+                _renderer);
 
             var command = new AnalyzeCodeCommand(path, progress);
             var result = await _mediator.Send(command);
@@ -93,7 +77,12 @@ public class AnalyzeCommand
         }
         catch (AnalysisException ex)
         {
-            return HandleAnalysisException(ex);
+            return CommandExecutionSupport.RenderDomainFailure(
+                _logger,
+                _renderer,
+                ex,
+                "Analysis failed",
+                (int)ExitCode.ValidationFailed);
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -107,20 +96,6 @@ public class AnalyzeCommand
             _renderer.RenderError(ex.Message);
             return (int)ExitCode.UnexpectedError;
         }
-    }
-
-    private int HandleAnalysisException(AnalysisException ex)
-    {
-        _logger.LogError(ex, "Analysis failed");
-        if (!string.IsNullOrEmpty(ex.ErrorCode))
-        {
-            _renderer.RenderErrorWithCode(ex.Message, ex.ErrorCode, ex.Suggestion);
-        }
-        else
-        {
-            _renderer.RenderError(ex.Message);
-        }
-        return (int)ExitCode.ValidationFailed;
     }
 }
 

--- a/src/Nexo.CLI/Commands/CommandExecutionSupport.cs
+++ b/src/Nexo.CLI/Commands/CommandExecutionSupport.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+using Nexo.CLI.Formatting;
+using Nexo.Core.Application.Common.Models;
+
+namespace Nexo.CLI.Commands;
+
+internal static class CommandExecutionSupport
+{
+    internal static Progress<ProgressReport>? CreateProgressReporter(
+        bool verbose,
+        bool json,
+        ILogger logger,
+        IConsoleRenderer renderer)
+    {
+        if (!verbose && json)
+            return null;
+
+        return new Progress<ProgressReport>(report =>
+        {
+            if (json)
+            {
+                logger.LogInformation(
+                    "Progress: {Percentage}% - {Message}",
+                    report.Percentage,
+                    report.Message);
+                return;
+            }
+
+            renderer.RenderProgress(report);
+        });
+    }
+
+    internal static int RenderDomainFailure(
+        ILogger logger,
+        IConsoleRenderer renderer,
+        Exception exception,
+        string logMessage,
+        int exitCode)
+    {
+        logger.LogError(exception, logMessage);
+        var code = exception switch
+        {
+            Nexo.Core.Domain.Exceptions.AnalysisException analysis => analysis.ErrorCode,
+            Nexo.Core.Domain.Exceptions.ValidationException validation => validation.ErrorCode,
+            _ => null
+        };
+        var suggestion = exception switch
+        {
+            Nexo.Core.Domain.Exceptions.AnalysisException analysis => analysis.Suggestion,
+            Nexo.Core.Domain.Exceptions.ValidationException validation => validation.Suggestion,
+            _ => null
+        };
+
+        if (!string.IsNullOrWhiteSpace(code))
+            renderer.RenderErrorWithCode(exception.Message, code!, suggestion);
+        else
+            renderer.RenderError(exception.Message);
+
+        return exitCode;
+    }
+}

--- a/src/Nexo.CLI/Commands/ValidateCommand.cs
+++ b/src/Nexo.CLI/Commands/ValidateCommand.cs
@@ -51,24 +51,11 @@ public class ValidateCommand
 
         try
         {
-            Progress<ProgressReport>? progress = null;
-            if (verbose || !json)
-            {
-                progress = new Progress<ProgressReport>(report =>
-                {
-                    if (json)
-                    {
-                        _logger.LogInformation(
-                            "Progress: {Percentage}% - {Message}",
-                            report.Percentage,
-                            report.Message);
-                    }
-                    else
-                    {
-                        _renderer.RenderProgress(report);
-                    }
-                });
-            }
+            var progress = CommandExecutionSupport.CreateProgressReporter(
+                verbose,
+                json,
+                _logger,
+                _renderer);
 
             var command = new RunValidationCommand(filter, progress);
             var result = await _mediator.Send(command);
@@ -84,7 +71,12 @@ public class ValidateCommand
         }
         catch (ValidationException ex)
         {
-            return HandleValidationException(ex);
+            return CommandExecutionSupport.RenderDomainFailure(
+                _logger,
+                _renderer,
+                ex,
+                "Validation failed",
+                (int)ExitCode.ValidationFailed);
         }
         catch (Exception ex)
         {
@@ -92,20 +84,6 @@ public class ValidateCommand
             _renderer.RenderError(ex.Message);
             return (int)ExitCode.UnexpectedError;
         }
-    }
-
-    private int HandleValidationException(ValidationException ex)
-    {
-        _logger.LogError(ex, "Validation failed");
-        if (!string.IsNullOrEmpty(ex.ErrorCode))
-        {
-            _renderer.RenderErrorWithCode(ex.Message, ex.ErrorCode, ex.Suggestion);
-        }
-        else
-        {
-            _renderer.RenderError(ex.Message);
-        }
-        return (int)ExitCode.ValidationFailed;
     }
 }
 

--- a/src/Nexo.CLI/Commands/WorkflowCommand.cs
+++ b/src/Nexo.CLI/Commands/WorkflowCommand.cs
@@ -1517,7 +1517,7 @@ public sealed class WorkflowCommand : Command
             if (!candidateState.PullResult.Ok && executionTarget.IsLocal)
             {
                 scenario = new ScenarioExecutionResult(
-                    Ok: true,
+                    Ok: false,
                     Summary: $"Skipped due to model pull failure: {candidateState.PullResult.Summary}",
                     ConflictCount: 0,
                     EscalationCount: 0,
@@ -1530,7 +1530,7 @@ public sealed class WorkflowCommand : Command
                      !preflight.Ok)
             {
                 scenario = new ScenarioExecutionResult(
-                    Ok: true,
+                    Ok: false,
                     Summary: $"Skipped due to provider preflight failure ({candidateState.ProfileProvider}): {preflight.Detail}",
                     ConflictCount: 0,
                     EscalationCount: 0,

--- a/src/Nexo.Client/NexoClientModels.cs
+++ b/src/Nexo.Client/NexoClientModels.cs
@@ -3,14 +3,28 @@ namespace Nexo.Client;
 // Request DTOs
 public sealed record AgentRequest(string AgentName, string? InputFilePath = null);
 public sealed record ValidationRequest(string? Filter = null);
-public sealed record OrchestrationRequest(string Request);
+public sealed record OrchestrationRequest(
+    string Request,
+    string? RuntimeSpecJson = null,
+    string? PreferModel = null,
+    string? Provider = null,
+    string? BarrierLevel = null,
+    string? PreferredRegion = null);
 public sealed record ExecutionBuildRequest(string DockerfilePath, string ImageTag, string ContextPath, Dictionary<string, string>? BuildArgs = null);
 public sealed record ExecutionRunRequest(string ImageTag, string[] Command, Dictionary<string, string>? EnvironmentVariables = null, Dictionary<string, string>? VolumeMounts = null, string? WorkingDirectory = null);
 
 // Response DTOs
 public sealed record AgentResponse(bool Success, string? Message, object? Output);
 public sealed record ValidationResponse(bool Passed, string? Message, int TotalTests, int PassedTests, int FailedTests);
-public sealed record OrchestrationResponse(bool Success, string? Summary, object? Output);
+public sealed record OrchestrationResponse(
+    bool Success,
+    string? Summary,
+    object? Output,
+    int? Conflicts = null,
+    int? Escalations = null,
+    string? ErrorCode = null);
 public sealed record StatusResponse(string Mode, string Message, int TotalAgents, int ActiveAgents);
 public sealed record ExecutionBuildResponse(bool Success, string? ErrorMessage, double DurationMs);
 public sealed record ExecutionRunResponse(bool Success, int ExitCode, string StandardOutput, string StandardError, string? ContainerId, double DurationMs);
+
+public sealed record TrustStatusResponse(bool IsPaused, string Status, string? ActivePolicyPackId, string? ActivePolicyPackVersion);

--- a/src/Nexo.Infrastructure/Execution/ProviderFactory.cs
+++ b/src/Nexo.Infrastructure/Execution/ProviderFactory.cs
@@ -1024,7 +1024,9 @@ public class ProviderFactory : IProviderFactory
         calls.Add(CreateWriteCall(
             root,
             "src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiDomainKnowledgeRetentionTests.cs",
-            BuildUiDomainKnowledgeRetentionTestSource()));
+            LoadCanonicalGeneratedSource(
+                root,
+                "src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiDomainKnowledgeRetentionTests.cs")));
 
         return JsonSerializer.Serialize(new { tool_calls = calls });
     }
@@ -3023,111 +3025,15 @@ export function mountFeature(host, context) {
 """;
     }
 
-    private static string BuildUiDomainKnowledgeRetentionTestSource() => """
-using Nexo.Core.Application.Testing.Abstractions;
-using Nexo.Core.Application.Testing.Models;
-using System.Text.Json;
-
-namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
-
-public sealed class UiDomainKnowledgeRetentionTests : UnitTestBase
-{
-    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    private static string BuildUiDomainKnowledgeRetentionTestSource()
     {
-        try
-        {
-            var dir = new DirectoryInfo(AppContext.BaseDirectory);
-            string? repoRoot = null;
-            while (dir != null)
-            {
-                if (Directory.Exists(Path.Combine(dir.FullName, "src")) &&
-                    Directory.Exists(Path.Combine(dir.FullName, "docs")))
-                {
-                    repoRoot = dir.FullName;
-                    break;
-                }
-                dir = dir.Parent;
-            }
-            AssertTrue(!string.IsNullOrWhiteSpace(repoRoot), "Unable to resolve repository root from test context.");
-
-            var uiRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "app");
-            var hostRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "host");
-            var avaloniaRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "avalonia");
-            var htmlPath = Path.Combine(uiRoot, "index.html");
-            var jsPath = Path.Combine(uiRoot, "app.js");
-            var domainPath = Path.Combine(uiRoot, "domain-knowledge.json");
-            var hostProgramPath = Path.Combine(hostRoot, "Program.cs");
-            var hostProjectPath = Path.Combine(hostRoot, "UiDemoHost.csproj");
-            var smokeProgramPath = Path.Combine(hostRoot, "SmokeProgram.cs");
-            var avaloniaContractsPath = Path.Combine(avaloniaRoot, "Nexo.Ui.Abstractions", "UiContracts.cs");
-            var avaloniaHostProgramPath = Path.Combine(avaloniaRoot, "Nexo.Ui.AvaloniaHost", "Program.cs");
-
-            AssertTrue(File.Exists(htmlPath), "Expected index.html to exist.");
-            AssertTrue(File.Exists(jsPath), "Expected app.js to exist.");
-            AssertTrue(File.Exists(domainPath), "Expected domain-knowledge.json to exist.");
-            AssertTrue(File.Exists(hostProgramPath), "Expected .NET host Program.cs to exist.");
-            AssertTrue(File.Exists(hostProjectPath), "Expected .NET host project file to exist.");
-            AssertTrue(File.Exists(smokeProgramPath), "Expected .NET smoke program to exist.");
-            AssertTrue(File.Exists(avaloniaContractsPath), "Expected Avalonia abstraction contracts to exist.");
-            AssertTrue(File.Exists(avaloniaHostProgramPath), "Expected Avalonia host Program.cs to exist.");
-
-            var html = File.ReadAllText(htmlPath);
-            var js = File.ReadAllText(jsPath);
-            var domainJson = File.ReadAllText(domainPath);
-            var hostProgram = File.ReadAllText(hostProgramPath);
-            var avaloniaContracts = File.ReadAllText(avaloniaContractsPath);
-            var avaloniaHostProgram = File.ReadAllText(avaloniaHostProgramPath);
-
-            AssertTrue(html.Contains("Nexo Chatbot", StringComparison.Ordinal), "UI should render chatbot section.");
-            AssertTrue(html.Contains("Dynamically loaded features", StringComparison.Ordinal), "UI should render dynamic feature host section.");
-            AssertTrue(js.Contains("explainNexo", StringComparison.Ordinal), "JS should implement chatbot explainer behavior.");
-            AssertTrue(js.Contains("/api/scaffold-feature", StringComparison.Ordinal), "JS should call scaffold API endpoint.");
-            AssertTrue(js.Contains("import(moduleUrl)", StringComparison.Ordinal), "JS should dynamically import generated feature modules.");
-            AssertTrue(hostProgram.Contains("MapPost(\"/api/scaffold-feature\"", StringComparison.Ordinal), ".NET host should expose scaffold endpoint.");
-            AssertTrue(hostProgram.Contains("UseStaticFiles", StringComparison.Ordinal), ".NET host should serve static UI.");
-            AssertTrue(avaloniaContracts.Contains("IUiFrameworkAdapter", StringComparison.Ordinal), "Avalonia stack should include cross-framework adapter contract.");
-            AssertTrue(avaloniaContracts.Contains("CrossFrameworkCompatibility", StringComparison.Ordinal), "Avalonia stack should include compatibility contract notes.");
-            AssertTrue(avaloniaHostProgram.Contains("AVALONIA_FEATURE_HOTLOAD", StringComparison.Ordinal), "Avalonia host should scaffold via Avalonia hotload objective.");
-            AssertTrue(avaloniaHostProgram.Contains("AVALONIA_APP_TRANSFORM", StringComparison.Ordinal), "Avalonia host should support full app transformation objective.");
-            AssertTrue(avaloniaHostProgram.Contains("Galactic Operations Console", StringComparison.Ordinal), "Avalonia host should render a distinct transformed application shell.");
-            AssertTrue(avaloniaHostProgram.Contains("AvaloniaUiFrameworkAdapter", StringComparison.Ordinal), "Avalonia host should render nodes through framework adapter.");
-            using var doc = JsonDocument.Parse(domainJson);
-            var capabilities = doc.RootElement.GetProperty("capabilities");
-            AssertTrue(capabilities.GetArrayLength() >= 4, "Expected at least 4 domain capabilities.");
-
-            return Task.FromResult(new TestResult
-            {
-                Name = nameof(UiDomainKnowledgeRetentionTests),
-                Category = "SelfExtendGenerated",
-                Passed = true,
-                Message = "UI demo retains domain knowledge and required artifacts."
-            });
-        }
-        catch (AssertionException ex)
-        {
-            return Task.FromResult(new TestResult
-            {
-                Name = nameof(UiDomainKnowledgeRetentionTests),
-                Category = "SelfExtendGenerated",
-                Passed = false,
-                ErrorMessage = $"Assertion failed: {ex.Message}",
-                StackTrace = ex.StackTrace
-            });
-        }
-        catch (Exception ex)
-        {
-            return Task.FromResult(new TestResult
-            {
-                Name = nameof(UiDomainKnowledgeRetentionTests),
-                Category = "SelfExtendGenerated",
-                Passed = false,
-                ErrorMessage = $"Unexpected exception: {ex.Message}",
-                StackTrace = ex.StackTrace
-            });
-        }
+        const string resourceName = "Nexo.Infrastructure.Execution.Templates.UiDomainKnowledgeRetentionTests.template.cs";
+        using var stream = typeof(ProviderFactory).Assembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+            throw new InvalidOperationException($"Embedded resource not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
     }
-}
-""";
 
     private static string BuildErrorStateSource() => """
 namespace Nexo.Unity.Generated;
@@ -3362,6 +3268,28 @@ public sealed class {{testClassName}} : UnitTestBase
         return match.Success && !string.IsNullOrWhiteSpace(match.Groups["root"].Value)
             ? match.Groups["root"].Value
             : ".";
+    }
+
+    private static string LoadCanonicalGeneratedSource(string root, string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+            return BuildUiDomainKnowledgeRetentionTestSource();
+
+        try
+        {
+            var baseRoot = string.IsNullOrWhiteSpace(root) ? "." : root;
+            var fullRoot = Path.IsPathRooted(baseRoot) ? baseRoot : Path.GetFullPath(baseRoot);
+            var fullPath = Path.GetFullPath(Path.Combine(fullRoot, relativePath));
+
+            if (File.Exists(fullPath))
+                return File.ReadAllText(fullPath);
+        }
+        catch
+        {
+            // Fall back to embedded template below.
+        }
+
+        return BuildUiDomainKnowledgeRetentionTestSource();
     }
 
     private static string InferScreenType(string prompt)

--- a/src/Nexo.Infrastructure/Execution/Templates/UiDomainKnowledgeRetentionTests.template.cs
+++ b/src/Nexo.Infrastructure/Execution/Templates/UiDomainKnowledgeRetentionTests.template.cs
@@ -1,0 +1,103 @@
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+using System.Text.Json;
+
+namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
+
+public sealed class UiDomainKnowledgeRetentionTests : UnitTestBase
+{
+    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            string? repoRoot = null;
+            while (dir != null)
+            {
+                if (Directory.Exists(Path.Combine(dir.FullName, "src")) &&
+                    Directory.Exists(Path.Combine(dir.FullName, "docs")))
+                {
+                    repoRoot = dir.FullName;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+            AssertTrue(!string.IsNullOrWhiteSpace(repoRoot), "Unable to resolve repository root from test context.");
+
+            var uiRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "app");
+            var hostRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "host");
+            var avaloniaRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "avalonia");
+            var htmlPath = Path.Combine(uiRoot, "index.html");
+            var jsPath = Path.Combine(uiRoot, "app.js");
+            var domainPath = Path.Combine(uiRoot, "domain-knowledge.json");
+            var hostProgramPath = Path.Combine(hostRoot, "Program.cs");
+            var hostProjectPath = Path.Combine(hostRoot, "UiDemoHost.csproj");
+            var smokeProgramPath = Path.Combine(hostRoot, "SmokeProgram.cs");
+            var avaloniaContractsPath = Path.Combine(avaloniaRoot, "Nexo.Ui.Abstractions", "UiContracts.cs");
+            var avaloniaHostProgramPath = Path.Combine(avaloniaRoot, "Nexo.Ui.AvaloniaHost", "Program.cs");
+
+            AssertTrue(File.Exists(htmlPath), "Expected index.html to exist.");
+            AssertTrue(File.Exists(jsPath), "Expected app.js to exist.");
+            AssertTrue(File.Exists(domainPath), "Expected domain-knowledge.json to exist.");
+            AssertTrue(File.Exists(hostProgramPath), "Expected .NET host Program.cs to exist.");
+            AssertTrue(File.Exists(hostProjectPath), "Expected .NET host project file to exist.");
+            AssertTrue(File.Exists(smokeProgramPath), "Expected .NET smoke program to exist.");
+            AssertTrue(File.Exists(avaloniaContractsPath), "Expected Avalonia abstraction contracts to exist.");
+            AssertTrue(File.Exists(avaloniaHostProgramPath), "Expected Avalonia host Program.cs to exist.");
+
+            var html = File.ReadAllText(htmlPath);
+            var js = File.ReadAllText(jsPath);
+            var domainJson = File.ReadAllText(domainPath);
+            var hostProgram = File.ReadAllText(hostProgramPath);
+            var avaloniaContracts = File.ReadAllText(avaloniaContractsPath);
+            var avaloniaHostProgram = File.ReadAllText(avaloniaHostProgramPath);
+
+            AssertTrue(html.Contains("Nexo Chatbot", StringComparison.Ordinal), "UI should render chatbot section.");
+            AssertTrue(html.Contains("Dynamically loaded features", StringComparison.Ordinal), "UI should render dynamic feature host section.");
+            AssertTrue(js.Contains("explainNexo", StringComparison.Ordinal), "JS should implement chatbot explainer behavior.");
+            AssertTrue(js.Contains("/api/scaffold-feature", StringComparison.Ordinal), "JS should call scaffold API endpoint.");
+            AssertTrue(js.Contains("import(moduleUrl)", StringComparison.Ordinal), "JS should dynamically import generated feature modules.");
+            AssertTrue(hostProgram.Contains("MapPost(\"/api/scaffold-feature\"", StringComparison.Ordinal), ".NET host should expose scaffold endpoint.");
+            AssertTrue(hostProgram.Contains("UseStaticFiles", StringComparison.Ordinal), ".NET host should serve static UI.");
+            AssertTrue(avaloniaContracts.Contains("IUiFrameworkAdapter", StringComparison.Ordinal), "Avalonia stack should include cross-framework adapter contract.");
+            AssertTrue(avaloniaContracts.Contains("CrossFrameworkCompatibility", StringComparison.Ordinal), "Avalonia stack should include compatibility contract notes.");
+            AssertTrue(avaloniaHostProgram.Contains("AVALONIA_FEATURE_HOTLOAD", StringComparison.Ordinal), "Avalonia host should scaffold via Avalonia hotload objective.");
+            AssertTrue(avaloniaHostProgram.Contains("AVALONIA_APP_TRANSFORM", StringComparison.Ordinal), "Avalonia host should support full app transformation objective.");
+            AssertTrue(avaloniaHostProgram.Contains("Galactic Operations Console", StringComparison.Ordinal), "Avalonia host should render a distinct transformed application shell.");
+            AssertTrue(avaloniaHostProgram.Contains("AvaloniaUiFrameworkAdapter", StringComparison.Ordinal), "Avalonia host should render nodes through framework adapter.");
+            using var doc = JsonDocument.Parse(domainJson);
+            var capabilities = doc.RootElement.GetProperty("capabilities");
+            AssertTrue(capabilities.GetArrayLength() >= 4, "Expected at least 4 domain capabilities.");
+
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiDomainKnowledgeRetentionTests),
+                Category = "SelfExtendGenerated",
+                Passed = true,
+                Message = "UI demo retains domain knowledge and required artifacts."
+            });
+        }
+        catch (AssertionException ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiDomainKnowledgeRetentionTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiDomainKnowledgeRetentionTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+    }
+}

--- a/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+++ b/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
@@ -12,6 +12,10 @@
     </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Execution/Templates/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nexo.Brick.Contracts\Nexo.Brick.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.Core.Domain\Nexo.Core.Domain.csproj" />
@@ -20,6 +24,10 @@
         <ProjectReference Include="..\Nexo.Policies\Nexo.Policies.csproj" />
         <ProjectReference Include="..\Nexo.Runtime\Nexo.Runtime.csproj" />
         <ProjectReference Include="..\Nexo.Abstractions\Nexo.Abstractions.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <EmbeddedResource Include="Execution/Templates/UiDomainKnowledgeRetentionTests.template.cs" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize `workflow optimize` skipped-infra semantics so model-pull/preflight skips are consistently marked `Ok: false` (matching existing stress/gate accounting)
- reduce CLI command duplication by introducing shared command execution helpers for progress reporting + domain exception rendering, then applying them in `AnalyzeCommand` and `ValidateCommand`
- align `Nexo.Client` orchestration DTO contracts with the expanded API orchestration request/response shape
- remove duplicated in-code generated source for `UiDomainKnowledgeRetentionTests` from `ProviderFactory`; now load the canonical checked-in test file (with embedded-template fallback)

## Redundancy hardening details

### Workflow semantics consolidation
- changed optimize-path skipped scenario creation to use:
  - `Ok: false`
  - `FailureCategory: "skipped_infra"`
  - `Skipped: true`
- this aligns optimize with existing skipped handling and avoids duplicate contradictory semantics for skipped runs.

### CLI command scaffolding dedup
- added `CommandExecutionSupport` with:
  - `CreateProgressReporter(...)`
  - `RenderDomainFailure(...)`
- updated both commands to use this shared support:
  - `AnalyzeCommand`
  - `ValidateCommand`

### Client/API contract alignment
- expanded `Nexo.Client` orchestration models to match API orchestration payload support:
  - request: `RuntimeSpecJson`, `PreferModel`, `Provider`, `BarrierLevel`, `PreferredRegion`
  - response: `Conflicts`, `Escalations`, `ErrorCode`

### Generated source dedup in ProviderFactory
- replaced inline giant string literal for `UiDomainKnowledgeRetentionTests` with canonical-source loading via:
  - `LoadCanonicalGeneratedSource(root, relativePath)`
- added embedded fallback template resource:
  - `src/Nexo.Infrastructure/Execution/Templates/UiDomainKnowledgeRetentionTests.template.cs`
- configured resource in `Nexo.Infrastructure.csproj` and excluded template `.cs` files from compilation.

## Validation performed
- `dotnet build src/Nexo.CLI/Nexo.CLI.csproj -v minimal`
- `dotnet build src/Nexo.Client/Nexo.Client.csproj -v minimal`
- `dotnet run --project src/Nexo.CLI -- test local --filter AnalyzeCommandTests --format-json`
- `dotnet run --project src/Nexo.CLI -- test local --filter ValidateCommandTests --format-json`

## Known testing gap
- `dotnet run --project src/Nexo.CLI -- test local --filter WorkflowCommandTests --format-json` fails at a pre-existing assertion in `TestOptimizeAutoPromotesWinnerBaselineAsync` (same failure location observed before this hardening pass). This PR does not introduce that underlying failure, but does touch `WorkflowCommand` skip semantics, so workflow suite follow-up should be handled separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e2cf93c-2952-4768-b1d1-cf6315940f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e2cf93c-2952-4768-b1d1-cf6315940f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

