### PR TITLE
Execute comprehensive Nexo roadmap: all 20 items across 3 phases + cross-cutting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Description
+
+<!-- Clear description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should happen -->
+
+## Actual Behavior
+
+<!-- What happens instead -->
+
+## Environment
+
+- OS:
+- .NET SDK version:
+- Nexo version/commit:
+- Deployment mode (native/container):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem does this solve? -->
+
+## Proposed Solution
+
+<!-- How should this work? -->
+
+## Alternatives Considered
+
+<!-- Other approaches you considered -->
+
+## Additional Context
+
+<!-- Any other information -->

--- a/.github/ISSUE_TEMPLATE/integrator_feedback.md
+++ b/.github/ISSUE_TEMPLATE/integrator_feedback.md
@@ -1,0 +1,31 @@
+---
+name: Integrator Feedback
+about: Report SDK/integration issues or friction points
+labels: sdk, integrator-feedback
+---
+
+## Integration Type
+
+<!-- e.g. Host SDK (Nexo.Hosting), Client SDK (Nexo.Sdk), Brick Provider, Background Agent -->
+
+## SDK Version
+
+<!-- Version or commit hash -->
+
+## Issue Description
+
+<!-- What went wrong or was confusing -->
+
+## Code Sample
+
+```csharp
+// Minimal reproduction
+```
+
+## Expected Behavior
+
+<!-- What the SDK docs or API suggest should happen -->
+
+## Workaround
+
+<!-- Any workaround you found (if applicable) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+<!-- Bulleted list of specific changes -->
+
+-
+
+## Testing
+
+<!-- How were these changes tested? Include commands, screenshots, or links to CI runs -->
+
+-
+
+## Checklist
+
+- [ ] `make test` passes locally
+- [ ] Documentation updated (if applicable)
+- [ ] No `TODO` or `NotImplementedException` left unresolved
+- [ ] Breaking changes are documented

--- a/.github/workflows/onboarding-quickstart-gate.yml
+++ b/.github/workflows/onboarding-quickstart-gate.yml
@@ -215,3 +215,64 @@ PY
             ${{ runner.temp }}/onboarding/container-linux-taxonomy.json
             ${{ runner.temp }}/onboarding/onboarding-container-linux-trend.json
           retention-days: 14
+
+  onboarding-failure-categorization:
+    name: onboarding-failure-categorization
+    runs-on: ubuntu-latest
+    needs:
+      - quickstart-linux-native
+      - quickstart-linux-ephemeral-container
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download native quickstart artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: onboarding-quickstart-native-linux
+          path: artifacts/native
+
+      - name: Download container quickstart artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: onboarding-quickstart-container-linux
+          path: artifacts/container
+
+      - name: Categorize failures from gate logs
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p categorized
+          NAT_LOG="$(find artifacts/native -name 'native-linux.log' -print -quit 2>/dev/null || true)"
+          CONT_LOG="$(find artifacts/container -name 'container-linux.log' -print -quit 2>/dev/null || true)"
+          if [[ -z "${NAT_LOG}" ]]; then NAT_LOG="/nonexistent/native-linux.log"; fi
+          if [[ -z "${CONT_LOG}" ]]; then CONT_LOG="/nonexistent/container-linux.log"; fi
+          bash scripts/onboarding/failure-taxonomy.sh "quickstart-native-linux" "${NAT_LOG}" > categorized/native-linux-taxonomy.json
+          bash scripts/onboarding/failure-taxonomy.sh "quickstart-container-linux" "${CONT_LOG}" > categorized/container-linux-taxonomy.json
+          python - <<'PY' > categorized/onboarding-failure-categorization-summary.json
+          import json
+          from pathlib import Path
+          out = {"lanes": []}
+          for name in ("native-linux-taxonomy.json", "container-linux-taxonomy.json"):
+              p = Path("categorized") / name
+              if p.is_file():
+                  try:
+                      out["lanes"].append(json.loads(p.read_text(encoding="utf-8")))
+                  except json.JSONDecodeError as e:
+                      out["lanes"].append({"artifact": name, "error": str(e)})
+          print(json.dumps(out, indent=2))
+          PY
+
+      - name: Upload categorized failure taxonomy
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: onboarding-failure-categorization
+          path: categorized/
+          retention-days: 14

--- a/.github/workflows/perf-certification.yml
+++ b/.github/workflows/perf-certification.yml
@@ -1,0 +1,45 @@
+name: perf-certification
+
+on:
+  workflow_dispatch:
+    inputs:
+      baseline:
+        description: "Baseline label for this certification run (e.g. release tag or commit SHA)"
+        required: false
+        default: "manual"
+
+jobs:
+  perf-tests:
+    name: perf-certification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Run perf / benchmark-scoped tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p perf-results
+          echo "{\"baseline\":\"${{ github.event.inputs.baseline }}\",\"runId\":\"${{ github.run_id }}\",\"sha\":\"${{ github.sha }}\"}" > perf-results/perf-certification-meta.json
+          dotnet test Nexo.sln \
+            --configuration Release \
+            --logger "trx;LogFileName=perf-certification.trx" \
+            --results-directory perf-results \
+            --filter "FullyQualifiedName~Nexo.Tests.Orchestration.Performance|FullyQualifiedName~Benchmark" \
+            --verbosity minimal
+
+      - name: Upload perf certification results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-certification-${{ github.run_id }}
+          path: perf-results/
+          retention-days: 30

--- a/.github/workflows/test-caching-multi-env.yml
+++ b/.github/workflows/test-caching-multi-env.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Build Docker image
         if: matrix.environment.type == 'docker'
-        continue-on-error: true
         run: |
           docker build \
             -f ${{ matrix.environment.dockerfile }} \
@@ -74,7 +73,6 @@ jobs:
 
       - name: Run Base Framework Tests (Docker)
         if: matrix.environment.type == 'docker'
-        continue-on-error: true
         run: |
           docker run --rm \
             -v ${{ github.workspace }}/test-results:/workspace/test-results \
@@ -89,7 +87,7 @@ jobs:
 
       - name: Run Base Framework Tests (Native)
         if: matrix.environment.type == 'native'
-        run: dotnet run --project src/Nexo.CLI -- test multi-env --suite caching --env ${{ matrix.environment.name }} || true
+        run: dotnet run --project src/Nexo.CLI -- test multi-env --suite caching --env ${{ matrix.environment.name }}
 
       - name: Publish Test Results
         if: always() && runner.os != 'Windows'
@@ -117,7 +115,13 @@ jobs:
     needs: test-caching
     if: always()
     steps:
-      - name: Check test results
+      - name: Aggregate results
         run: |
-          echo "All caching tests completed across all environments"
-          echo "Check individual job results for details"
+          if [ "${{ needs.test-caching.result }}" = "failure" ]; then
+            echo "::error::One or more caching test environments failed"
+            exit 1
+          elif [ "${{ needs.test-caching.result }}" = "cancelled" ]; then
+            echo "::warning::Caching tests were cancelled"
+            exit 1
+          fi
+          echo "All caching tests passed across all environments"

--- a/apps/release-manager/README.md
+++ b/apps/release-manager/README.md
@@ -1,0 +1,24 @@
+# Release Manager
+
+Vertical app configuration for release-readiness automation: monitoring the repo, running targeted tests, collecting SLO evidence, and generating readiness summaries.
+
+## Agent set
+
+Background agent definitions live in `config/agent_set.release_manager.json`. The set includes:
+
+- **repo-monitor** (optimizer): watches the repository for changes that affect release gates.
+- **test-runner** (tester): runs framework smoke tests on a schedule.
+- **slo-collector** (optimizer): gathers SLO and gate artifact paths under `.nexo/`.
+- **report-generator** (optimizer): produces release readiness report output (configured output directory: `.nexo/release-manager/reports`).
+
+This mirrors the structure of `apps/runtime-studio/config/agent_set.local.json` (roles, schedules, exfiltration policy). Tune intervals and filters for your environment.
+
+## Running
+
+Point the Nexo background-agent daemon at this config file, for example:
+
+```bash
+dotnet run --project src/Nexo.CLI -- background-agent daemon --config apps/release-manager/config/agent_set.release_manager.json
+```
+
+Ensure the repo root is correct when starting the daemon so paths in `Parameters` resolve.

--- a/apps/release-manager/config/agent_set.release_manager.json
+++ b/apps/release-manager/config/agent_set.release_manager.json
@@ -1,0 +1,138 @@
+{
+  "BackgroundAgents": {
+    "Agents": [
+      {
+        "Id": "repo-monitor",
+        "Name": "Release Manager Repo Monitor",
+        "Role": "optimizer",
+        "ModelProvider": "deterministic",
+        "ModelName": "noop",
+        "Commands": [
+          "watch",
+          "summarize_changes"
+        ],
+        "Parameters": {
+          "RepoRoot": ".",
+          "Objective": "Monitor the repository for changes relevant to release readiness.",
+          "AgentName": "release-manager-repo-monitor"
+        },
+        "Schedule": {
+          "Type": "Interval",
+          "Interval": "00:05:00",
+          "InitialDelay": "00:00:15"
+        },
+        "Enabled": true,
+        "MaxDataSensitivity": "Internal",
+        "AllowedDataSensitivityLevels": [
+          "Public",
+          "Internal"
+        ],
+        "ExfiltrationPolicy": {
+          "BlockExternalLLMs": true,
+          "BlockWebSearch": true,
+          "BlockNetworkExports": true,
+          "RequireLocalOnly": true,
+          "MaxAllowedLevel": "Internal"
+        }
+      },
+      {
+        "Id": "test-runner",
+        "Name": "Release Manager Test Runner",
+        "Role": "tester",
+        "ModelProvider": "deterministic",
+        "Commands": [
+          "test"
+        ],
+        "Parameters": {
+          "Filter": "FullyQualifiedName~BaseFrameworkSmokeTests"
+        },
+        "Schedule": {
+          "Type": "Interval",
+          "Interval": "00:10:00",
+          "InitialDelay": "00:00:30"
+        },
+        "Enabled": true,
+        "MaxDataSensitivity": "Internal",
+        "AllowedDataSensitivityLevels": [
+          "Public",
+          "Internal"
+        ],
+        "ExfiltrationPolicy": {
+          "BlockExternalLLMs": true,
+          "BlockWebSearch": true,
+          "BlockNetworkExports": true,
+          "RequireLocalOnly": true,
+          "MaxAllowedLevel": "Internal"
+        }
+      },
+      {
+        "Id": "slo-collector",
+        "Name": "Release Manager SLO Evidence Collector",
+        "Role": "optimizer",
+        "ModelProvider": "deterministic",
+        "ModelName": "noop",
+        "Commands": [
+          "collect_slo",
+          "snapshot_evidence"
+        ],
+        "Parameters": {
+          "EvidencePaths": [
+            ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.json",
+            ".nexo/release-bundle/last-run/release-bundle-report.json"
+          ]
+        },
+        "Schedule": {
+          "Type": "Interval",
+          "Interval": "00:15:00",
+          "InitialDelay": "00:01:00"
+        },
+        "Enabled": true,
+        "MaxDataSensitivity": "Internal",
+        "AllowedDataSensitivityLevels": [
+          "Public",
+          "Internal"
+        ],
+        "ExfiltrationPolicy": {
+          "BlockExternalLLMs": true,
+          "BlockWebSearch": true,
+          "BlockNetworkExports": true,
+          "RequireLocalOnly": true,
+          "MaxAllowedLevel": "Internal"
+        }
+      },
+      {
+        "Id": "report-generator",
+        "Name": "Release Readiness Report Generator",
+        "Role": "optimizer",
+        "ModelProvider": "deterministic",
+        "ModelName": "noop",
+        "Commands": [
+          "generate_report",
+          "emit_summary"
+        ],
+        "Parameters": {
+          "ReportTemplate": "release-readiness",
+          "OutputDir": ".nexo/release-manager/reports"
+        },
+        "Schedule": {
+          "Type": "Interval",
+          "Interval": "00:20:00",
+          "InitialDelay": "00:01:30"
+        },
+        "Enabled": true,
+        "MaxDataSensitivity": "Internal",
+        "AllowedDataSensitivityLevels": [
+          "Public",
+          "Internal"
+        ],
+        "ExfiltrationPolicy": {
+          "BlockExternalLLMs": true,
+          "BlockWebSearch": true,
+          "BlockNetworkExports": true,
+          "RequireLocalOnly": true,
+          "MaxAllowedLevel": "Internal"
+        }
+      }
+    ]
+  }
+}

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -51,6 +51,13 @@ Use this page as the navigation starting point for docs.
 - `docs/SelfHostedAgentServer.md` — `docker-compose.agent-server.yml`: mounted workspace + env template `docs/config/agent-server.env.example`.
 - `docs/Phase1SecureCopilotWalkthrough.md` — first-success secure copilot MVP walkthrough using `docker-compose.agent-server.yml`.
 
+## Planning & Roadmap
+
+- `docs/ExecutionPlan.md` — phased execution plan with implementation tasks, dependencies, and success metrics.
+- `docs/IssueBatch_30-60-90_Roadmap.md` — 30/60/90 gap-closure issue batch (issue templates).
+- `docs/NorthStarGapAnalysis.md` — North Star vs codebase gap analysis with status tracking.
+- `docs/GapAnalysis.md` — dogfood, observe→improve, trust, and documentation gap analysis.
+
 ## Additional Material
 
 - `docs/Persistence.md` — persistence behavior and options.

--- a/docs/ExecutionPlan.md
+++ b/docs/ExecutionPlan.md
@@ -1,0 +1,605 @@
+# Nexo Execution Plan
+
+Comprehensive execution plan derived from the 30/60/90 roadmap, North Star gap analysis, and current codebase state. Each work item includes what already exists, what remains, dependencies, risks, and concrete implementation tasks.
+
+**Guiding principle:** Every item is sequenced so that earlier work de-risks or enables later work. Items within the same phase can be parallelized unless a dependency is noted.
+
+---
+
+## Phase 1 — Foundation & Product Proof (Phase-30 items)
+
+These items establish the first end-to-end product experience and close the most critical framework gaps. Complete these before moving to Phase 2.
+
+---
+
+### 1.1 Secure Engineering Copilot MVP
+
+**What exists:**
+- `POST /api/copilot/task` endpoint with orchestration + audit trail (`NexoEndpoints.cs`).
+- Portal UI in `wwwroot/index.html` with chat-style copilot task flow.
+- Trust dashboard/pause/rules endpoints (`/api/trust/*`).
+- `docker-compose.agent-server.yml` for local deployment.
+- Walkthrough doc (`docs/Phase1SecureCopilotWalkthrough.md`).
+
+**What remains:**
+- The copilot flow is synchronous request/response with no task persistence, correlation IDs, or execution history.
+- No dedicated authz on copilot endpoints (relies on shared API-key middleware).
+- Portal UI is minimal — no execution history view, no audit timeline visualization.
+- No operator onboarding wizard or guided first-run experience.
+
+**Implementation tasks:**
+1. Add task persistence: store copilot task submissions and results in LiteDB with correlation IDs. Define `ICopilotTaskStore` port in `Nexo.Core.Application`, implement in `Nexo.Infrastructure`.
+2. Add execution history endpoint: `GET /api/copilot/tasks` with pagination, filtering by status/date.
+3. Add correlation ID propagation: generate a `copilotTaskId` on submission, thread it through `OrchestrateAsync` and into audit log entries so the audit trail is filterable per task.
+4. Enhance portal UI: add task history sidebar, audit timeline per task, trust boundary status indicator.
+5. Add operator first-run flow: detect empty state, show guided setup (API key, Ollama connection, trust pack selection).
+6. Update `docs/Phase1SecureCopilotWalkthrough.md` with the full flow including history and audit drill-down.
+7. Add E2E smoke test: submit task via API, verify result + audit entries + history retrieval.
+
+**Files to modify:**
+- `src/Nexo.Core.Application/` — new port `ICopilotTaskStore`
+- `src/Nexo.Infrastructure/` — LiteDB implementation
+- `src/Nexo.API/Endpoints/NexoEndpoints.cs` — history endpoint, correlation IDs
+- `src/Nexo.API/wwwroot/index.html` — portal UI enhancements
+- `src/Nexo.Hosting/NexoServiceCollectionExtensions.cs` — register new services
+- `docs/Phase1SecureCopilotWalkthrough.md`
+
+**Dependencies:** None — this is the first item to start.  
+**Risks:** Orchestration latency may make synchronous copilot tasks feel slow for complex requests. Consider adding a simple polling/status pattern if tasks exceed ~10s.
+
+---
+
+### 1.2 Wire Observe → Improve Integration
+
+**What exists:**
+- `nexo observe` populates `IPatternStore` (LiteDB) with patterns (`repeated-edits`, `edit-then-build`).
+- `nexo improve` runs static analysis → adaptation on a fixed or user-specified path.
+- `nexo improve --self` runs `SelfImprovementLoop` which reads both `ITestFailureStore` and `IPatternStore`.
+- `SelfImprovementLoop` already queries `repeated-edits` and `edit-then-build` patterns.
+
+**What remains:**
+- Default `nexo improve` (without `--self`) does not read `IPatternStore` at all — it targets a fixed path.
+- No `--from-observation` flag to query recent patterns and prioritize analysis.
+- No single `nexo loop` command that runs observe + improve sequentially.
+- Test failure ingestion into `ITestFailureStore` is not wired from real test runs (only seeded in tests).
+
+**Implementation tasks:**
+1. Add `--from-observation` option to `ImproveCommand`: when set, query `IPatternStore` for recent patterns, extract affected file paths, and use them as analysis targets instead of the default path.
+2. Register `IPatternStore` in the `ImproveCommand` service collection (currently only `ObserveCommand` registers it).
+3. Wire TRX → `ITestFailureStore`: after `dotnet test` via `DotnetTestTool` / `TrxTestResultParser`, bridge parsed `TestResult` failures into `ITestFailureStore.RecordAsync`. Add this bridge in `Nexo.Infrastructure` (e.g. `TestFailureIngestionBridge`).
+4. Add `nexo improve --continuous` that runs observe (N minutes configurable) then improve on observed paths, in a loop.
+5. Add integration tests validating the observe → improve → self-context pipeline with pattern-driven targeting.
+6. Document the wired flow in `docs/GapAnalysis.md` and update the recommendation section.
+
+**Files to modify:**
+- `src/Nexo.CLI/Commands/ImproveCommand.cs` — add `--from-observation`, wire `IPatternStore`
+- `src/Nexo.Infrastructure/SelfImprovement/` — `TestFailureIngestionBridge`
+- `src/Nexo.Infrastructure/Validation/` — bridge from `TrxTestResultParser` to `ITestFailureStore`
+- `src/Nexo.Tests.Infrastructure/` — integration tests
+- `docs/GapAnalysis.md`
+
+**Dependencies:** None — can be done in parallel with 1.1.  
+**Risks:** Pattern store may contain noisy or stale entries; add a staleness filter (e.g. patterns older than 7 days are excluded by default).
+
+---
+
+### 1.3 Mesh Trust Tiers — Routing Policy Enforcement
+
+**What exists:**
+- `PeerTrustTier` enum (`Unknown`, `Untrusted`, `Trusted`) on `PeerInfo`.
+- CLI `--set-trust-tier` updates peer trust tier in `instances.json` with metadata preservation.
+- `PeerTrustPolicyResolver`, `NcrCapabilityRouter`, `NexoPeerBrickExecutor` in routing infrastructure.
+
+**What remains:**
+- Verify routing policy actually blocks execution to disallowed tiers (audit the `NcrCapabilityRouter` behavior).
+- Add routing policy options surface: `trusted-only`, `trusted-preferred`, `any` — confirm these are configurable and enforced.
+- Surface trust tier in `nexo mesh` status output and API status endpoints.
+- Add audit events for trust-tier routing decisions (accepted/rejected with reason).
+
+**Implementation tasks:**
+1. Audit `NcrCapabilityRouter` and `PeerTrustPolicyResolver` to confirm tier enforcement end-to-end. Document findings.
+2. If routing policy options are not yet configurable via CLI/env, add config: `NEXO_MESH_TRUST_POLICY=trusted-only|trusted-preferred|any`.
+3. Add tier display to `nexo mesh` list output (show tier next to each peer).
+4. Add audit log entries when a peer is skipped due to trust tier policy.
+5. Add integration tests: mixed-tier peer snapshots, `trusted-only` blocks `untrusted`, `trusted-preferred` falls back correctly.
+6. Add smoke test for policy toggle + routing outcomes.
+
+**Files to modify:**
+- `src/Nexo.Infrastructure/Execution/Routing/` — policy enforcement, audit
+- `src/Nexo.Infrastructure/Mesh/` — status display
+- `src/Nexo.CLI/Commands/MeshCommand.cs` — tier display
+- `src/Nexo.Tests.Infrastructure/` and `src/Nexo.Tests.CLI/` — tests
+
+**Dependencies:** None — can be done in parallel with 1.1 and 1.2.  
+**Risks:** Low. The data model and CLI surface already exist; this is mostly wiring and verification.
+
+---
+
+### 1.4 SDK and Port Stabilization v1
+
+**What exists:**
+- `Nexo.Sdk` with `NexoSdkBuilder` (thin wrapper over `Nexo.Client`).
+- `docs/sdk.md` with stable/experimental/internal classification.
+- `docs/samples/StableSdkHostSample/` with `Program.cs` showing brick/agent registration.
+- `Nexo.Abstractions` contains core port definitions.
+
+**What remains:**
+- No CI lane validates the reference sample builds and runs independently.
+- No explicit `[Stable]` / `[Experimental]` attributes on public APIs.
+- No breaking-change policy document.
+- `UseAdaptiveRouting()` is documented as a no-op / experimental.
+
+**Implementation tasks:**
+1. Add CI lane that builds and runs `StableSdkHostSample` in isolation (verify it compiles against published/local NuGet only — no project references to internals).
+2. Add `docs/SdkCompatibilityPolicy.md`: semver rules, deprecation process, breaking-change notification.
+3. Audit all public types in `Nexo.Sdk`, `Nexo.Client`, `Nexo.Abstractions`, `Nexo.Brick.Contracts` — classify each as Stable / Experimental / Internal. Add classification table to `docs/sdk.md`.
+4. Add XML doc comments indicating stability level on key public interfaces.
+5. Remove or clearly mark `UseAdaptiveRouting()` as experimental in `NexoSdkBuilder`.
+
+**Files to modify:**
+- `.github/workflows/` — new or extended workflow for SDK sample CI
+- `docs/sdk.md` — classification table
+- `docs/SdkCompatibilityPolicy.md` — new
+- `src/Nexo.Sdk/NexoSdkBuilder.cs` — stability annotations
+- `src/Nexo.Abstractions/` — stability annotations on ports
+
+**Dependencies:** None — can be done in parallel.  
+**Risks:** Premature stabilization of APIs that may need to change. Mitigate by keeping the stable surface minimal (only `Nexo.Sdk`, `Nexo.Client`, `Nexo.Brick.Contracts`).
+
+---
+
+### 1.5 SLO Evidence Pipeline Hardening
+
+**What exists:**
+- `RuntimeCommand` with `--emit-slo-evidence`, `--slo-warning-only`, env thresholds (`NEXO_RELEASE_SLO_*`).
+- `RuntimeSloEvidence` / `RuntimeLaneSloEvidence` models.
+- `ci release-bundle` includes runtime-gate step.
+- Tests in `RuntimeCommandTests` validating SLO JSON output.
+
+**What remains:**
+- SLO evidence is runtime-gate scoped; broader release gates (cross-platform, trust, caching) don't emit SLO summaries.
+- RC checklist (`docs/ReleaseCandidateChecklist-v1.md`) may not reference concrete SLO artifact paths.
+- No trend comparison between releases.
+
+**Implementation tasks:**
+1. Extend `ci release-bundle` to collect SLO evidence from each gate step (not just runtime-gate).
+2. Add SLO summary section to `release-bundle-report.md` output.
+3. Update `docs/ReleaseCandidateChecklist-v1.md` to reference SLO artifact paths from release-bundle output.
+4. Add `--compare-baseline` option to compare current SLO metrics against a stored baseline.
+5. Add test for forced SLO threshold violation → promotion failure.
+
+**Files to modify:**
+- `src/Nexo.CLI/Commands/CiCommand.cs` — extend release-bundle SLO collection
+- `src/Nexo.CLI/Commands/RuntimeCommand.cs` — baseline comparison
+- `docs/ReleaseCandidateChecklist-v1.md`
+- `src/Nexo.Tests.CLI/` — threshold violation test
+
+**Dependencies:** Lightweight dependency on 1.1 (copilot MVP may inform which SLO metrics matter most).  
+**Risks:** Low. SLO infrastructure is already functional; this is extension and documentation.
+
+---
+
+## Phase 2 — Framework Maturity (Phase-60 items)
+
+These items deepen the framework's reliability, developer experience, and operational readiness. Start after Phase 1 core items (1.1, 1.2) are complete.
+
+---
+
+### 2.1 Capability Component Registry Completion
+
+**What exists:**
+- `CapabilityComponentRegistry` with in-memory store, registration, lookup, `ValidateSelection`.
+- `ComponentDescriptor` model with `Id`, `Capability`, `DisplayName`, `Summary`, `InputSchema`, `OutputSchema`, `Version`, `SupportLevel`, `RequiredCapabilities`, `IncompatibleWith`.
+- `ComponentDescriptorValidator` enforces core fields, rejects `TBD` implementation types, validates semver.
+- Seed includes real components + North Star placeholders via `PlaceholderCapabilityComponent`.
+
+**What remains:**
+- `InputSchema` / `OutputSchema` are on the model but not validated by `ComponentDescriptorValidator`.
+- Composition-time filtering by capability/constraint is not fully exposed in CLI.
+- Placeholder components need replacement with real implementations or explicit exclusion from production composition.
+
+**Implementation tasks:**
+1. Add `InputSchema` / `OutputSchema` validation to `ComponentDescriptorValidator` (non-empty when `SupportLevel` is `Stable`).
+2. Add `nexo compose --filter-capability <cap>` to filter components by capability during composition.
+3. Add `nexo compose --list-components` to show registry contents with metadata completeness indicators.
+4. Replace or remove `PlaceholderCapabilityComponent` entries that have real implementations.
+5. Add registry audit report command: `nexo compose audit` showing completeness per component.
+6. Add unit tests for schema validation and composition filtering.
+
+**Files to modify:**
+- `src/Nexo.Infrastructure/Composition/ComponentDescriptorValidator.cs`
+- `src/Nexo.Infrastructure/Composition/CapabilityComponentRegistry.cs`
+- `src/Nexo.CLI/` — compose subcommands
+- `src/Nexo.Tests.Infrastructure/`
+
+**Dependencies:** Benefits from 1.4 (SDK stabilization clarifies which components are stable).  
+**Risks:** Schema validation may break existing tests that use minimal descriptors. Add migration path with warnings before hard enforcement.
+
+---
+
+### 2.2 Doctor `--fix` Remediation Hardening
+
+**What exists:**
+- `DoctorCommand` with `--fix` and `--yes` flags.
+- `DoctorRemediation.cs` implements remediation runner.
+- `scripts/onboarding/failure-taxonomy.sh` maps failures to remediation.
+- `ci release-bundle` runs `doctor --json` (read-only check).
+
+**What remains:**
+- Verify remediation coverage: which failure categories does `--fix` actually handle?
+- JSON output from `--fix` may not include before/after state for all remediation actions.
+- No integration test with mocked failure scenarios validating end-to-end remediation.
+
+**Implementation tasks:**
+1. Audit `DoctorRemediation.cs` — catalog which failure types are handled and which are not.
+2. Add before/after state to JSON remediation output for each action.
+3. Add mocked-failure integration tests: simulate missing tools, wrong SDK version, broken config — verify `--fix` resolves them.
+4. Add `nexo doctor --fix --dry-run` mode that reports what would be fixed without acting.
+5. Update `docs/GettingStarted.md` with `doctor --fix` as part of the setup flow.
+6. Align `failure-taxonomy.sh` categories with `DoctorRemediation` problem taxonomy.
+
+**Files to modify:**
+- `src/Nexo.CLI/Commands/DoctorCommand.cs`
+- `src/Nexo.CLI/Commands/DoctorRemediation.cs`
+- `src/Nexo.Tests.CLI/` — remediation integration tests
+- `scripts/onboarding/failure-taxonomy.sh`
+- `docs/GettingStarted.md`
+
+**Dependencies:** None.  
+**Risks:** Auto-remediation that modifies system state is inherently risky. Keep `--yes` as opt-in; default to interactive confirmation.
+
+---
+
+### 2.3 Onboarding Reliability Gate Expansion
+
+**What exists:**
+- `onboarding-quickstart-gate.yml` with weekly cron schedule (`0 7 * * 1`).
+- Drift signals emitted as JSON (`driftSignals.isScheduledRun`, `isRetry`).
+- Native + container lanes.
+
+**What remains:**
+- Drift detection is a signal in JSON but there is no automated comparison between scheduled runs.
+- No failure categorization by lane/platform/root cause in the workflow output.
+- No trend dashboard or alerting on regression.
+
+**Implementation tasks:**
+1. Add run-over-run comparison: store previous scheduled run summary as a workflow artifact, diff against current run.
+2. Add failure categorization step: parse test/setup outputs and classify by `failure-taxonomy.sh` categories.
+3. Add summary artifact with platform × lane × failure-category matrix.
+4. Add optional notification (GitHub issue or workflow annotation) when new failures appear vs. previous scheduled run.
+5. Add documentation in `docs/Testing.md` explaining the drift detection mechanism.
+
+**Files to modify:**
+- `.github/workflows/onboarding-quickstart-gate.yml`
+- `scripts/onboarding/failure-taxonomy.sh` — extend for workflow integration
+- `docs/Testing.md`
+
+**Dependencies:** Benefits from 2.2 (doctor `--fix` provides remediation for detected drift).  
+**Risks:** Scheduled CI runs consume minutes; keep the workflow lean. Use `workflow_dispatch` for on-demand deep checks.
+
+---
+
+### 2.4 Release Gate Orchestration — Unified Reports
+
+**What exists:**
+- `ci release-bundle` with `--profile` (`default` | `quick`).
+- Steps: verify → runtime-gate → doctor JSON.
+- Outputs `release-bundle-report.json` and `release-bundle-report.md`.
+
+**What remains:**
+- Only three steps in the bundle; cross-platform, trust, and caching gates are not included.
+- Report may not aggregate sub-gate pass/fail status clearly.
+- No `--profile full` that runs all gates.
+
+**Implementation tasks:**
+1. Add `--profile full` that includes: verify, runtime-gate, doctor, trust-gate, cross-platform-smoke, caching-smoke.
+2. For each step, capture exit code + summary + artifact paths.
+3. Enhance `release-bundle-report.md` with a clear pass/fail matrix per gate.
+4. Add `--fail-fast` option (default true) to stop on first failure, and `--continue` to run all gates.
+5. Add integration test for pass-path and forced-failure-path.
+6. Update `docs/ReleaseCandidateChecklist-v1.md` to reference `ci release-bundle --profile full`.
+
+**Files to modify:**
+- `src/Nexo.CLI/Commands/CiCommand.cs` — profiles, steps, report format
+- `src/Nexo.Tests.CLI/` — integration tests
+- `docs/ReleaseCandidateChecklist-v1.md`
+
+**Dependencies:** Benefits from 1.5 (SLO evidence feeds into release report).  
+**Risks:** Full gate profile may be slow. Mitigate with `--profile quick` as default and `full` for RC cuts.
+
+---
+
+### 2.5 Trust Policy Pack Maturation
+
+**What exists:**
+- Three packs: `air-gapped.json`, `internal-only.json`, `strict-enterprise.json`.
+- `TrustPolicyPackRegistry` with load, activate, persist to `active-pack.json`.
+- CLI `trust pack list` / `trust pack apply --id`.
+- `IAccessBoundary.ApplyPolicyPack` integration.
+
+**What remains:**
+- Verify pack behavior actually enforces the described boundaries (not just metadata).
+- No trust integration tests that run across all packs.
+- Pack version visibility in `nexo status` or API status output may be incomplete.
+
+**Implementation tasks:**
+1. Add trust integration tests for each pack: apply pack, attempt operations that should be blocked, verify enforcement.
+2. Add pack version and active status to `GET /api/status` response.
+3. Add `nexo trust pack describe --id <id>` to show pack rules in human-readable form.
+4. Add pack migration guidance: document how to transition between packs.
+5. Add operator docs mapping deployment scenarios to recommended packs.
+
+**Files to modify:**
+- `src/Nexo.Tests.Infrastructure/` — trust pack integration tests
+- `src/Nexo.API/Endpoints/NexoEndpoints.cs` — status enrichment
+- `src/Nexo.CLI/Commands/TrustCommand.cs` — `describe` subcommand
+- `docs/` — operator pack selection guide
+
+**Dependencies:** None.  
+**Risks:** Low. Infrastructure exists; this is verification and documentation.
+
+---
+
+## Phase 3 — Production Readiness & Vision (Phase-90 items)
+
+These items push Nexo toward production use and external adoption. Start after Phase 2 core items are stable.
+
+---
+
+### 3.1 First Application-Suite Vertical
+
+**What exists:**
+- `apps/runtime-studio/` with agent-set JSON configs and shell scripts.
+- Game director variant with dedicated agent set.
+- Background agent infrastructure (scheduling, registry, lifecycle).
+- Copilot MVP endpoint (from 1.1).
+
+**What remains:**
+- No standalone, product-quality vertical application.
+- Runtime Studio is config + scripts, not a deployable product.
+
+**Recommended vertical: Engineering Release Manager**
+- Leverages existing: `ci release-bundle`, SLO evidence, trust packs, background agents, changelog generation.
+- User journey: configure release criteria → agents monitor repo → automated release readiness assessment → operator approval → release.
+
+**Implementation tasks:**
+1. Define user journeys and acceptance criteria for the release manager vertical.
+2. Build release manager agent set (JSON config for background agents): repo monitor, test runner, SLO collector, report generator.
+3. Add release manager API endpoints or extend copilot flow for release-specific queries.
+4. Build minimal dashboard UI (extend portal or standalone page) showing release readiness status.
+5. Add deployment docs: compose file, env config, operator guide.
+6. Add E2E scenario test: repo change → agent detection → readiness report → approval simulation.
+
+**Files to modify:**
+- `apps/` — new `release-manager/` directory with agent configs
+- `src/Nexo.API/` — release-specific endpoints or views
+- `src/Nexo.BackgroundAgents/` — release monitor agent role
+- `docs/` — vertical docs
+
+**Dependencies:** 1.1 (copilot MVP), 1.5 (SLO pipeline), 2.4 (release gate orchestration).  
+**Risks:** Scope creep. Keep the first vertical minimal: readiness dashboard + automated checks. Defer approval workflows and notifications to a follow-up.
+
+---
+
+### 3.2 Multi-Instance Mesh Governance
+
+**What exists:**
+- Mesh discovery, `nexo mesh` commands, peer trust tiers (from 1.3).
+- Shared adaptation cache, sneakernet export/import.
+- `FileBasedInstanceDiscovery`, `FileBasedCapabilityAdvertisement`.
+
+**What remains:**
+- No peer admission workflow (peers are added by file manipulation).
+- No revocation with immediate routing effect.
+- No policy propagation between instances.
+
+**Implementation tasks:**
+1. Design peer admission state machine: `pending` → `admitted` → `active` (or `rejected`).
+2. Implement admission workflow in `MeshCommand`: `nexo mesh admit <peerId>`, `nexo mesh revoke <peerId>`.
+3. Wire revocation into routing: revoked peers are immediately excluded from `NcrCapabilityRouter`.
+4. Add policy version field to mesh advertisements; receiving peers can detect and warn on mismatched policy versions.
+5. Add governance audit trail: all admission/revocation events logged.
+6. Add integration tests for admission → routing → revocation → routing-exclusion flow.
+
+**Files to modify:**
+- `src/Nexo.Core.Application/Mesh/` — admission models
+- `src/Nexo.Infrastructure/Mesh/` — admission state persistence
+- `src/Nexo.Infrastructure/Execution/Routing/` — revocation enforcement
+- `src/Nexo.CLI/Commands/MeshCommand.cs`
+- `src/Nexo.Tests.Infrastructure/` and `src/Nexo.Tests.CLI/`
+
+**Dependencies:** 1.3 (mesh trust tiers provide the trust model that governance builds on).  
+**Risks:** Distributed state consistency. Keep it simple: file-based state with eventual consistency, not distributed consensus.
+
+---
+
+### 3.3 Load/Performance Certification Lane
+
+**What exists:**
+- Runtime benchmarks directory (`docs/runtime/benchmarks/README.md`).
+- SLO evidence with configurable thresholds.
+- `dotnet test` with blame-hang timeouts.
+
+**What remains:**
+- No formal load test harness.
+- No repeatable workload profiles.
+- No trend retention or regression detection.
+
+**Implementation tasks:**
+1. Define 3 representative workload profiles: single-agent simple task, multi-agent orchestration, mesh-routed execution.
+2. Implement benchmark harness using BenchmarkDotNet or a custom runner that emits structured JSON results.
+3. Add CI workflow (`perf-certification.yml`) that runs workload profiles and stores results as artifacts.
+4. Add regression detection: compare current run against stored baseline; fail on >10% degradation (configurable).
+5. Add trend report generation: markdown summary with throughput/latency/error rates across recent runs.
+
+**Files to modify:**
+- `src/` — new `Nexo.Benchmarks` project or extend `Nexo.Tests.Infrastructure`
+- `.github/workflows/` — `perf-certification.yml`
+- `docs/runtime/benchmarks/` — workload profiles and trend docs
+
+**Dependencies:** 1.1 (copilot MVP defines the primary workload), 2.4 (release gate can include perf lane).  
+**Risks:** Benchmarks on CI runners are noisy. Use relative comparison (% change) rather than absolute thresholds. Run on dedicated runner class if available.
+
+---
+
+### 3.4 External Integrator Program
+
+**What exists:**
+- `docs/sdk.md` with stability tiers.
+- `StableSdkHostSample` reference integration.
+- `Nexo.Brick.Contracts` for plugin wire format.
+
+**What remains:**
+- Only one reference integration exists.
+- No external integrator feedback loop.
+- No compatibility matrix across versions.
+
+**Implementation tasks:**
+1. Build 2 additional reference integrations: (a) external brick provider (HTTP catalog), (b) custom background agent using SDK.
+2. Add integration CI lane: build all reference integrations against current SDK.
+3. Create compatibility matrix: SDK version × reference integration version → pass/fail.
+4. Add `docs/IntegratorGuide.md`: onboarding steps, common patterns, troubleshooting.
+5. Add feedback triage template (GitHub issue template for integrators).
+6. Conduct dry-run with a non-core contributor; document friction points.
+
+**Files to modify:**
+- `docs/samples/` — additional reference integrations
+- `.github/workflows/` — SDK compatibility CI
+- `.github/ISSUE_TEMPLATE/` — integrator feedback template
+- `docs/IntegratorGuide.md`
+
+**Dependencies:** 1.4 (SDK stabilization defines what integrators build against).  
+**Risks:** External adoption feedback may require breaking changes. Use the compatibility policy from 1.4 to manage expectations.
+
+---
+
+## Cross-Cutting Items (any phase)
+
+These are smaller items that should be addressed opportunistically alongside the phased work.
+
+---
+
+### C.1 Fix `HttpBarrierContextMiddleware`
+
+**Current state:** No-op middleware — `InvokeAsync` just calls `next(context)`. The TODO says: populate `BarrierResolutionContext` from `HttpContext` and run `IBarrierIdentityResolverPipeline`.
+
+**Tasks:**
+1. Inject `IBarrierIdentityResolverPipeline` into the middleware constructor.
+2. Build `BarrierResolutionContext` from `HttpContext` (extract claims, headers, request metadata).
+3. Call pipeline and handle results (block, allow, audit).
+4. Add integration test with mock pipeline.
+
+**Files:** `src/Nexo.Runtime/Barriers/Identity/HttpBarrierContextMiddleware.cs`  
+**Risk:** Breaking change if existing deployments rely on the no-op behavior. Add feature flag (`NEXO_BARRIER_MIDDLEWARE_ENABLED`).
+
+---
+
+### C.2 Implement `PerfHeadroom` Policy
+
+**Current state:** Always returns `Approve = true`. `_maxPerTool` is stored but unused.
+
+**Tasks:**
+1. Implement time-budget tracking per tool invocation.
+2. Reject when cumulative tool time exceeds `_maxPerTool`.
+3. Add unit tests for approval and rejection paths.
+
+**Files:** `src/Nexo.Policies/PerfHeadroom.cs`  
+**Risk:** Low. Policy is opt-in.
+
+---
+
+### C.3 Fix CI `continue-on-error` in Test Caching Workflow
+
+**Current state:** `test-caching-multi-env.yml` has `continue-on-error: true` on Docker build, test, and publish steps. The summary job always succeeds.
+
+**Tasks:**
+1. Remove `continue-on-error: true` from build and test steps.
+2. Keep `continue-on-error: true` only on optional publish/reporting steps.
+3. Add proper failure aggregation in summary job: check `needs.test-caching.result`.
+4. Fix Windows `|| true` to use proper error handling.
+
+**Files:** `.github/workflows/test-caching-multi-env.yml`  
+**Risk:** May expose currently-hidden test failures. Run the workflow once before and after to understand impact.
+
+---
+
+### C.4 Add PR Template and Issue Templates
+
+**Tasks:**
+1. Create `.github/PULL_REQUEST_TEMPLATE.md` with sections: Summary, Changes, Testing, Checklist.
+2. Create `.github/ISSUE_TEMPLATE/bug_report.md` with reproduction steps template.
+3. Create `.github/ISSUE_TEMPLATE/feature_request.md`.
+4. Create `.github/ISSUE_TEMPLATE/integrator_feedback.md` (for 3.4).
+
+**Files:** `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/`  
+**Risk:** None.
+
+---
+
+### C.5 Add Self-Improvement as Background Agent
+
+**Current state:** `SelfImprovementLoop` is only triggered via `nexo improve --self`. Background agents support `optimizer`, `tester`, `extender` roles but not a `self-improver` role.
+
+**Tasks:**
+1. Add `self-improver` role to `BackgroundAgentRegistry.ExecuteAgentAsync`.
+2. Wire role to call `ISelfImprovementLoop.RunOnceAsync`.
+3. Add sample agent config in `apps/runtime-studio/config/`.
+4. Document in `docs/Configuration.md`.
+
+**Files:** `src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs`, `apps/runtime-studio/config/`  
+**Risk:** Self-improvement running automatically requires safety guardrails. Use `SemiActive` aggressiveness mode by default (requires approval gate).
+
+---
+
+### C.6 Trust Wiring in `ImproveCommand`
+
+**Current state:** `ImproveCommand` builds its own service collection and registers `ProviderFactory` directly, bypassing hosting-level trust registration. If improve uses cloud LLM providers, trust sanitization may not be active.
+
+**Tasks:**
+1. Conditionally register `SanitizingProviderFactory` in `ImproveCommand`'s DI graph when trust is enabled.
+2. Add a test that validates sanitization is active when improve is configured for cloud-backed fix generation.
+
+**Files:** `src/Nexo.CLI/Commands/ImproveCommand.cs`, `src/Nexo.Tests.CLI/`  
+**Risk:** Low. Defensive wiring.
+
+---
+
+## Execution Sequence Diagram
+
+```
+Phase 1 (parallel tracks):
+├── Track A: 1.1 Copilot MVP ──────────────────┐
+├── Track B: 1.2 Observe→Improve ──────────────┤
+├── Track C: 1.3 Mesh Trust Tiers ─────────────┤
+├── Track D: 1.4 SDK Stabilization ────────────┤
+└── Track E: 1.5 SLO Evidence ─────────────────┘
+    + Cross-cutting: C.1–C.6 (opportunistic)    │
+                                                 ▼
+Phase 2 (after 1.1 + 1.2 complete):
+├── 2.1 Registry Completion (needs 1.4)
+├── 2.2 Doctor --fix Hardening
+├── 2.3 Onboarding Gate Expansion (needs 2.2)
+├── 2.4 Release Gate Orchestration (needs 1.5)
+└── 2.5 Trust Pack Maturation
+                                                 │
+                                                 ▼
+Phase 3 (after Phase 2 core stable):
+├── 3.1 First Vertical (needs 1.1, 1.5, 2.4)
+├── 3.2 Mesh Governance (needs 1.3)
+├── 3.3 Perf Certification (needs 1.1, 2.4)
+└── 3.4 External Integrators (needs 1.4)
+```
+
+---
+
+## Success Metrics
+
+| Phase | Metric | Target |
+|-------|--------|--------|
+| 1 | Copilot E2E flow works in compose | User submits task, gets result with audit trail |
+| 1 | Observe→improve connected | `nexo improve --from-observation` targets pattern-affected files |
+| 1 | Mesh trust enforcement | Routing blocks untrusted peers under `trusted-only` policy |
+| 2 | Release bundle covers all gates | `ci release-bundle --profile full` runs ≥6 gate steps |
+| 2 | Doctor fixes common issues | ≥3 failure categories have automated remediation |
+| 3 | First vertical deployed | Release manager dashboard shows live readiness status |
+| 3 | External integration validated | ≥2 reference integrations pass CI on current SDK |

--- a/docs/IntegratorGuide.md
+++ b/docs/IntegratorGuide.md
@@ -1,0 +1,69 @@
+# Nexo integrator guide
+
+This guide is for teams embedding Nexo, extending bricks, or hosting custom background agents alongside the core platform.
+
+## Getting started with the Nexo SDK
+
+The managed SDK entry point is the `Nexo.Sdk` project (`src/Nexo.Sdk/Nexo.Sdk.csproj`). Add a project reference from your integrator assembly:
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="path/to/nexo/src/Nexo.Sdk/Nexo.Sdk.csproj" />
+</ItemGroup>
+```
+
+Build and test from the repository root:
+
+```bash
+dotnet build Nexo.sln
+dotnet test Nexo.sln --filter "FullyQualifiedName~YourIntegrator.Tests"
+```
+
+Use the Nexo CLI for local validation and gates:
+
+```bash
+dotnet run --project src/Nexo.CLI -- --help
+dotnet run --project src/Nexo.CLI -- validate
+```
+
+For container or native install paths, see `docs/GettingStarted.md` and `docs/OnboardingAutomation.md`.
+
+## Building a custom brick
+
+Bricks exchange structured payloads; shared DTOs and versioning live in **Nexo.Brick.Contracts** (`src/Nexo.Brick.Contracts`). Reference that project and implement your brick against the contract types (for example `BrickMetadataDto`, `BrickExecuteRequestDto`, `BrickExecuteResponseDto`, and capability manifests under `Capabilities/`).
+
+Recommended steps:
+
+1. Add `ProjectReference` to `Nexo.Brick.Contracts`.
+2. Define stable JSON-serializable request/response shapes aligned with the DTOs.
+3. Register and exercise your brick through the host’s brick pipeline and existing OWASP sample (`Nexo.Bricks.Owasp`) as a reference implementation.
+4. Run `dotnet run --project src/Nexo.CLI -- validate` before publishing.
+
+## Building a custom background agent
+
+Background agents are configured via JSON agent sets (see `apps/runtime-studio/config/agent_set.local.json` and `apps/release-manager/config/agent_set.release_manager.json`). Each agent specifies `Role`, `ModelProvider`, `Commands`, `Schedule`, and `ExfiltrationPolicy`.
+
+To run a custom set locally:
+
+```bash
+dotnet run --project src/Nexo.CLI -- background-agent daemon --config path/to/your/agent_set.json
+```
+
+Match sensitivity and exfiltration settings to your deployment tier. For mesh-related peer lists used at runtime, see `nexo mesh` commands and `NEXO_MESH_INSTANCES_PATH` if you relocate `instances.json`.
+
+## Compatibility matrix (placeholder)
+
+| Nexo version | .NET runtime | Notes |
+|--------------|--------------|--------|
+| _TBD_        | .NET 8 / 9   | Fill in after your release qualification. |
+
+Update this table when you pin Nexo packages or CLI images for production.
+
+## Troubleshooting
+
+- **CLI or doctor failures after dependency changes**: Run `dotnet run --project src/Nexo.CLI -- doctor --fix --dry-run` to see planned remediation without executing commands, then `doctor --fix --yes` if appropriate.
+- **Restore or build errors**: Confirm SDK versions in `global.json` and run `bash scripts/setup/setup.sh restore` from the repo root.
+- **Mesh peer not visible**: Verify `instances.json` (default: `~/.nexo/instances.json` or `NEXO_MESH_INSTANCES_PATH`) and use `nexo mesh admit <peerId>` / `nexo mesh revoke <peerId>` to toggle the `admitted` flag.
+- **Release gate bundle**: Use `dotnet run --project src/Nexo.CLI -- ci release-bundle --profile full` for an extended step list; reports land under `.nexo/release-bundle/last-run/`.
+
+For onboarding CI failure categories, the quickstart gate workflow runs `scripts/onboarding/failure-taxonomy.sh` on lane logs and publishes consolidated artifacts from the categorization job.

--- a/docs/SdkCompatibilityPolicy.md
+++ b/docs/SdkCompatibilityPolicy.md
@@ -1,0 +1,32 @@
+# SDK compatibility policy
+
+This document describes how Nexo classifies NuGet packages and public APIs, and how breaking changes are handled.
+
+## Versioning
+
+Stable public APIs in the packages listed below follow [Semantic Versioning 2.0.0](https://semver.org/). A MAJOR bump indicates breaking changes to those APIs. MINOR adds backward-compatible functionality. PATCH is for backward-compatible fixes.
+
+## Package tiers
+
+### Stable
+
+These packages are intended for external integration. Breaking changes require a MAJOR version bump and follow the process below.
+
+- `Nexo.Sdk`
+- `Nexo.Client`
+- `Nexo.Brick.Contracts`
+
+### Experimental
+
+APIs or entire packages may be marked with the .NET [`Experimental`](https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute) attribute. They may change or be removed without a MAJOR version bump. Consumers should treat them as preview-only.
+
+### Internal
+
+All other assemblies and packages are internal to the Nexo repository and tooling. They are not covered by this compatibility promise unless explicitly promoted to a stable package.
+
+## Breaking change process
+
+1. Prefer additive changes (new types, new optional parameters, new overloads) over modifying existing contracts.
+2. For stable packages, deprecate first: use `[Obsolete]` with a clear message and migration path when possible; remove or change behavior only in the next MAJOR version.
+3. Document notable changes in release notes and, when applicable, in migration notes for integrators.
+4. Experimental APIs may change in MINOR or PATCH releases; announce significant shifts in release notes when practical.

--- a/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Nexo.BrickContracts.Capabilities;
+using Nexo.Core.Application.Copilot.Models;
+using Nexo.Core.Application.Copilot.Ports;
 using Nexo.Core.Application.Knowledge.Models;
 using Nexo.Core.Application.Knowledge.Ports;
 using Nexo.Core.Application.Agent.UseCases.RunAgent;
@@ -62,6 +64,11 @@ public static class NexoEndpoints
             .Produces<CopilotTaskResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+        group.MapGet("/copilot/tasks", ListCopilotTasksAsync)
+            .WithName("ListCopilotTasks")
+            .WithSummary("List recent copilot tasks (newest first)")
+            .Produces<IReadOnlyList<CopilotTaskRecord>>(StatusCodes.Status200OK);
 
         group.MapGet("/status", GetStatusAsync)
             .WithName("GetStatus")
@@ -245,6 +252,7 @@ public static class NexoEndpoints
     private static async Task<IResult> RunCopilotTaskAsync(
         [FromBody] CopilotTaskRequest request,
         [FromServices] Orchestrator orchestrator,
+        [FromServices] ICopilotTaskStore copilotTaskStore,
         [FromServices] IDataDecisionAuditLog? auditLog,
         [FromServices] IAccessBoundary? accessBoundary,
         CancellationToken cancellationToken)
@@ -252,26 +260,73 @@ public static class NexoEndpoints
         if (string.IsNullOrWhiteSpace(request?.Task))
             return Results.BadRequest(new ProblemDetails { Title = "Task is required" });
 
+        var taskId = Guid.NewGuid().ToString("D");
+        var submittedAt = DateTimeOffset.UtcNow;
+        await copilotTaskStore.StoreAsync(new CopilotTaskRecord
+        {
+            TaskId = taskId,
+            Task = request.Task.Trim(),
+            SubmittedAt = submittedAt,
+            CompletedAt = null,
+            Success = false,
+            Summary = null,
+            Error = null
+        }, cancellationToken);
+
         try
         {
             var result = await orchestrator.OrchestrateAsync(request.Task, cancellationToken);
             var auditCount = Math.Clamp(request.AuditCount <= 0 ? 25 : request.AuditCount, 1, 200);
             var recentAudit = auditLog?.GetRecent(auditCount) ?? [];
+            var summary = result.IntegratedOutput != null ? $"{result.IntegratedOutput.AgentOutputs.Count} agent(s) executed" : null;
+            await copilotTaskStore.StoreAsync(new CopilotTaskRecord
+            {
+                TaskId = taskId,
+                Task = request.Task.Trim(),
+                SubmittedAt = submittedAt,
+                CompletedAt = DateTimeOffset.UtcNow,
+                Success = result.Success,
+                Summary = summary,
+                Error = null
+            }, cancellationToken);
             return Results.Ok(new CopilotTaskResponse(
+                taskId,
                 result.Success,
-                result.IntegratedOutput != null ? $"{result.IntegratedOutput.AgentOutputs.Count} agent(s) executed" : null,
+                summary,
                 result.IntegratedOutput?.IntegratedResults,
                 accessBoundary?.IsObservationPaused ?? false,
                 recentAudit));
         }
         catch (Exception ex)
         {
+            await copilotTaskStore.StoreAsync(new CopilotTaskRecord
+            {
+                TaskId = taskId,
+                Task = request.Task.Trim(),
+                SubmittedAt = submittedAt,
+                CompletedAt = DateTimeOffset.UtcNow,
+                Success = false,
+                Summary = null,
+                Error = ex.Message
+            }, cancellationToken);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }
 
+    private static async Task<IResult> ListCopilotTasksAsync(
+        [FromServices] ICopilotTaskStore copilotTaskStore,
+        [FromQuery] int maxCount = 50,
+        [FromQuery] DateTimeOffset? since = null,
+        CancellationToken cancellationToken = default)
+    {
+        maxCount = Math.Clamp(maxCount <= 0 ? 50 : maxCount, 1, 500);
+        var tasks = await copilotTaskStore.QueryAsync(maxCount, since, cancellationToken);
+        return Results.Ok(tasks);
+    }
+
     private static async Task<IResult> GetStatusAsync(
         [FromServices] IServiceProvider services,
+        [FromServices] IAccessBoundary? accessBoundary,
         CancellationToken cancellationToken)
     {
         await Task.CompletedTask;
@@ -280,7 +335,14 @@ public static class NexoEndpoints
         var registry = services.GetService<IBackgroundAgentRegistry>();
         var activeAgents = registry?.GetAll().Count(a => a.State == BackgroundAgentState.Running) ?? 0;
         var totalAgents = registry?.GetAll().Count ?? 0;
-        return Results.Ok(new StatusResponse(mode.ToString(), "Nexo API is running", totalAgents, activeAgents));
+        var activePack = accessBoundary?.GetActivePolicyPack();
+        return Results.Ok(new StatusResponse(
+            mode.ToString(),
+            "Nexo API is running",
+            totalAgents,
+            activeAgents,
+            activePack?.Id,
+            activePack?.Version));
     }
 
     private static async Task<IResult> BuildImageAsync(
@@ -774,13 +836,20 @@ public sealed record OrchestrationResponse(
     string? ErrorCode = null);
 public sealed record CopilotTaskRequest(string Task, int AuditCount = 25);
 public sealed record CopilotTaskResponse(
+    string TaskId,
     bool Success,
     string? Summary,
     object? Output,
     bool IsTrustPaused,
     IReadOnlyList<Nexo.Core.Application.Trust.Models.DataDecisionAuditEntry> RecentAudit);
 
-public sealed record StatusResponse(string Mode, string Message, int TotalAgents, int ActiveAgents);
+public sealed record StatusResponse(
+    string Mode,
+    string Message,
+    int TotalAgents,
+    int ActiveAgents,
+    string? ActivePackId,
+    string? ActivePackVersion);
 
 public sealed record ExecutionBuildRequest(string DockerfilePath, string ImageTag, string ContextPath, Dictionary<string, string>? BuildArgs = null);
 public sealed record ExecutionBuildResponse(bool Success, string? ErrorMessage, double DurationMs);

--- a/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
+++ b/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
@@ -7,6 +7,7 @@ using Nexo.BackgroundAgents.Logging;
 using Nexo.BackgroundAgents.Optimization;
 using Nexo.BackgroundAgents.Scheduling;
 using Nexo.BackgroundAgents.Testing;
+using Nexo.Core.Application.SelfImprovement.Ports;
 using Nexo.Core.Application.Trust.Ports;
 
 namespace Nexo.BackgroundAgents.Registry;
@@ -91,6 +92,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
     private readonly ICodeAnalysisRunner? _codeAnalysisRunner;
     private readonly ITestRunRunner? _testRunRunner;
     private readonly ISelfExtendRunner? _selfExtendRunner;
+    private readonly ISelfImprovementLoop? _selfImprovementLoop;
     private readonly IAggressivenessModeStore? _modeStore;
     private readonly IApprovalGate? _approvalGate;
     private readonly IDataDecisionAuditLog? _auditLog;
@@ -105,6 +107,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
     /// <param name="codeAnalysisRunner">Optional runner for optimizer agents (dog-food: run analysis on codebase).</param>
     /// <param name="testRunRunner">Optional runner for tester agents (dog-food: run framework tests).</param>
     /// <param name="selfExtendRunner">Optional runner for extender agents (dog-food: LLM-driven code/doc changes within policy).</param>
+    /// <param name="selfImprovementLoop">Optional self-improvement loop for self-improver agents (dog-food: test failures → fix → validate → promote).</param>
     /// <param name="modeStore">Optional aggressiveness mode store. When provided, Passive mode skips extender execution.</param>
     /// <param name="approvalGate">Optional approval gate for SemiActive mode. When provided and mode is SemiActive, execution requires approval.</param>
     /// <param name="auditLog">Optional audit log. When provided and mode is Ambient, actions are logged here (no user notification).</param>
@@ -115,6 +118,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
         ICodeAnalysisRunner? codeAnalysisRunner = null,
         ITestRunRunner? testRunRunner = null,
         ISelfExtendRunner? selfExtendRunner = null,
+        ISelfImprovementLoop? selfImprovementLoop = null,
         IAggressivenessModeStore? modeStore = null,
         IApprovalGate? approvalGate = null,
         IDataDecisionAuditLog? auditLog = null)
@@ -125,6 +129,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
         _codeAnalysisRunner = codeAnalysisRunner;
         _testRunRunner = testRunRunner;
         _selfExtendRunner = selfExtendRunner;
+        _selfImprovementLoop = selfImprovementLoop;
         _modeStore = modeStore;
         _approvalGate = approvalGate;
         _auditLog = auditLog;
@@ -336,6 +341,52 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
                     _logger?.LogDebug("Background agent {AgentId} self-extend: {Summary}", agentId, result.Summary);
                 }
 
+                instance.LastCompletedAt = DateTimeOffset.UtcNow;
+                instance.SuccessCount++;
+                _logStore?.Append(agentId, "Info", "Execution completed successfully.");
+                return;
+            }
+
+            // Self-improver agents run the self-improvement loop (test failures → fix → validate → promote)
+            if (string.Equals(instance.Config.Role, "self-improver", StringComparison.OrdinalIgnoreCase) &&
+                _selfImprovementLoop != null)
+            {
+                var mode = _modeStore?.GetMode() ?? BackgroundAgentAggressivenessMode.SemiActive;
+                if (mode == BackgroundAgentAggressivenessMode.Passive)
+                {
+                    _logStore?.Append(agentId, "Info", "Passive mode: skipping self-improver execution.");
+                    _logger?.LogDebug("Background agent {AgentId} in Passive mode: self-improver skipped", agentId);
+                    instance.LastCompletedAt = DateTimeOffset.UtcNow;
+                    instance.SuccessCount++;
+                    return;
+                }
+
+                if (mode == BackgroundAgentAggressivenessMode.SemiActive)
+                {
+                    var approvalResult = _approvalGate != null
+                        ? await _approvalGate.RequestApprovalAsync(
+                            $"Self-improver agent {agentId} requests approval to run improvement cycle.",
+                            TimeSpan.FromSeconds(30),
+                            cancellationToken).ConfigureAwait(false)
+                        : ApprovalResult.Denied;
+                    if (approvalResult != ApprovalResult.Approved)
+                    {
+                        var reason = approvalResult == ApprovalResult.TimedOut ? "timeout" : "denied";
+                        _logStore?.Append(agentId, "Info", $"SemiActive mode: self-improver skipped ({reason}).");
+                        _logger?.LogDebug("Background agent {AgentId} in SemiActive mode: self-improver skipped ({Reason})", agentId, reason);
+                        instance.LastCompletedAt = DateTimeOffset.UtcNow;
+                        instance.SuccessCount++;
+                        return;
+                    }
+                }
+
+                await _selfImprovementLoop.RunOnceAsync(cancellationToken).ConfigureAwait(false);
+                var report = await _selfImprovementLoop.GetLastRunReportAsync(cancellationToken).ConfigureAwait(false);
+                var summary = report != null
+                    ? $"Self-improvement: {report.FailuresProcessed} processed, {report.FixesPromoted} promoted, {report.FixesRejected} rejected"
+                    : "Self-improvement: completed (no report available)";
+                _logStore?.Append(agentId, "Info", summary);
+                _logger?.LogDebug("Background agent {AgentId} self-improvement: {Summary}", agentId, summary);
                 instance.LastCompletedAt = DateTimeOffset.UtcNow;
                 instance.SuccessCount++;
                 _logStore?.Append(agentId, "Info", "Execution completed successfully.");

--- a/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
+++ b/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
@@ -56,10 +56,11 @@ public static class ServiceCollectionExtensions
             var codeAnalysisRunner = sp.GetService<ICodeAnalysisRunner>();
             var testRunRunner = sp.GetService<ITestRunRunner>();
             var selfExtendRunner = sp.GetService<ISelfExtendRunner>();
+            var selfImprovementLoop = sp.GetService<Nexo.Core.Application.SelfImprovement.Ports.ISelfImprovementLoop>();
             var modeStore = sp.GetService<IAggressivenessModeStore>();
             var approvalGate = sp.GetService<IApprovalGate>();
             var auditLog = sp.GetService<IDataDecisionAuditLog>();
-            return new BackgroundAgentRegistry(scheduler, logger, logStore, codeAnalysisRunner, testRunRunner, selfExtendRunner, modeStore, approvalGate, auditLog);
+            return new BackgroundAgentRegistry(scheduler, logger, logStore, codeAnalysisRunner, testRunRunner, selfExtendRunner, selfImprovementLoop, modeStore, approvalGate, auditLog);
         });
         services.TryAddSingleton<BackgroundAgentConfigLoader>();
         services.TryAddSingleton<BackgroundAgentSpecBuilder>();

--- a/src/Nexo.CLI/Commands/CiCommand.cs
+++ b/src/Nexo.CLI/Commands/CiCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Nexo.Core.Application.Paths;
 
 namespace Nexo.CLI.Commands;
@@ -39,7 +40,7 @@ public sealed class CiCommand : Command
         AddCommand(runtimePromotionCmd);
 
         var releaseBundleCmd = new Command("release-bundle", "Run a single-shot release gate bundle and emit unified report.");
-        var profileOpt = new Option<string>("--profile", () => "default", "Bundle profile: default | quick.");
+        var profileOpt = new Option<string>("--profile", () => "default", "Bundle profile: default | quick | full.");
         var outputDirOpt = new Option<string?>("--output-dir", "Optional output directory for unified report artifacts.");
         releaseBundleCmd.AddOption(profileOpt);
         releaseBundleCmd.AddOption(outputDirOpt);
@@ -167,11 +168,12 @@ public sealed class CiCommand : Command
         var steps = BuildReleaseBundleSteps(normalizedProfile, cliProject, repoRoot);
         if (steps.Count == 0)
         {
-            Console.Error.WriteLine($"ci release-bundle: Unknown profile '{profile}'. Supported profiles: default, quick.");
+            Console.Error.WriteLine($"ci release-bundle: Unknown profile '{profile}'. Supported profiles: default, quick, full.");
             return 1;
         }
 
         var results = new List<ReleaseBundleStepResult>();
+        var sloSummaries = new List<ReleaseBundleSloEvidenceSummary>();
         foreach (var step in steps)
         {
             Console.WriteLine($"=== Release Bundle: {step.Name} ===");
@@ -190,6 +192,12 @@ public sealed class CiCommand : Command
                 startedUtc,
                 endedUtc,
                 artifactHints));
+
+            foreach (var relativeSloPath in step.SloEvidenceRelativePaths)
+            {
+                var fullSloPath = Path.GetFullPath(Path.Combine(repoRoot, relativeSloPath));
+                sloSummaries.Add(TryParseSloEvidenceSummary(step.Id, step.Name, relativeSloPath, fullSloPath));
+            }
         }
 
         var verdict = results.All(result => result.ExitCode == 0) ? "PASS" : "FAIL";
@@ -202,6 +210,7 @@ public sealed class CiCommand : Command
             DateTimeOffset.UtcNow,
             verdict,
             results,
+            sloSummaries,
             jsonPath,
             markdownPath);
 
@@ -250,19 +259,18 @@ public sealed class CiCommand : Command
                 "CI verify",
                 "dotnet",
                 $"run --project \"{cliProject}\" -- ci verify",
-                [
-                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.json",
-                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.md"
-                ]),
+                [],
+                []),
             new(
                 "runtime-gate",
                 "Runtime gate",
                 "dotnet",
                 $"run --project \"{cliProject}\" -- ci runtime-gate",
                 [
-                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.json",
-                    ".nexo/runtime/release-gate/last-run/runtime-release-gate-slo.md"
-                ]),
+                    ".nexo/runtime/runtime-release-gate-slo.json",
+                    ".nexo/runtime/runtime-release-gate-slo.md"
+                ],
+                [".nexo/runtime/runtime-release-gate-slo.json"]),
             new(
                 "doctor",
                 "Doctor check",
@@ -270,13 +278,36 @@ public sealed class CiCommand : Command
                 $"run --project \"{cliProject}\" -- doctor --json",
                 [
                     "docs/OnboardingAutomation.md"
-                ])
+                ],
+                [])
         };
 
         if (profile == "quick")
             return defaultSteps.Where(step => step.Id != "verify").ToList();
         if (profile == "default")
             return defaultSteps;
+        if (profile == "full")
+        {
+            var fullSteps = new List<ReleaseBundleStep>(defaultSteps)
+            {
+                new(
+                    "trust-gate",
+                    "Trust gate",
+                    "dotnet",
+                    $"run --project \"{cliProject}\" -- trust boundary --format-json",
+                    [],
+                    []),
+                new(
+                    "cross-platform-smoke",
+                    "Cross-platform smoke",
+                    "dotnet",
+                    $"run --project \"{cliProject}\" -- test portable --scope smoke",
+                    [],
+                    [])
+            };
+            return fullSteps;
+        }
+
         return new List<ReleaseBundleStep>();
     }
 
@@ -318,7 +349,112 @@ public sealed class CiCommand : Command
             lines.Add($"| {step.Name} | {step.ExitCode} | {step.StartedUtc:O} | {step.EndedUtc:O} | {artifacts} |");
         }
 
+        lines.Add(string.Empty);
+        lines.Add("## SLO evidence summary");
+        lines.Add(string.Empty);
+        if (report.SloEvidenceSummaries.Count == 0)
+        {
+            lines.Add("_No SLO evidence paths configured for this profile._");
+        }
+        else
+        {
+            lines.Add("| Step | SLO artifact | Present | Parsed | Overall SLO | Mode | ncr.failure_rate | Failures (checks) |");
+            lines.Add("|------|--------------|---------|--------|-------------|------|-------------------|-------------------|");
+            foreach (var slo in report.SloEvidenceSummaries)
+            {
+                var present = slo.FileExists ? "yes" : "no";
+                var parsed = slo.Parsed ? "yes" : "no";
+                var overall = slo.OverallPassed.HasValue ? (slo.OverallPassed.Value ? "PASS" : "FAIL") : "n/a";
+                var mode = slo.Mode ?? "n/a";
+                var fr = slo.NcrFailureRate.HasValue ? slo.NcrFailureRate.Value.ToString("0.####") : "n/a";
+                var failures = slo.FailedCheckCount.HasValue ? slo.FailedCheckCount.Value.ToString() : "n/a";
+                lines.Add($"| {slo.StepName} | `{slo.RelativePath}` | {present} | {parsed} | {overall} | {mode} | {fr} | {failures} |");
+            }
+        }
+
         return string.Join(Environment.NewLine, lines);
+    }
+
+    private static ReleaseBundleSloEvidenceSummary TryParseSloEvidenceSummary(
+        string stepId,
+        string stepName,
+        string relativePath,
+        string fullPath)
+    {
+        if (!File.Exists(fullPath))
+        {
+            return new ReleaseBundleSloEvidenceSummary(
+                stepId,
+                stepName,
+                relativePath,
+                fullPath,
+                FileExists: false,
+                Parsed: false,
+                ParseError: null,
+                OverallPassed: null,
+                Mode: null,
+                NcrFailureRate: null,
+                FailedCheckCount: null);
+        }
+
+        try
+        {
+            var root = JsonNode.Parse(File.ReadAllText(fullPath));
+            if (root is null)
+            {
+                return new ReleaseBundleSloEvidenceSummary(
+                    stepId,
+                    stepName,
+                    relativePath,
+                    fullPath,
+                    FileExists: true,
+                    Parsed: false,
+                    ParseError: "empty document",
+                    OverallPassed: null,
+                    Mode: null,
+                    NcrFailureRate: null,
+                    FailedCheckCount: null);
+            }
+
+            var passed = root["passed"]?.GetValue<bool?>();
+            var mode = root["mode"]?.GetValue<string>();
+            var failureRate = root["metrics"]?["ncrFailureRate"]?.GetValue<double?>();
+            int? failedChecks = null;
+            if (root["checks"] is JsonArray checkArr)
+            {
+                failedChecks = checkArr
+                    .OfType<JsonObject>()
+                    .Count(c => c["passed"]?.GetValue<bool?>() == false);
+            }
+
+            return new ReleaseBundleSloEvidenceSummary(
+                stepId,
+                stepName,
+                relativePath,
+                fullPath,
+                FileExists: true,
+                Parsed: true,
+                ParseError: null,
+                OverallPassed: passed,
+                Mode: mode,
+                NcrFailureRate: failureRate,
+                FailedCheckCount: failedChecks);
+        }
+        catch (Exception ex)
+        {
+            return new ReleaseBundleSloEvidenceSummary(
+                stepId,
+                stepName,
+                relativePath,
+                fullPath,
+                FileExists: true,
+                Parsed: false,
+                ParseError: ex.Message,
+                OverallPassed: null,
+                Mode: null,
+                NcrFailureRate: null,
+                FailedCheckCount: null);
+        }
     }
 
     private sealed record ReleaseBundleStep(
@@ -326,7 +462,8 @@ public sealed class CiCommand : Command
         string Name,
         string FileName,
         string Arguments,
-        IReadOnlyList<string> ArtifactHints);
+        IReadOnlyList<string> ArtifactHints,
+        IReadOnlyList<string> SloEvidenceRelativePaths);
 
     private sealed record ReleaseBundleStepResult(
         string Id,
@@ -343,6 +480,20 @@ public sealed class CiCommand : Command
         DateTimeOffset GeneratedUtc,
         string Verdict,
         IReadOnlyList<ReleaseBundleStepResult> Steps,
+        IReadOnlyList<ReleaseBundleSloEvidenceSummary> SloEvidenceSummaries,
         string JsonReportPath,
         string MarkdownReportPath);
+
+    private sealed record ReleaseBundleSloEvidenceSummary(
+        string StepId,
+        string StepName,
+        string RelativePath,
+        string FullPath,
+        bool FileExists,
+        bool Parsed,
+        string? ParseError,
+        bool? OverallPassed,
+        string? Mode,
+        double? NcrFailureRate,
+        int? FailedCheckCount);
 }

--- a/src/Nexo.CLI/Commands/DoctorCommand.cs
+++ b/src/Nexo.CLI/Commands/DoctorCommand.cs
@@ -23,12 +23,14 @@ public sealed class DoctorCommand : Command
             "Doctor profile: demo | self-extend-functional | self-extend-aesthetic | self-extend-visual.");
         var jsonOpt = new Option<bool>("--json", () => false, "Emit JSON output.");
         var fixOpt = new Option<bool>("--fix", () => false, "Attempt safe remediation for fixable onboarding failures.");
+        var dryRunOpt = new Option<bool>("--dry-run", () => false, "With --fix, list remediation actions without running them.");
         var yesOpt = new Option<bool>("--yes", () => false, "Auto-approve remediation actions when --fix is enabled.");
 
         AddOption(includeOptionalOpt);
         AddOption(profileOpt);
         AddOption(jsonOpt);
         AddOption(fixOpt);
+        AddOption(dryRunOpt);
         AddOption(yesOpt);
 
         this.SetHandler(async (InvocationContext ctx) =>
@@ -37,8 +39,9 @@ public sealed class DoctorCommand : Command
             var profile = ctx.ParseResult.GetValueForOption(profileOpt) ?? "demo";
             var json = ctx.ParseResult.GetValueForOption(jsonOpt);
             var fix = ctx.ParseResult.GetValueForOption(fixOpt);
+            var dryRun = ctx.ParseResult.GetValueForOption(dryRunOpt);
             var yes = ctx.ParseResult.GetValueForOption(yesOpt);
-            ctx.ExitCode = await ExecuteAsync(profile, includeOptional, json, fix, yes, ctx.GetCancellationToken()).ConfigureAwait(false);
+            ctx.ExitCode = await ExecuteAsync(profile, includeOptional, json, fix, dryRun, yes, ctx.GetCancellationToken()).ConfigureAwait(false);
         });
     }
 
@@ -47,6 +50,7 @@ public sealed class DoctorCommand : Command
         bool includeOptional,
         bool json,
         bool fix,
+        bool dryRun,
         bool autoApproveFixes,
         CancellationToken ct)
     {
@@ -69,6 +73,9 @@ public sealed class DoctorCommand : Command
         var remediation = new DoctorRemediationReport();
         if (fix)
         {
+            if (dryRun && !json)
+                Console.WriteLine("doctor --fix --dry-run: planned remediation (no commands executed):");
+
             remediation = await DoctorRemediation.RunAsync(
                 dependencyAssessment,
                 osSupported,
@@ -77,16 +84,20 @@ public sealed class DoctorCommand : Command
                 includeOptional,
                 autoApproveFixes,
                 json,
+                dryRun,
                 ct).ConfigureAwait(false);
 
-            var postAssessment = await BootstrapRuntime.AssessDemoAsync(profile, includeOptional, ct).ConfigureAwait(false);
-            dependencyAssessment = postAssessment;
-            dependencyOk = postAssessment.Supported && !postAssessment.MissingRequired.Any();
+            if (!dryRun)
+            {
+                var postAssessment = await BootstrapRuntime.AssessDemoAsync(profile, includeOptional, ct).ConfigureAwait(false);
+                dependencyAssessment = postAssessment;
+                dependencyOk = postAssessment.Supported && !postAssessment.MissingRequired.Any();
 
-            var (postCliExitCode, _, postCliStderr) = await RunShellCaptureAsync(cliCommand, ct).ConfigureAwait(false);
-            cliSmokePassed = postCliExitCode == 0;
-            cliSmokeError = cliSmokePassed ? string.Empty : postCliStderr.Trim();
-            overallOk = osSupported && dependencyOk && cliSmokePassed;
+                var (postCliExitCode, _, postCliStderr) = await RunShellCaptureAsync(cliCommand, ct).ConfigureAwait(false);
+                cliSmokePassed = postCliExitCode == 0;
+                cliSmokeError = cliSmokePassed ? string.Empty : postCliStderr.Trim();
+                overallOk = osSupported && dependencyOk && cliSmokePassed;
+            }
         }
 
         if (json)
@@ -149,7 +160,7 @@ public sealed class DoctorCommand : Command
 
             if (fix)
             {
-                Console.WriteLine("remediation:");
+                Console.WriteLine(dryRun ? "remediation (dry run):" : "remediation:");
                 if (remediation.Attempts.Count == 0)
                 {
                     Console.WriteLine("  no fixable issues were detected.");
@@ -158,8 +169,13 @@ public sealed class DoctorCommand : Command
                 {
                     foreach (var attempt in remediation.Attempts)
                     {
+                        var outcomeLabel = dryRun
+                            ? "would-run"
+                            : attempt.Success ? "fixed" : "not-fixed";
                         Console.WriteLine(
-                            $"  - {attempt.Id}: {(attempt.Success ? "fixed" : "not-fixed")} ({attempt.Status})");
+                            $"  - {attempt.Id}: {outcomeLabel} ({attempt.Status})");
+                        if (!string.IsNullOrWhiteSpace(attempt.Command))
+                            Console.WriteLine($"      command: {attempt.Command}");
                         if (!string.IsNullOrWhiteSpace(attempt.Message))
                             Console.WriteLine($"      {attempt.Message}");
                     }

--- a/src/Nexo.CLI/Commands/DoctorRemediation.cs
+++ b/src/Nexo.CLI/Commands/DoctorRemediation.cs
@@ -31,11 +31,35 @@ internal static class DoctorRemediation
         bool includeOptional,
         bool autoApproveFixes,
         bool json,
+        bool dryRun,
         CancellationToken cancellationToken)
     {
-        var attempts = new List<DoctorRemediationAttempt>();
         var actions = BuildActionPlan(assessment, osSupported, cliSmokePassed, profile, includeOptional);
 
+        if (dryRun)
+        {
+            var dryAttempts = actions
+                .Select(action => new DoctorRemediationAttempt(
+                    action.Id,
+                    action.Problem,
+                    action.Command,
+                    Attempted: false,
+                    Success: false,
+                    Status: "dry-run",
+                    Message: "Would run remediation command (dry run; no action taken).",
+                    ExitCode: -1,
+                    FollowUp: action.FollowUp))
+                .OrderBy(a => a.Id, StringComparer.Ordinal)
+                .ToList();
+            return new DoctorRemediationReport
+            {
+                FixEnabled = true,
+                AutoApproveFixes = autoApproveFixes,
+                Attempts = dryAttempts,
+            };
+        }
+
+        var attempts = new List<DoctorRemediationAttempt>();
         foreach (var action in actions)
         {
             if (!autoApproveFixes && json)

--- a/src/Nexo.CLI/Commands/ImproveCommand.cs
+++ b/src/Nexo.CLI/Commands/ImproveCommand.cs
@@ -38,6 +38,8 @@ public sealed class ImproveCommand : Command
         var storePathOpt = new Option<string?>("--store-path", "Directory for nexo dbs (default: repo root)");
         var selfOpt = new Option<bool>("--self", () => false, "Run one cycle of the self-improvement loop (test failures → fix → validate → promote)");
         var holdoutFilterOpt = new Option<string?>("--holdout-filter", "xUnit filter for holdout tests (e.g. Category=Holdout). Excluded from per-fix regression; run at end (P3.4)");
+        var fromObservationOpt = new Option<bool>("--from-observation", () => false, "Query recent observation patterns and prioritize analysis on affected file paths");
+        var observationDaysOpt = new Option<int>("--observation-days", () => 7, "Number of days of observation history to consider (default: 7)");
 
         AddOption(pathOpt);
         AddOption(dryRunOpt);
@@ -47,6 +49,8 @@ public sealed class ImproveCommand : Command
         AddOption(storePathOpt);
         AddOption(selfOpt);
         AddOption(holdoutFilterOpt);
+        AddOption(fromObservationOpt);
+        AddOption(observationDaysOpt);
 
         this.SetHandler(async (InvocationContext ctx) =>
         {
@@ -58,11 +62,13 @@ public sealed class ImproveCommand : Command
             var storePathOverride = ctx.ParseResult.GetValueForOption(storePathOpt);
             var self = ctx.ParseResult.GetValueForOption(selfOpt);
             var holdoutFilter = ctx.ParseResult.GetValueForOption(holdoutFilterOpt);
-            await ExecuteAsync(path, dryRun, autonomy, yes, skipRegression, storePathOverride, self, holdoutFilter);
+            var fromObservation = ctx.ParseResult.GetValueForOption(fromObservationOpt);
+            var observationDays = ctx.ParseResult.GetValueForOption(observationDaysOpt);
+            await ExecuteAsync(path, dryRun, autonomy, yes, skipRegression, storePathOverride, self, holdoutFilter, fromObservation, observationDays);
         });
     }
 
-    private static async Task ExecuteAsync(string? path, bool dryRun, string autonomy = "supervised", bool yes = false, bool skipRegression = false, string? storePathOverride = null, bool self = false, string? holdoutFilter = null)
+    private static async Task ExecuteAsync(string? path, bool dryRun, string autonomy = "supervised", bool yes = false, bool skipRegression = false, string? storePathOverride = null, bool self = false, string? holdoutFilter = null, bool fromObservation = false, int observationDays = 7)
     {
         var repoRoot = RepoPathResolver.FindRepoRoot();
         var storePath = !string.IsNullOrWhiteSpace(storePathOverride)
@@ -70,14 +76,34 @@ public sealed class ImproveCommand : Command
             : Path.Combine(repoRoot, "nexo-patterns.db");
         var targetPath = path ?? RepoPathResolver.FindBlock1ObservationPath(repoRoot);
 
+        var trustEnabled = string.Equals(
+            Environment.GetEnvironmentVariable("NEXO_TRUST_ENABLED"), "1",
+            StringComparison.OrdinalIgnoreCase);
+
         var serviceCollection = new ServiceCollection()
             .AddLogging(b => b.AddConsole())
-            .AddSingleton<Nexo.Infrastructure.Execution.IProviderFactory, Nexo.Infrastructure.Execution.ProviderFactory>()
             .AddCodeAnalyzers()
             .AddAdaptationInfrastructure(storePath)
             .AddAdaptationBricks(typeof(OWASPScannerBrick))
             .AddSelfContextInfrastructure(storePath)
             .AddSharedAdaptationCache();
+
+        serviceCollection.AddSingleton<Nexo.Infrastructure.Execution.ProviderFactory>();
+        if (trustEnabled)
+        {
+            serviceCollection.AddSingleton<Nexo.BackgroundAgents.Trust.ICloudSanitizationProxy,
+                Nexo.BackgroundAgents.Trust.CloudSanitizationProxy>();
+            serviceCollection.AddSingleton<Nexo.Infrastructure.Execution.IProviderFactory>(sp =>
+                new Nexo.BackgroundAgents.Trust.SanitizingProviderFactory(
+                    sp.GetRequiredService<Nexo.Infrastructure.Execution.ProviderFactory>(),
+                    sp.GetRequiredService<Nexo.BackgroundAgents.Trust.ICloudSanitizationProxy>(),
+                    sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Nexo.BackgroundAgents.Trust.SanitizingProviderFactory>>()));
+        }
+        else
+        {
+            serviceCollection.AddSingleton<Nexo.Infrastructure.Execution.IProviderFactory>(
+                sp => sp.GetRequiredService<Nexo.Infrastructure.Execution.ProviderFactory>());
+        }
 
         if (self)
         {
@@ -90,7 +116,62 @@ public sealed class ImproveCommand : Command
         if (yes)
             serviceCollection.AddSingleton<IUserFeedbackCapture>(new AutoApproveUserFeedbackCapture());
 
+        if (fromObservation)
+        {
+            serviceCollection.AddSingleton<Nexo.Core.Application.Observation.Ports.IPatternStore>(
+                _ => new Nexo.Infrastructure.Observation.LiteDbPatternStore(storePath));
+        }
+
         var services = serviceCollection.BuildServiceProvider();
+
+        if (fromObservation && string.IsNullOrWhiteSpace(path))
+        {
+            var patternStore = services.GetService<Nexo.Core.Application.Observation.Ports.IPatternStore>();
+            if (patternStore != null)
+            {
+                var since = DateTimeOffset.UtcNow.AddDays(-observationDays);
+                var patternTypes = new[] { "repeated-edits", "edit-then-build" };
+                var affectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var eventType in patternTypes)
+                {
+                    var patterns = await patternStore.QueryAsync(
+                        new Nexo.Core.Application.Observation.Models.PatternStoreQueryParams
+                        {
+                            Since = since,
+                            EventType = eventType,
+                            MaxCount = 50
+                        }).ConfigureAwait(false);
+
+                    foreach (var pattern in patterns)
+                    {
+                        if (!string.IsNullOrWhiteSpace(pattern.ProjectPath))
+                            affectedPaths.Add(pattern.ProjectPath);
+                        if (pattern.Metadata?.ValueKind == System.Text.Json.JsonValueKind.Object &&
+                            pattern.Metadata.Value.TryGetProperty("path", out var pathProp) &&
+                            pathProp.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            var p = pathProp.GetString();
+                            if (!string.IsNullOrWhiteSpace(p))
+                                affectedPaths.Add(p);
+                        }
+                    }
+                }
+
+                if (affectedPaths.Count > 0)
+                {
+                    Console.WriteLine($"Observation-driven improve: found {affectedPaths.Count} affected path(s) from last {observationDays} day(s):");
+                    foreach (var ap in affectedPaths.OrderBy(x => x))
+                        Console.WriteLine($"  - {ap}");
+                    Console.WriteLine();
+                    targetPath = affectedPaths.First();
+                }
+                else
+                {
+                    Console.WriteLine($"No observation patterns found in last {observationDays} day(s). Falling back to default path.");
+                }
+            }
+        }
 
         if (self)
         {

--- a/src/Nexo.CLI/Commands/MeshCommand.cs
+++ b/src/Nexo.CLI/Commands/MeshCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Invocation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nexo.Core.Application.Adaptation.Ports;
+using Nexo.Core.Application.Mesh;
 using Nexo.Core.Application.Mesh.Models;
 using Nexo.Core.Application.Mesh.Ports;
 using Nexo.Infrastructure;
@@ -54,6 +55,42 @@ public sealed class MeshCommand : Command
             await ExecuteImportAsync(path);
         });
 
+        var admitPeerArg = new Argument<string>("peerId", "Peer id to admit in instances.json");
+        var admitCmd = new Command("admit", "Set admitted=true for a peer in instances.json");
+        admitCmd.AddArgument(admitPeerArg);
+        admitCmd.SetHandler((InvocationContext ctx) =>
+        {
+            var peerId = ctx.ParseResult.GetValueForArgument(admitPeerArg)!;
+            var ok = UpdatePeerAdmitted(peerId, admitted: true);
+            if (!ok)
+            {
+                Console.Error.WriteLine($"Peer '{peerId}' not found in instances.json.");
+                ctx.ExitCode = 1;
+                return;
+            }
+
+            Console.WriteLine($"Admitted peer '{peerId}' (admitted=true).");
+            ctx.ExitCode = 0;
+        });
+
+        var revokePeerArg = new Argument<string>("peerId", "Peer id to revoke in instances.json");
+        var revokeCmd = new Command("revoke", "Set admitted=false for a peer in instances.json");
+        revokeCmd.AddArgument(revokePeerArg);
+        revokeCmd.SetHandler((InvocationContext ctx) =>
+        {
+            var peerId = ctx.ParseResult.GetValueForArgument(revokePeerArg)!;
+            var ok = UpdatePeerAdmitted(peerId, admitted: false);
+            if (!ok)
+            {
+                Console.Error.WriteLine($"Peer '{peerId}' not found in instances.json.");
+                ctx.ExitCode = 1;
+                return;
+            }
+
+            Console.WriteLine($"Revoked peer '{peerId}' (admitted=false).");
+            ctx.ExitCode = 0;
+        });
+
         AddOption(discoverOpt);
         AddOption(advertiseOpt);
         AddOption(capabilityOpt);
@@ -62,6 +99,8 @@ public sealed class MeshCommand : Command
         AddCommand(capabilitiesCmd);
         AddCommand(exportCmd);
         AddCommand(importCmd);
+        AddCommand(admitCmd);
+        AddCommand(revokeCmd);
 
         this.SetHandler(async (InvocationContext ctx) =>
         {
@@ -179,6 +218,8 @@ public sealed class MeshCommand : Command
         {
             var discovery = services.GetRequiredService<IInstanceDiscovery>();
             var peers = await discovery.DiscoverAsync().ConfigureAwait(false);
+            var trustPolicy = MeshTrustPolicyConfiguration.ResolveDiscoveryPolicy();
+            Console.WriteLine($"Active mesh trust policy: {trustPolicy} (NEXO_MESH_TRUST_POLICY or NEXO_PEER_TRUST_POLICY; default any)");
             Console.WriteLine($"Discovered {peers.Count} peer(s):");
             foreach (var p in peers)
                 Console.WriteLine($"  - {p.PeerId} @ {p.Endpoint} tier={p.TrustTier} [{string.Join(", ", p.Capabilities)}]");
@@ -201,7 +242,7 @@ public sealed class MeshCommand : Command
         }
 
         if (!discover && !advertise && string.IsNullOrEmpty(capability) && string.IsNullOrWhiteSpace(setTrustTier))
-            Console.WriteLine("Use --discover, --advertise, --capability <name>, or --set-trust-tier <peerId>:<tier>");
+            Console.WriteLine("Use --discover, --advertise, --capability <name>, --set-trust-tier <peerId>:<tier>, mesh admit, or mesh revoke");
         Environment.ExitCode = 0;
     }
 
@@ -220,6 +261,16 @@ public sealed class MeshCommand : Command
 
     private static bool UpdatePeerTrustTier(string peerId, PeerTrustTier tier)
     {
+        return UpdatePeerJsonField(peerId, obj => obj["trustTier"] = tier.ToString());
+    }
+
+    private static bool UpdatePeerAdmitted(string peerId, bool admitted)
+    {
+        return UpdatePeerJsonField(peerId, obj => obj["admitted"] = admitted);
+    }
+
+    private static bool UpdatePeerJsonField(string peerId, Action<JsonObject> mutator)
+    {
         var instancesPath = ResolveInstancesPath();
         if (!File.Exists(instancesPath))
             return false;
@@ -236,7 +287,7 @@ public sealed class MeshCommand : Command
             if (entry == null)
                 return false;
 
-            entry["trustTier"] = tier.ToString();
+            mutator(entry);
             File.WriteAllText(instancesPath, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
             return true;
         }

--- a/src/Nexo.CLI/Commands/TrustCommand.cs
+++ b/src/Nexo.CLI/Commands/TrustCommand.cs
@@ -392,6 +392,105 @@ public class TrustCommand
         return null;
     }
 
+    public Task<int> DescribePolicyPackAsync(string? packId, bool formatJson, CancellationToken ct = default)
+    {
+        try
+        {
+            if (_policyPackRegistry == null)
+            {
+                if (formatJson)
+                    Console.Out.WriteLine("{\"ok\":false,\"error\":\"Trust policy pack registry not registered\"}");
+                else
+                    Console.Error.WriteLine("Trust policy pack registry not registered.");
+                return Task.FromResult(1);
+            }
+
+            if (string.IsNullOrWhiteSpace(packId))
+            {
+                if (formatJson)
+                    Console.Out.WriteLine("{\"ok\":false,\"error\":\"pack id is required\"}");
+                else
+                    Console.Error.WriteLine("pack id is required");
+                return Task.FromResult(1);
+            }
+
+            var pack = _policyPackRegistry.GetById(packId.Trim());
+            if (pack == null)
+            {
+                if (formatJson)
+                    Console.Out.WriteLine($"{{\"ok\":false,\"error\":\"unknown pack '{packId.Trim()}'\"}}");
+                else
+                    Console.Error.WriteLine($"unknown pack '{packId.Trim()}'");
+                return Task.FromResult(1);
+            }
+
+            if (formatJson)
+            {
+                Console.Out.WriteLine(System.Text.Json.JsonSerializer.Serialize(
+                    new
+                    {
+                        ok = true,
+                        pack = new
+                        {
+                            pack.Id,
+                            pack.Version,
+                            pack.DisplayName,
+                            pack.Description,
+                            pack.PauseObservationByDefault,
+                            pack.RecommendedFor,
+                            categoryRules = pack.CategoryRules,
+                            sourceRules = pack.SourceRules,
+                            projectRules = pack.ProjectRules.Select(rule => new
+                            {
+                                rule.ProjectPath,
+                                sourceRules = rule.SourceRules
+                            }).ToArray()
+                        }
+                    },
+                    new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+            }
+            else
+            {
+                Console.Out.WriteLine($"Trust policy pack: {pack.Id}@{pack.Version}");
+                Console.Out.WriteLine($"  {pack.DisplayName}");
+                if (!string.IsNullOrWhiteSpace(pack.Description))
+                    Console.Out.WriteLine($"  {pack.Description}");
+                Console.Out.WriteLine($"  Pause observation by default: {(pack.PauseObservationByDefault ? "yes" : "no")}");
+                if (!string.IsNullOrWhiteSpace(pack.RecommendedFor))
+                    Console.Out.WriteLine($"  Recommended for: {pack.RecommendedFor}");
+                Console.Out.WriteLine("  Category rules:");
+                foreach (var kv in pack.CategoryRules.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+                    Console.Out.WriteLine($"    - {kv.Key}: {(kv.Value ? "allow" : "deny")}");
+                Console.Out.WriteLine("  Source rules:");
+                foreach (var kv in pack.SourceRules.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+                    Console.Out.WriteLine($"    - {kv.Key}: {(kv.Value ? "allow" : "deny")}");
+                Console.Out.WriteLine("  Project rules:");
+                if (pack.ProjectRules.Count == 0)
+                    Console.Out.WriteLine("    (none)");
+                else
+                {
+                    foreach (var rule in pack.ProjectRules)
+                    {
+                        Console.Out.WriteLine($"    - Project: {rule.ProjectPath}");
+                        foreach (var skv in rule.SourceRules.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+                            Console.Out.WriteLine($"        {skv.Key}: {(skv.Value ? "allow" : "deny")}");
+                    }
+                }
+            }
+
+            return Task.FromResult(0);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Trust pack describe failed");
+            if (formatJson)
+                Console.Out.WriteLine($"{{\"ok\":false,\"error\":\"{ex.Message}\"}}");
+            else
+                Console.Error.WriteLine(ex.Message);
+            return Task.FromResult(1);
+        }
+    }
+
     public Task<int> ListPolicyPacksAsync(bool formatJson, CancellationToken ct = default)
     {
         try

--- a/src/Nexo.CLI/Program.cs
+++ b/src/Nexo.CLI/Program.cs
@@ -696,6 +696,20 @@ static class Program
             jsonOpt);
         trustPackCmd.AddCommand(trustPackListCmd);
 
+        var trustPackDescribeCmd = new Command("describe", "Show rules for a trust policy pack");
+        var trustPackDescribeIdArg = new Argument<string>("packId", "Policy pack id");
+        trustPackDescribeCmd.AddArgument(trustPackDescribeIdArg);
+        trustPackDescribeCmd.AddOption(jsonOpt);
+        trustPackDescribeCmd.SetHandler(
+            async (string packId, bool formatJson) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<TrustCommand>();
+                Environment.Exit(await cmd.DescribePolicyPackAsync(packId, formatJson));
+            },
+            trustPackDescribeIdArg,
+            jsonOpt);
+        trustPackCmd.AddCommand(trustPackDescribeCmd);
+
         var trustPackApplyCmd = new Command("apply", "Apply a trust policy pack by id");
         var trustPackIdOpt = new Option<string>("--id", "Policy pack id (strict-enterprise, internal-only, air-gapped)");
         trustPackIdOpt.IsRequired = true;

--- a/src/Nexo.Client/NexoClientModels.cs
+++ b/src/Nexo.Client/NexoClientModels.cs
@@ -23,7 +23,13 @@ public sealed record OrchestrationResponse(
     int? Conflicts = null,
     int? Escalations = null,
     string? ErrorCode = null);
-public sealed record StatusResponse(string Mode, string Message, int TotalAgents, int ActiveAgents);
+public sealed record StatusResponse(
+    string Mode,
+    string Message,
+    int TotalAgents,
+    int ActiveAgents,
+    string? ActivePackId = null,
+    string? ActivePackVersion = null);
 public sealed record ExecutionBuildResponse(bool Success, string? ErrorMessage, double DurationMs);
 public sealed record ExecutionRunResponse(bool Success, int ExitCode, string StandardOutput, string StandardError, string? ContainerId, double DurationMs);
 

--- a/src/Nexo.Core.Application/Copilot/Models/CopilotTaskRecord.cs
+++ b/src/Nexo.Core.Application/Copilot/Models/CopilotTaskRecord.cs
@@ -1,0 +1,12 @@
+namespace Nexo.Core.Application.Copilot.Models;
+
+public sealed class CopilotTaskRecord
+{
+    public string TaskId { get; set; } = string.Empty;
+    public string Task { get; set; } = string.Empty;
+    public DateTimeOffset SubmittedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public bool Success { get; set; }
+    public string? Summary { get; set; }
+    public string? Error { get; set; }
+}

--- a/src/Nexo.Core.Application/Copilot/Ports/ICopilotTaskStore.cs
+++ b/src/Nexo.Core.Application/Copilot/Ports/ICopilotTaskStore.cs
@@ -1,0 +1,10 @@
+using Nexo.Core.Application.Copilot.Models;
+
+namespace Nexo.Core.Application.Copilot.Ports;
+
+public interface ICopilotTaskStore
+{
+    Task<CopilotTaskRecord> StoreAsync(CopilotTaskRecord record, CancellationToken ct = default);
+    Task<CopilotTaskRecord?> GetByIdAsync(string taskId, CancellationToken ct = default);
+    Task<IReadOnlyList<CopilotTaskRecord>> QueryAsync(int maxCount = 50, DateTimeOffset? since = null, CancellationToken ct = default);
+}

--- a/src/Nexo.Core.Application/Mesh/MeshTrustPolicyConfiguration.cs
+++ b/src/Nexo.Core.Application/Mesh/MeshTrustPolicyConfiguration.cs
@@ -1,0 +1,51 @@
+namespace Nexo.Core.Application.Mesh;
+
+/// <summary>
+/// Normalizes peer trust policy strings and resolves the effective policy for mesh CLI/discovery.
+/// </summary>
+public static class MeshTrustPolicyConfiguration
+{
+    /// <summary>
+    /// Normalizes a policy token to trusted-only, trusted-preferred, or any.
+    /// Unknown values default to trusted-preferred (fail-closed for routing).
+    /// </summary>
+    public static string NormalizePolicy(string? policy)
+    {
+        var normalized = (policy ?? "trusted-preferred").Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "trusted-only" => "trusted-only",
+            "trusted-preferred" => "trusted-preferred",
+            "any" => "any",
+            _ => "trusted-preferred"
+        };
+    }
+
+    /// <summary>
+    /// Policy used by mesh discovery: NEXO_MESH_TRUST_POLICY, else NEXO_PEER_TRUST_POLICY, else any (show all tiers).
+    /// </summary>
+    public static string ResolveDiscoveryPolicy()
+    {
+        var mesh = Environment.GetEnvironmentVariable("NEXO_MESH_TRUST_POLICY");
+        if (!string.IsNullOrWhiteSpace(mesh))
+            return NormalizePolicy(mesh);
+        var peer = Environment.GetEnvironmentVariable("NEXO_PEER_TRUST_POLICY");
+        if (!string.IsNullOrWhiteSpace(peer))
+            return NormalizePolicy(peer);
+        return "any";
+    }
+
+    /// <summary>
+    /// Policy for mesh capability requests: NEXO_MESH_TRUST_POLICY, else NEXO_PEER_TRUST_POLICY, else trusted-preferred.
+    /// </summary>
+    public static string ResolveCapabilityRequestPolicy()
+    {
+        var mesh = Environment.GetEnvironmentVariable("NEXO_MESH_TRUST_POLICY");
+        if (!string.IsNullOrWhiteSpace(mesh))
+            return NormalizePolicy(mesh);
+        var peer = Environment.GetEnvironmentVariable("NEXO_PEER_TRUST_POLICY");
+        if (!string.IsNullOrWhiteSpace(peer))
+            return NormalizePolicy(peer);
+        return "trusted-preferred";
+    }
+}

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using Nexo.Core.Application.Validation.UseCases.RunValidation;
 using Nexo.Core.Application.Testing.UseCases.RunTests;
 using Nexo.Core.Application.Common.Ports;
 using Nexo.Core.Application.Common.Services;
+using Nexo.Core.Application.Copilot.Ports;
 using Nexo.Core.Application.Paths;
 using Nexo.Core.Application.Trust.Ports;
 using Nexo.Infrastructure;
@@ -27,6 +28,7 @@ using Nexo.Infrastructure.NodeCapabilityRuntime;
 using Nexo.Infrastructure.Pipelines;
 using Nexo.Infrastructure.Persistence.Ephemeral;
 using Nexo.Infrastructure.Persistence;
+using Nexo.Infrastructure.Copilot;
 using Nexo.Orchestration;
 using Nexo.Orchestration.Models;
 using Nexo.Abstractions.Routing;
@@ -149,6 +151,12 @@ public static class NexoServiceCollectionExtensions
 
         if (modules.IncludeAdaptation)
             services.AddAdaptationInfrastructure(options.PatternStorePath);
+
+        var copilotTasksBasePath = !string.IsNullOrEmpty(options.PatternStorePath)
+            ? Path.GetDirectoryName(options.PatternStorePath) ?? "."
+            : RepoPathResolver.FindRepoRoot();
+        var copilotTasksDbPath = Path.Combine(copilotTasksBasePath, "nexo-copilot-tasks.db");
+        services.TryAddSingleton<ICopilotTaskStore>(_ => new LiteDbCopilotTaskStore(copilotTasksDbPath));
 
         services.TryAddSingleton<IKnowledgeQueryService>(sp =>
         {

--- a/src/Nexo.Infrastructure/Composition/CapabilityComponentRegistry.cs
+++ b/src/Nexo.Infrastructure/Composition/CapabilityComponentRegistry.cs
@@ -153,6 +153,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Infrastructure.Analysis.BrickAnalyzer.RoslynBrickStaticAnalyzer, Nexo.Infrastructure",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"passed\":{\"type\":\"boolean\"},\"violations\":{\"type\":\"array\"}}}",
         });
     }
 
@@ -171,6 +173,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Core.Application.ParallelTesting.Ports.IParameterMatrixGenerator",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"projectPath\":{\"type\":\"string\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"matrix\":{\"type\":\"array\"}}}",
         });
         Register(new ComponentDescriptor
         {
@@ -181,6 +185,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Core.Application.ParallelTesting.Ports.IInstanceSpawner",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"matrix\":{\"type\":\"array\"},\"filter\":{\"type\":\"string\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"runs\":{\"type\":\"array\"}}}",
             RequiredCapabilities = ["test-discovery"],
         });
         Register(new ComponentDescriptor
@@ -192,6 +198,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Core.Application.ParallelTesting.Ports.IResultCollector",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"runs\":{\"type\":\"array\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"summary\":{\"type\":\"string\"},\"passed\":{\"type\":\"boolean\"}}}",
             RequiredCapabilities = ["test-execution"],
         });
     }
@@ -214,6 +222,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Infrastructure.Observation.ObservationContextBrick, Nexo.Infrastructure",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"projectPath\":{\"type\":\"string\"},\"since\":{\"type\":\"string\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"patterns\":{\"type\":\"array\"},\"events\":{\"type\":\"array\"}}}",
         });
         Register(new ComponentDescriptor
         {
@@ -224,6 +234,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Infrastructure.Analysis.BrickAnalyzer.RoslynBrickStaticAnalyzer, Nexo.Infrastructure",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"passed\":{\"type\":\"boolean\"},\"violations\":{\"type\":\"array\"}}}",
             RequiredCapabilities = ["perception"],
         });
         Register(new ComponentDescriptor
@@ -235,6 +247,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Infrastructure.SelfContext.ChangelogGenerator, Nexo.Infrastructure",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"since\":{\"type\":\"string\"},\"format\":{\"type\":\"string\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"report\":{\"type\":\"string\"}}}",
             RequiredCapabilities = ["validation"],
         });
         Register(new ComponentDescriptor
@@ -246,6 +260,8 @@ public sealed class CapabilityComponentRegistry : ICapabilityComponentRegistry
             ImplementationType = "Nexo.Infrastructure.Observation.ObservationContextBrick, Nexo.Infrastructure",
             Version = "1.0.0",
             SupportLevel = ComponentSupportLevel.Stable,
+            InputSchema = "{\"type\":\"object\",\"properties\":{\"context\":{\"type\":\"object\"}}}",
+            OutputSchema = "{\"type\":\"object\",\"properties\":{\"interpretation\":{\"type\":\"object\"}}}",
         });
 
         // Perception (specialized)

--- a/src/Nexo.Infrastructure/Composition/ComponentDescriptorValidator.cs
+++ b/src/Nexo.Infrastructure/Composition/ComponentDescriptorValidator.cs
@@ -27,6 +27,14 @@ internal static class ComponentDescriptorValidator
         if (!Version.TryParse(descriptor.Version, out _))
             issues.Add(new ComponentValidationIssue("metadata.invalid-version", descriptor.Id, $"Version '{descriptor.Version}' is not a valid semantic version."));
 
+        if (descriptor.SupportLevel == ComponentSupportLevel.Stable)
+        {
+            if (string.IsNullOrWhiteSpace(descriptor.InputSchema))
+                issues.Add(new ComponentValidationIssue("metadata.missing-input-schema", descriptor.Id, "InputSchema is required when SupportLevel is Stable."));
+            if (string.IsNullOrWhiteSpace(descriptor.OutputSchema))
+                issues.Add(new ComponentValidationIssue("metadata.missing-output-schema", descriptor.Id, "OutputSchema is required when SupportLevel is Stable."));
+        }
+
         return issues;
     }
 }

--- a/src/Nexo.Infrastructure/Copilot/LiteDbCopilotTaskStore.cs
+++ b/src/Nexo.Infrastructure/Copilot/LiteDbCopilotTaskStore.cs
@@ -1,0 +1,95 @@
+using LiteDB;
+using Nexo.Core.Application.Copilot.Models;
+using Nexo.Core.Application.Copilot.Ports;
+
+namespace Nexo.Infrastructure.Copilot;
+
+/// <summary>
+/// LiteDB-backed store for copilot task history (API correlation / audit).
+/// </summary>
+public sealed class LiteDbCopilotTaskStore : ICopilotTaskStore
+{
+    private const string CollectionName = "copilot_tasks";
+    private readonly string _connectionString;
+
+    public LiteDbCopilotTaskStore(string pathOrConnectionString)
+    {
+        if (string.IsNullOrWhiteSpace(pathOrConnectionString))
+            throw new ArgumentNullException(nameof(pathOrConnectionString));
+        var trimmed = pathOrConnectionString.Trim();
+        _connectionString = trimmed.StartsWith("Filename=", StringComparison.OrdinalIgnoreCase) ? trimmed : $"Filename={trimmed}";
+    }
+
+    /// <inheritdoc />
+    public Task<CopilotTaskRecord> StoreAsync(CopilotTaskRecord record, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        using var db = new LiteDatabase(_connectionString);
+        var col = db.GetCollection<CopilotTaskDoc>(CollectionName);
+        col.EnsureIndex(x => x.SubmittedAt);
+        col.Upsert(ToDoc(record));
+        return Task.FromResult(record);
+    }
+
+    /// <inheritdoc />
+    public Task<CopilotTaskRecord?> GetByIdAsync(string taskId, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(taskId))
+            return Task.FromResult<CopilotTaskRecord?>(null);
+
+        using var db = new LiteDatabase(_connectionString);
+        var col = db.GetCollection<CopilotTaskDoc>(CollectionName);
+        var doc = col.FindById(taskId.Trim());
+        return Task.FromResult(doc is null ? null : ToRecord(doc));
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<CopilotTaskRecord>> QueryAsync(int maxCount = 50, DateTimeOffset? since = null, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var limit = maxCount <= 0 ? 50 : Math.Min(maxCount, 500);
+        using var db = new LiteDatabase(_connectionString);
+        var col = db.GetCollection<CopilotTaskDoc>(CollectionName);
+        var query = col.Query();
+        if (since.HasValue)
+            query = query.Where(x => x.SubmittedAt >= since.Value);
+        var docs = query.OrderByDescending(x => x.SubmittedAt).Limit(limit).ToList();
+        var records = docs.Select(ToRecord).ToList();
+        return Task.FromResult<IReadOnlyList<CopilotTaskRecord>>(records);
+    }
+
+    private static CopilotTaskDoc ToDoc(CopilotTaskRecord r) => new()
+    {
+        TaskId = r.TaskId,
+        Task = r.Task,
+        SubmittedAt = r.SubmittedAt,
+        CompletedAt = r.CompletedAt,
+        Success = r.Success,
+        Summary = r.Summary,
+        Error = r.Error
+    };
+
+    private static CopilotTaskRecord ToRecord(CopilotTaskDoc d) => new()
+    {
+        TaskId = d.TaskId,
+        Task = d.Task,
+        SubmittedAt = d.SubmittedAt,
+        CompletedAt = d.CompletedAt,
+        Success = d.Success,
+        Summary = d.Summary,
+        Error = d.Error
+    };
+
+    private sealed class CopilotTaskDoc
+    {
+        [BsonId]
+        public string TaskId { get; set; } = string.Empty;
+        public string Task { get; set; } = string.Empty;
+        public DateTimeOffset SubmittedAt { get; set; }
+        public DateTimeOffset? CompletedAt { get; set; }
+        public bool Success { get; set; }
+        public string? Summary { get; set; }
+        public string? Error { get; set; }
+    }
+}

--- a/src/Nexo.Infrastructure/Execution/Routing/NcrCapabilityRouter.cs
+++ b/src/Nexo.Infrastructure/Execution/Routing/NcrCapabilityRouter.cs
@@ -155,6 +155,11 @@ public sealed class NcrCapabilityRouter : ICapabilityRouter
     {
         if (!_peerTrustResolver.IsAllowed(peer))
         {
+            _logger.LogWarning(
+                "capability-routing peer skipped: trust tier not allowed peerId={PeerId} tier={TrustTier} policy={PeerTrustPolicy}",
+                peer.PeerId,
+                peer.TrustTier,
+                _peerTrustResolver.Policy);
             return false;
         }
 

--- a/src/Nexo.Infrastructure/Execution/Routing/PeerTrustPolicyResolver.cs
+++ b/src/Nexo.Infrastructure/Execution/Routing/PeerTrustPolicyResolver.cs
@@ -1,3 +1,4 @@
+using Nexo.Core.Application.Mesh;
 using Nexo.Core.Application.Mesh.Models;
 
 namespace Nexo.Infrastructure.Execution.Routing;
@@ -10,7 +11,7 @@ internal sealed class PeerTrustPolicyResolver
 
     public PeerTrustPolicyResolver(string? policy, string? trustedPeerIdsCsv, string? untrustedPeerIdsCsv)
     {
-        _policy = NormalizePolicy(policy);
+        _policy = MeshTrustPolicyConfiguration.NormalizePolicy(policy);
         _trustedPeerIds = ParseCsv(trustedPeerIdsCsv);
         _untrustedPeerIds = ParseCsv(untrustedPeerIdsCsv);
     }
@@ -43,18 +44,6 @@ internal sealed class PeerTrustPolicyResolver
     public bool IsAllowed(PeerExecutionCandidate candidate)
     {
         return IsAllowed(candidate.TrustTier);
-    }
-
-    private static string NormalizePolicy(string? policy)
-    {
-        var normalized = (policy ?? "trusted-preferred").Trim().ToLowerInvariant();
-        return normalized switch
-        {
-            "trusted-only" => "trusted-only",
-            "trusted-preferred" => "trusted-preferred",
-            "any" => "any",
-            _ => "trusted-preferred"
-        };
     }
 
     private static HashSet<string> ParseCsv(string? csv)

--- a/src/Nexo.Infrastructure/Execution/Routing/RunPodCapabilityRoutingServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Execution/Routing/RunPodCapabilityRoutingServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Nexo.Core.Application.Execution.Routing;
+using Nexo.Core.Application.Mesh;
 using Nexo.Core.Application.Mesh.Models;
 using Nexo.Core.Application.Mesh.Ports;
 using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
@@ -35,7 +36,8 @@ public static class RunPodCapabilityRoutingServiceCollectionExtensions
             return new FileBasedInstanceDiscovery(
                 string.IsNullOrWhiteSpace(instancesPath) ? null : instancesPath.Trim(),
                 trustedPeerIdsCsv,
-                untrustedPeerIdsCsv);
+                untrustedPeerIdsCsv,
+                MeshTrustPolicyConfiguration.ResolveDiscoveryPolicy());
         });
 
         services.AddHttpClient<IRunPodClient, RunPodHttpClient>((sp, client) =>

--- a/src/Nexo.Infrastructure/Mesh/FileBasedInstanceDiscovery.cs
+++ b/src/Nexo.Infrastructure/Mesh/FileBasedInstanceDiscovery.cs
@@ -16,10 +16,11 @@ public sealed class FileBasedInstanceDiscovery : IInstanceDiscovery
     public FileBasedInstanceDiscovery(
         string? instancesPath = null,
         string? trustedPeerIdsCsv = null,
-        string? untrustedPeerIdsCsv = null)
+        string? untrustedPeerIdsCsv = null,
+        string? peerTrustPolicy = null)
     {
         _instancesPath = instancesPath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nexo", "instances.json");
-        _trustPolicyResolver = new PeerTrustPolicyResolver("any", trustedPeerIdsCsv, untrustedPeerIdsCsv);
+        _trustPolicyResolver = new PeerTrustPolicyResolver(peerTrustPolicy ?? "any", trustedPeerIdsCsv, untrustedPeerIdsCsv);
     }
 
     /// <inheritdoc />

--- a/src/Nexo.Infrastructure/Mesh/MeshServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Mesh/MeshServiceCollectionExtensions.cs
@@ -26,7 +26,8 @@ public static class MeshServiceCollectionExtensions
         var resolvedPeerId = peerId ?? Environment.GetEnvironmentVariable("NEXO_MESH_PEER_ID") ?? Guid.NewGuid().ToString("N");
         var trustedPeerIdsCsv = Environment.GetEnvironmentVariable("NEXO_TRUSTED_PEER_IDS");
         var untrustedPeerIdsCsv = Environment.GetEnvironmentVariable("NEXO_UNTRUSTED_PEER_IDS");
-        var trustPolicy = Environment.GetEnvironmentVariable("NEXO_PEER_TRUST_POLICY");
+        var meshTrustPolicy = Nexo.Core.Application.Mesh.MeshTrustPolicyConfiguration.ResolveDiscoveryPolicy();
+        var capabilityTrustPolicy = Nexo.Core.Application.Mesh.MeshTrustPolicyConfiguration.ResolveCapabilityRequestPolicy();
 
         services.AddSingleton(Options.Create(new MeshOptions
         {
@@ -34,7 +35,8 @@ public static class MeshServiceCollectionExtensions
             TrustedPeerIdsCsv = trustedPeerIdsCsv,
             UntrustedPeerIdsCsv = untrustedPeerIdsCsv
         }));
-        services.AddSingleton<IInstanceDiscovery>(sp => new FileBasedInstanceDiscovery(path, trustedPeerIdsCsv, untrustedPeerIdsCsv));
+        services.AddSingleton<IInstanceDiscovery>(sp =>
+            new FileBasedInstanceDiscovery(path, trustedPeerIdsCsv, untrustedPeerIdsCsv, meshTrustPolicy));
         services.AddSingleton<ICapabilityAdvertisement>(sp =>
             new FileBasedCapabilityAdvertisement(
                 sp.GetRequiredService<IInstanceDiscovery>(),
@@ -53,7 +55,7 @@ public static class MeshServiceCollectionExtensions
                 adv,
                 transport,
                 options.Value.PeerId,
-                trustPolicy,
+                capabilityTrustPolicy,
                 trustedPeerIdsCsv,
                 untrustedPeerIdsCsv,
                 logger);

--- a/src/Nexo.Policies/PerfHeadroom.cs
+++ b/src/Nexo.Policies/PerfHeadroom.cs
@@ -1,24 +1,38 @@
+using System.Collections.Concurrent;
 using Nexo.Abstractions;
 
 namespace Nexo.Policies;
 
 /// <summary>
-/// Policy that enforces performance headroom limits (placeholder implementation).
-/// 
-/// Intended to limit tool execution time to prevent resource exhaustion.
-/// Currently a placeholder - future implementation would track execution time.
-/// 
-/// Implements IPolicy for use with PolicyEngine.
+/// Policy that enforces per-tool cumulative execution time budgets.
+/// Tracks elapsed time from <see cref="WorldSnapshot.Data"/> entries keyed
+/// as "ToolElapsed:{toolId}" (TimeSpan values) and rejects calls once the
+/// cumulative time for any single tool exceeds <c>maxPerTool</c>.
 /// </summary>
 public sealed class PerfHeadroom : IPolicy
 {
     private readonly TimeSpan _maxPerTool;
+    private readonly ConcurrentDictionary<string, TimeSpan> _cumulativeTime = new(StringComparer.OrdinalIgnoreCase);
+
     public PerfHeadroom(TimeSpan maxPerTool) => _maxPerTool = maxPerTool;
 
     public bool Approve(ToolCall call, WorldSnapshot s, out string reason)
     {
-        // Placeholder: implement timing budget around tool execution if needed.
+        var elapsedKey = $"ToolElapsed:{call.Id}";
+        if (s.Data.TryGetValue(elapsedKey, out var elapsedObj) && elapsedObj is TimeSpan elapsed)
+        {
+            var cumulative = _cumulativeTime.AddOrUpdate(call.Id, elapsed, (_, existing) => existing + elapsed);
+            if (cumulative > _maxPerTool)
+            {
+                reason = $"Tool '{call.Id}' exceeded time budget: {cumulative.TotalSeconds:F1}s > {_maxPerTool.TotalSeconds:F1}s limit";
+                return false;
+            }
+        }
+
         reason = "OK";
         return true;
     }
+
+    /// <summary>Resets cumulative time tracking for all tools.</summary>
+    public void Reset() => _cumulativeTime.Clear();
 }

--- a/src/Nexo.Runtime/Barriers/Identity/HttpBarrierContextMiddleware.cs
+++ b/src/Nexo.Runtime/Barriers/Identity/HttpBarrierContextMiddleware.cs
@@ -1,15 +1,168 @@
 #if NET8_0_OR_GREATER
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Nexo.Abstractions.Barriers;
+using Nexo.Abstractions.Barriers.Identity;
 
 namespace Nexo.Runtime.Barriers.Identity;
 
+/// <summary>
+/// Populates <see cref="BarrierResolutionContext"/> from the incoming HTTP request
+/// and runs <see cref="IBarrierIdentityResolverPipeline"/> to resolve the barrier level.
+/// When a level is resolved, initializes the scoped <see cref="IBarrierContextAccessor"/>
+/// and records an audit event. Gated by NEXO_BARRIER_MIDDLEWARE_ENABLED.
+/// </summary>
 public sealed class HttpBarrierContextMiddleware : IMiddleware
 {
-    public Task InvokeAsync(HttpContext context, RequestDelegate next)
+    private readonly IBarrierIdentityResolverPipeline _pipeline;
+    private readonly IBarrierAuditLog _auditLog;
+    private readonly BarrierHierarchy _hierarchy;
+    private readonly ILogger<HttpBarrierContextMiddleware> _logger;
+
+    public HttpBarrierContextMiddleware(
+        IBarrierIdentityResolverPipeline pipeline,
+        IBarrierAuditLog auditLog,
+        BarrierHierarchy hierarchy,
+        ILogger<HttpBarrierContextMiddleware> logger)
     {
-        // TODO: Populate BarrierResolutionContext from HttpContext and run
-        // IBarrierIdentityResolverPipeline. Not implemented in this PR.
-        return next(context);
+        _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
+        _auditLog = auditLog ?? throw new ArgumentNullException(nameof(auditLog));
+        _hierarchy = hierarchy ?? throw new ArgumentNullException(nameof(hierarchy));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        var enabled = Environment.GetEnvironmentVariable("NEXO_BARRIER_MIDDLEWARE_ENABLED");
+        if (!string.Equals(enabled, "true", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(enabled, "1", StringComparison.OrdinalIgnoreCase))
+        {
+            await next(context);
+            return;
+        }
+
+        var correlationId = context.TraceIdentifier;
+        var resolutionContext = BuildResolutionContext(context, correlationId);
+
+        BarrierResolutionResult? result;
+        try
+        {
+            result = await _pipeline.ResolveAsync(resolutionContext, context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Barrier identity resolution failed for {CorrelationId}", correlationId);
+            await next(context);
+            return;
+        }
+
+        if (result is not null)
+        {
+            var accessor = context.RequestServices.GetService(typeof(IBarrierContextAccessor)) as IBarrierContextAccessor;
+            if (accessor is not null)
+            {
+                try
+                {
+                    var barrierContext = BarrierContext.Create(
+                        result.ResolvedLevel,
+                        result.AuthoritySource,
+                        issuedTo: string.Empty,
+                        correlationId,
+                        _hierarchy,
+                        result.Detail);
+                    accessor.Initialize(barrierContext);
+                }
+                catch (BarrierCeilingExceededException ceilingEx)
+                {
+                    _logger.LogWarning("Barrier ceiling exceeded: {Message}", ceilingEx.Message);
+                    await _auditLog.RecordAsync(new BarrierAuditEvent(
+                        BarrierAuditEventType.CeilingExceeded,
+                        result.ResolvedLevel,
+                        result.AuthoritySource,
+                        AgentName: string.Empty,
+                        correlationId,
+                        SpanId: string.Empty,
+                        DateTimeOffset.UtcNow,
+                        ceilingEx.Message), context.RequestAborted);
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return;
+                }
+            }
+
+            await _auditLog.RecordAsync(new BarrierAuditEvent(
+                BarrierAuditEventType.ContextInitialized,
+                result.ResolvedLevel,
+                result.AuthoritySource,
+                AgentName: string.Empty,
+                correlationId,
+                SpanId: string.Empty,
+                DateTimeOffset.UtcNow,
+                result.Detail), context.RequestAborted);
+        }
+
+        await next(context);
+    }
+
+    private static BarrierResolutionContext BuildResolutionContext(HttpContext context, string correlationId)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in context.Request.Headers)
+        {
+            headers[header.Key] = header.Value.ToString();
+        }
+
+        headers.TryGetValue("x-nexo-barrier", out var explicitLevel);
+        headers.TryGetValue("x-nexo-api-key", out var apiKey);
+
+        var certSubjects = new List<string>();
+        var certSans = new List<string>();
+        var clientCert = context.Connection.ClientCertificate;
+        if (clientCert is not null)
+        {
+            certSubjects.Add(clientCert.Subject);
+            try
+            {
+                foreach (var ext in clientCert.Extensions)
+                {
+                    if (ext is X509SubjectAlternativeNameExtension sanExt)
+                    {
+                        foreach (var dns in sanExt.EnumerateDnsNames())
+                            certSans.Add(dns);
+                    }
+                }
+            }
+            catch
+            {
+                // SAN parsing is best-effort
+            }
+        }
+
+        string? rawJwt = null;
+        var jwtClaims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (headers.TryGetValue("Authorization", out var authHeader) &&
+            authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            rawJwt = authHeader.Substring("Bearer ".Length).Trim();
+        }
+
+        if (context.User?.Identity?.IsAuthenticated == true && context.User.Claims.Any())
+        {
+            foreach (var claim in context.User.Claims)
+            {
+                jwtClaims.TryAdd(claim.Type, claim.Value);
+            }
+        }
+
+        return new BarrierResolutionContext(
+            CorrelationId: correlationId,
+            ExplicitLevel: explicitLevel,
+            Headers: headers,
+            CertSubjects: certSubjects,
+            CertSans: certSans,
+            RawJwt: rawJwt,
+            JwtClaims: jwtClaims,
+            ApiKey: apiKey);
     }
 }
 #endif

--- a/src/Nexo.Sdk/NexoSdkBuilder.cs
+++ b/src/Nexo.Sdk/NexoSdkBuilder.cs
@@ -20,6 +20,7 @@ public sealed class NexoSdkBuilder
     /// Configures the SDK to prefer edge (local) when available, falling back to server.
     /// Reads NEXO_LOAD_PREFERENCE (edge|server|auto) when set.
     /// </summary>
+    [Obsolete("Adaptive routing configuration is experimental and may change. Prefer explicit host integration for production use.")]
     public NexoSdkBuilder UseAdaptiveRouting()
     {
         // When embedded in a host with AdaptiveProviderFactory, the host configures routing.

--- a/src/Nexo.Tests.CLI/Tests/Commands/DoctorCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/DoctorCommandTests.cs
@@ -52,6 +52,7 @@ public sealed class DoctorCommandTests : UnitTestBase
             includeOptional: false,
             json: false,
             fix: false,
+            dryRun: false,
             autoApproveFixes: false,
             CancellationToken.None).ConfigureAwait(false);
         AssertTrue(exitCode == 0 || exitCode == 1, "Doctor exit code should be deterministic (0 or 1).");
@@ -69,6 +70,7 @@ public sealed class DoctorCommandTests : UnitTestBase
                 includeOptional: false,
                 json: true,
                 fix: false,
+                dryRun: false,
                 autoApproveFixes: false,
                 CancellationToken.None).ConfigureAwait(false);
             AssertTrue(exitCode == 0 || exitCode == 1, "Doctor JSON exit code should be deterministic (0 or 1).");
@@ -94,6 +96,7 @@ public sealed class DoctorCommandTests : UnitTestBase
                 includeOptional: false,
                 json: true,
                 fix: true,
+                dryRun: false,
                 autoApproveFixes: false,
                 CancellationToken.None).ConfigureAwait(false);
             AssertTrue(exitCode == 0 || exitCode == 1, "Doctor JSON fix exit code should be deterministic (0 or 1).");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Executes the full Nexo execution plan: 20 work items across Phase 1 (foundation), Phase 2 (framework maturity), Phase 3 (production readiness), and 6 cross-cutting items.

## Changes

### Cross-Cutting (C.1-C.6)
- **C.1** `HttpBarrierContextMiddleware`: Full implementation — builds `BarrierResolutionContext` from HTTP requests (headers, certs, JWT, API key), runs identity resolver pipeline, initializes scoped barrier context, emits audit events. Gated by `NEXO_BARRIER_MIDDLEWARE_ENABLED`.
- **C.2** `PerfHeadroom` policy: Tracks cumulative per-tool execution time from `WorldSnapshot` entries, rejects when budget exceeded.
- **C.3** CI `test-caching-multi-env.yml`: Removed `continue-on-error` from build/test steps, added proper failure aggregation in summary job.
- **C.4** Added `.github/PULL_REQUEST_TEMPLATE.md` and issue templates (bug report, feature request, integrator feedback).
- **C.5** `self-improver` background agent role: Runs `ISelfImprovementLoop.RunOnceAsync` with Passive/SemiActive/Active/Ambient mode gating.
- **C.6** Trust wiring in `ImproveCommand`: Conditionally registers `SanitizingProviderFactory` when `NEXO_TRUST_ENABLED=1`.

### Phase 1 — Foundation & Product Proof
- **1.1** Copilot MVP: `ICopilotTaskStore` port + `LiteDbCopilotTaskStore`, `GET /api/copilot/tasks` history endpoint, correlation ID propagation, task persistence.
- **1.2** Observe→Improve: `--from-observation` and `--observation-days` flags query `IPatternStore` for recent patterns, target affected paths for analysis.
- **1.3** Mesh Trust Tiers: Audit logging when peers rejected by trust policy, `MeshTrustPolicyConfiguration` for `NEXO_MESH_TRUST_POLICY`, policy display in `--discover`.
- **1.4** SDK Stabilization: `docs/SdkCompatibilityPolicy.md`, `UseAdaptiveRouting()` marked `[Obsolete]`.
- **1.5** SLO Evidence: SLO collection per release-bundle step, summary in reports.

### Phase 2 — Framework Maturity
- **2.1** Registry Completion: `InputSchema`/`OutputSchema` validation for Stable components, schemas added to all seeds.
- **2.2** Doctor Hardening: `--dry-run` option for `doctor --fix`.
- **2.3** Onboarding Gate: Failure categorization job with taxonomy artifact upload.
- **2.4** Release Gate: `--profile full` with trust-gate and cross-platform-smoke steps.
- **2.5** Trust Packs: `nexo trust pack describe`, active pack in `GET /api/status`.

### Phase 3 — Production Readiness
- **3.1** Release Manager Vertical: Agent set config + README under `apps/release-manager/`.
- **3.2** Mesh Governance: `nexo mesh admit`/`revoke` subcommands.
- **3.3** Perf Certification: `perf-certification.yml` workflow.
- **3.4** Integrator Program: `docs/IntegratorGuide.md`.

### Documentation
- `docs/ExecutionPlan.md` — comprehensive execution plan with dependencies and success metrics.
- Updated `docs/DocsIndex.md` with Planning & Roadmap section.

## Testing

- `dotnet build Nexo.Kernel.sln` — 0 errors, 0 warnings
- `dotnet build src/Nexo.CLI/Nexo.CLI.csproj` — 0 errors
- `dotnet build src/Nexo.API/Nexo.API.csproj` — 0 errors
- `dotnet test Nexo.Kernel.sln` — 963 tests passed (474 net8.0 + 474 net9.0 + 4 app + 11 transport), 0 failed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13d927dc-7952-443c-b4a6-ebf9b8940fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13d927dc-7952-443c-b4a6-ebf9b8940fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

