### PR TITLE
Copilot MVP portal UI + self-improvement loop closure

### DIFF
--- a/src/Nexo.API/wwwroot/index.html
+++ b/src/Nexo.API/wwwroot/index.html
@@ -380,6 +380,70 @@
     .settings-inner { padding: 18px; }
     .settings-inner h3 { margin: 0 0 12px 0; }
     .settings-inner footer { margin-top: 16px; display: flex; gap: 8px; flex-wrap: wrap; }
+    .pill.warn::before { background: var(--warn); }
+    .task-history-list {
+      max-height: 340px;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+    .task-history-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 10px;
+      border-top: 1px solid var(--line);
+      cursor: pointer;
+      font-size: 13px;
+      transition: background 0.12s;
+    }
+    .task-history-item:first-child { border-top: none; }
+    .task-history-item:hover { background: var(--accent-soft); }
+    .task-history-item .task-id { font-family: monospace; color: var(--muted); min-width: 70px; }
+    .task-history-item .task-text { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .task-history-item .task-ts { color: var(--muted); font-size: 11px; white-space: nowrap; }
+    .task-detail-viewer {
+      margin-top: 10px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--bg) 70%, var(--panel));
+      padding: 10px;
+      overflow: auto;
+      max-height: 320px;
+      white-space: pre-wrap;
+      font-size: 12px;
+    }
+    .welcome-msg {
+      padding: 14px;
+      color: var(--muted);
+      font-size: 13px;
+      text-align: center;
+      border: 1px dashed var(--line);
+      border-radius: 8px;
+      margin-top: 8px;
+    }
+    .audit-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 8px;
+      border-top: 1px solid var(--line);
+      font-size: 12px;
+    }
+    .audit-row:first-child { border-top: none; }
+    .audit-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .audit-dot.green { background: var(--ok); }
+    .audit-dot.yellow { background: var(--warn); }
+    .audit-dot.red { background: var(--bad); }
+    .audit-dot.grey { background: var(--muted); }
+    .audit-type { font-weight: 600; min-width: 140px; }
+    .audit-ts { color: var(--muted); min-width: 130px; }
+    .audit-detail { color: var(--muted); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     @media (max-width: 900px) {
       .grid { grid-template-columns: 1fr; }
     }
@@ -406,6 +470,7 @@
       <div class="toolbar">
         <span id="connPill" class="pill dot" title="API reachability">Connecting…</span>
         <span id="modePill" class="pill" hidden></span>
+        <span id="trustPill" class="pill dot" hidden>Trust: …</span>
         <span style="flex:1"></span>
         <button type="button" class="icon" id="settingsBtn" aria-haspopup="dialog">Preferences</button>
       </div>
@@ -472,6 +537,13 @@
         <button type="button" class="primary" id="chatSendBtn">Send prompt</button>
         <button type="button" class="secondary" id="chatClearBtn">Clear transcript</button>
       </div>
+    </section>
+
+    <section class="panel">
+      <h2>Copilot task history</h2>
+      <p class="sub">Recent copilot tasks, newest first.</p>
+      <div id="copilotTaskList" class="task-history-list"></div>
+      <div id="copilotTaskDetail" class="task-detail-viewer" hidden></div>
     </section>
 
     <section class="panel">
@@ -592,6 +664,9 @@
       const auditTable = el("auditTable");
       const agentSummary = el("agentSummary");
       const knowledgeBlock = el("knowledgeBlock");
+      const trustPill = el("trustPill");
+      const copilotTaskList = el("copilotTaskList");
+      const copilotTaskDetail = el("copilotTaskDetail");
 
       const chipSets = {
         shape: [
@@ -944,7 +1019,8 @@
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ task: prompt, auditCount: 20 })
           });
-          chatEntries.push({ kind: "result", text: "Nexo: " + (result.summary || "Done") });
+          const taskLabel = result.taskId ? " [" + String(result.taskId).substring(0, 8) + "]" : "";
+          chatEntries.push({ kind: "result", text: "Nexo" + taskLabel + ": " + (result.summary || "Done") });
           chatEntries.push({ kind: "system", text: pretty(result.output ?? {}) });
           if (result.recentAudit && result.recentAudit.length) {
             chatEntries.push({ kind: "system", text: "Audit events captured: " + result.recentAudit.length });
@@ -952,6 +1028,8 @@
           renderChat();
           chatPrompt.value = "";
           setStatus("Chat turn completed.");
+          refreshCopilotTasks().catch(() => {});
+          if (result.isTrustPaused !== undefined) updateTrustPill(result.isTrustPaused, null);
         } catch (err) {
           chatEntries.push({ kind: "system", text: "Error: " + err.message });
           renderChat();
@@ -973,10 +1051,33 @@
             row.textContent = "No recent trust audit events.";
             auditTable.appendChild(row);
           } else {
-            events.slice(0, 8).forEach((e) => {
+            const greenTypes = ["ContextInitialized", "IdentityResolved"];
+            const yellowTypes = ["DefaultApplied"];
+            const redTypes = ["CeilingExceeded", "ValidationFailed", "ElevationDenied"];
+            function auditDotColor(eventType) {
+              if (greenTypes.includes(eventType)) return "green";
+              if (yellowTypes.includes(eventType)) return "yellow";
+              if (redTypes.includes(eventType)) return "red";
+              return "grey";
+            }
+            events.slice(0, 15).forEach((e) => {
               const row = document.createElement("div");
-              const ts = e.timestamp ? new Date(e.timestamp).toLocaleString() : "—";
-              row.textContent = ts + " · " + (e.eventType || "event") + " · " + (e.reason || e.changeType || e.dataType || "");
+              row.className = "audit-row";
+              const dot = document.createElement("span");
+              dot.className = "audit-dot " + auditDotColor(e.eventType || "");
+              const typeSpan = document.createElement("span");
+              typeSpan.className = "audit-type";
+              typeSpan.textContent = e.eventType || "event";
+              const tsSpan = document.createElement("span");
+              tsSpan.className = "audit-ts";
+              tsSpan.textContent = e.timestamp ? new Date(e.timestamp).toLocaleString() : "—";
+              const detailSpan = document.createElement("span");
+              detailSpan.className = "audit-detail";
+              detailSpan.textContent = e.reason || e.changeType || e.dataType || "";
+              row.appendChild(dot);
+              row.appendChild(typeSpan);
+              row.appendChild(tsSpan);
+              row.appendChild(detailSpan);
               auditTable.appendChild(row);
             });
           }
@@ -1051,6 +1152,72 @@
         }
       }
 
+      function updateTrustPill(isPaused, packName) {
+        trustPill.hidden = false;
+        if (isPaused) {
+          trustPill.className = "pill dot warn";
+          trustPill.textContent = "Trust: paused" + (packName ? " · " + packName : "");
+        } else {
+          trustPill.className = "pill dot ok";
+          trustPill.textContent = "Trust: active" + (packName ? " · " + packName : "");
+        }
+      }
+
+      async function refreshTrustPill() {
+        try {
+          const trust = await fetchJson("/api/trust/dashboard?count=1");
+          updateTrustPill(trust.isPaused, trust.activeTrustPack || null);
+        } catch { /* non-fatal */ }
+      }
+
+      async function refreshCopilotTasks() {
+        try {
+          const tasks = await fetchJson("/api/copilot/tasks?maxCount=20");
+          copilotTaskList.innerHTML = "";
+          if (!tasks || !tasks.length) {
+            const msg = document.createElement("div");
+            msg.className = "welcome-msg";
+            msg.textContent = "Welcome! Submit your first task using the chat above, or run an iteration to get started.";
+            copilotTaskList.appendChild(msg);
+            copilotTaskDetail.hidden = true;
+            return;
+          }
+          for (const t of tasks) {
+            const item = document.createElement("div");
+            item.className = "task-history-item";
+            const idSpan = document.createElement("span");
+            idSpan.className = "task-id";
+            idSpan.textContent = String(t.taskId || "").substring(0, 8);
+            const textSpan = document.createElement("span");
+            textSpan.className = "task-text";
+            const taskStr = t.task || t.prompt || "";
+            textSpan.textContent = taskStr.length > 60 ? taskStr.substring(0, 60) + "…" : taskStr;
+            const badge = document.createElement("span");
+            badge.className = "badge " + (t.success ? "ok" : "bad");
+            badge.textContent = t.success ? "ok" : "failed";
+            const tsSpan = document.createElement("span");
+            tsSpan.className = "task-ts";
+            tsSpan.textContent = t.submittedAt ? new Date(t.submittedAt).toLocaleString() : "";
+            item.appendChild(idSpan);
+            item.appendChild(textSpan);
+            item.appendChild(badge);
+            item.appendChild(tsSpan);
+            item.addEventListener("click", () => {
+              copilotTaskDetail.hidden = false;
+              copilotTaskDetail.textContent = pretty(t);
+            });
+            copilotTaskList.appendChild(item);
+          }
+        } catch (err) {
+          copilotTaskList.innerHTML = "";
+          const errDiv = document.createElement("div");
+          errDiv.className = "muted";
+          errDiv.style.padding = "10px";
+          errDiv.textContent = "Could not load copilot tasks: " + err.message;
+          copilotTaskList.appendChild(errDiv);
+        }
+      }
+
       el("runBtn").addEventListener("click", runIteration);
       el("refreshBtn").addEventListener("click", async () => {
         setStatus("Refreshing dailies…");
@@ -1082,11 +1249,14 @@
       refreshTrustDashboard().catch(() => {});
       refreshBackgroundAgents().catch(() => {});
       refreshKnowledge().catch(() => {});
+      refreshCopilotTasks().catch(() => {});
+      refreshTrustPill().catch(() => {});
 
       setInterval(() => {
         refreshStatus().catch(() => {});
         refreshTrustDashboard().catch(() => {});
         refreshBackgroundAgents().catch(() => {});
+        refreshTrustPill().catch(() => {});
       }, 60000);
     })();
   </script>

--- a/src/Nexo.CLI/Commands/ImproveCommand.cs
+++ b/src/Nexo.CLI/Commands/ImproveCommand.cs
@@ -15,6 +15,7 @@ using Nexo.Core.Application.Rollback.Ports;
 using Nexo.Infrastructure;
 using Nexo.Core.Application.SelfContext.Ports;
 using Nexo.Core.Application.Adaptation;
+using Nexo.BackgroundAgents.Observation;
 using Nexo.Infrastructure.Adaptation;
 using Nexo.Infrastructure.Analysis;
 using Nexo.Infrastructure.Observation;
@@ -40,6 +41,9 @@ public sealed class ImproveCommand : Command
         var holdoutFilterOpt = new Option<string?>("--holdout-filter", "xUnit filter for holdout tests (e.g. Category=Holdout). Excluded from per-fix regression; run at end (P3.4)");
         var fromObservationOpt = new Option<bool>("--from-observation", () => false, "Query recent observation patterns and prioritize analysis on affected file paths");
         var observationDaysOpt = new Option<int>("--observation-days", () => 7, "Number of days of observation history to consider (default: 7)");
+        var continuousOpt = new Option<bool>("--continuous", () => false, "Run observe → improve loop continuously until Ctrl+C");
+        var intervalMinutesOpt = new Option<int>("--interval-minutes", () => 5, "Minutes between continuous loop iterations (default: 5)");
+        var observeMinutesOpt = new Option<int>("--observe-minutes", () => 5, "Minutes to observe per continuous iteration (default: 5)");
 
         AddOption(pathOpt);
         AddOption(dryRunOpt);
@@ -51,6 +55,9 @@ public sealed class ImproveCommand : Command
         AddOption(holdoutFilterOpt);
         AddOption(fromObservationOpt);
         AddOption(observationDaysOpt);
+        AddOption(continuousOpt);
+        AddOption(intervalMinutesOpt);
+        AddOption(observeMinutesOpt);
 
         this.SetHandler(async (InvocationContext ctx) =>
         {
@@ -64,7 +71,18 @@ public sealed class ImproveCommand : Command
             var holdoutFilter = ctx.ParseResult.GetValueForOption(holdoutFilterOpt);
             var fromObservation = ctx.ParseResult.GetValueForOption(fromObservationOpt);
             var observationDays = ctx.ParseResult.GetValueForOption(observationDaysOpt);
-            await ExecuteAsync(path, dryRun, autonomy, yes, skipRegression, storePathOverride, self, holdoutFilter, fromObservation, observationDays);
+            var continuous = ctx.ParseResult.GetValueForOption(continuousOpt);
+            var intervalMinutes = ctx.ParseResult.GetValueForOption(intervalMinutesOpt);
+            var observeMinutes = ctx.ParseResult.GetValueForOption(observeMinutesOpt);
+
+            if (continuous)
+            {
+                await ExecuteContinuousAsync(path, dryRun, autonomy, yes, skipRegression, storePathOverride, self, holdoutFilter, observationDays, intervalMinutes, observeMinutes);
+            }
+            else
+            {
+                await ExecuteAsync(path, dryRun, autonomy, yes, skipRegression, storePathOverride, self, holdoutFilter, fromObservation, observationDays);
+            }
         });
     }
 
@@ -489,5 +507,142 @@ public sealed class ImproveCommand : Command
         var outcome = analysisResult.Passed ? "passed" : "violations";
         await executionTracer.TraceAsync("improve.end", null, targetPath, outcome).ConfigureAwait(false);
         Environment.ExitCode = analysisResult.Passed ? 0 : 1;
+    }
+
+    private static async Task ExecuteContinuousAsync(
+        string? path, bool dryRun, string autonomy, bool yes, bool skipRegression,
+        string? storePathOverride, bool self, string? holdoutFilter,
+        int observationDays, int intervalMinutes, int observeMinutes)
+    {
+        var repoRoot = path ?? RepoPathResolver.FindRepoRoot();
+        var storePath = !string.IsNullOrWhiteSpace(storePathOverride)
+            ? Path.Combine(Path.GetFullPath(storePathOverride), "nexo-patterns.db")
+            : Path.Combine(repoRoot, "nexo-patterns.db");
+
+        using var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            cts.Cancel();
+        };
+
+        Console.WriteLine("Continuous self-improvement mode");
+        Console.WriteLine($"  Root: {repoRoot}");
+        Console.WriteLine($"  Observe: {observeMinutes}m per cycle, Interval: {intervalMinutes}m between cycles");
+        Console.WriteLine("  Press Ctrl+C to stop.");
+        Console.WriteLine();
+
+        var iteration = 0;
+        while (!cts.IsCancellationRequested)
+        {
+            iteration++;
+            Console.WriteLine($"=== Continuous iteration {iteration} ({DateTimeOffset.UtcNow:HH:mm:ss}) ===");
+
+            try
+            {
+                await RunObservationPhaseAsync(repoRoot, storePath, TimeSpan.FromMinutes(observeMinutes), cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+
+            if (cts.IsCancellationRequested) break;
+
+            Console.WriteLine();
+            Console.WriteLine("Running improve --from-observation...");
+            try
+            {
+                await ExecuteAsync(path, dryRun, autonomy, yes, skipRegression, storePathOverride, self, holdoutFilter, true, observationDays).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Improve cycle error: {ex.Message}");
+            }
+
+            if (cts.IsCancellationRequested) break;
+
+            Console.WriteLine();
+            Console.WriteLine($"Sleeping {intervalMinutes}m before next cycle...");
+            try
+            {
+                await Task.Delay(TimeSpan.FromMinutes(intervalMinutes), cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Continuous mode stopped after {iteration} iteration(s).");
+        Environment.ExitCode = 0;
+    }
+
+    private static async Task RunObservationPhaseAsync(string repoRoot, string storePath, TimeSpan duration, CancellationToken ct)
+    {
+        var services = new ServiceCollection()
+            .AddLogging(b => b.AddConsole())
+            .AddOptions()
+            .AddAdaptationInfrastructure(storePath)
+            .AddSelfContextInfrastructure(storePath)
+            .Configure<ObservationPipelineOptions>(opts =>
+            {
+                opts.RepoRoot = repoRoot;
+                opts.StorePath = Path.GetFileName(storePath);
+                opts.WatchPaths = new[] { "src", ".github", "tools" };
+                opts.ProcessFilters = new[] { "dotnet", "msbuild", "nexo" };
+            })
+            .AddSingleton<IPatternStore>(_ => new LiteDbPatternStore(storePath))
+            .AddSingleton<IContextAssembler, ContextAssembler>()
+            .BuildServiceProvider();
+
+        var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+
+        var watchPaths = new[] { "src", ".github", "tools" }
+            .Select(p => Path.Combine(repoRoot, p.TrimStart('/', '\\')))
+            .Where(Directory.Exists)
+            .ToList();
+
+        if (watchPaths.Count == 0)
+        {
+            Console.WriteLine("No watch paths exist. Skipping observation phase.");
+            return;
+        }
+
+        Console.WriteLine($"Observing for {duration.TotalMinutes}m: {string.Join(", ", watchPaths.Select(Path.GetFileName))}");
+
+        var patternStore = services.GetRequiredService<IPatternStore>();
+        var patternDetector = new PatternDetector(
+            TimeSpan.FromMinutes(5),
+            3,
+            patternStore,
+            loggerFactory.CreateLogger<PatternDetector>());
+
+        var fileSource = new FileSystemEventSource(
+            watchPaths,
+            repoRoot,
+            new[] { "*" },
+            loggerFactory.CreateLogger<FileSystemEventSource>());
+        var processSource = new ProcessEventSource(
+            new[] { "dotnet", "msbuild", "nexo" },
+            repoRoot,
+            TimeSpan.FromSeconds(2),
+            loggerFactory.CreateLogger<ProcessEventSource>());
+        var compositeSource = new CompositeEventSource(new IObservableEventSource[] { fileSource, processSource });
+
+        using var observeCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        observeCts.CancelAfter(duration);
+
+        var eventCount = 0;
+        try
+        {
+            await foreach (var evt in compositeSource.SubscribeAsync(observeCts.Token).WithCancellation(observeCts.Token))
+            {
+                eventCount++;
+                await patternDetector.ProcessAsync(evt, observeCts.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // Observation time elapsed (not the outer cancellation)
+        }
+
+        Console.WriteLine($"Observation phase complete: {eventCount} event(s) captured.");
     }
 }

--- a/src/Nexo.CLI/Commands/IngestFailuresCommand.cs
+++ b/src/Nexo.CLI/Commands/IngestFailuresCommand.cs
@@ -1,0 +1,93 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Paths;
+using Nexo.Infrastructure;
+using Nexo.Infrastructure.Adaptation;
+using Nexo.Infrastructure.SelfContext;
+using Nexo.Infrastructure.SelfImprovement;
+using Nexo.Infrastructure.Validation.Parsers;
+
+namespace Nexo.CLI.Commands;
+
+/// <summary>
+/// CLI command that parses TRX test result files and ingests failures into
+/// the ITestFailureStore, closing the loop for self-improvement.
+/// Usage: nexo ingest-failures --trx-path ./TestResults
+/// </summary>
+public sealed class IngestFailuresCommand : Command
+{
+    public IngestFailuresCommand() : base("ingest-failures", "Parse TRX test result files and ingest failures into the self-improvement store.")
+    {
+        var trxPathOpt = new Option<string>("--trx-path", "Path to a TRX file or directory containing TRX files") { IsRequired = true };
+        var storePathOpt = new Option<string?>("--store-path", "Directory for nexo dbs (default: repo root)");
+
+        AddOption(trxPathOpt);
+        AddOption(storePathOpt);
+
+        this.SetHandler(async (InvocationContext ctx) =>
+        {
+            var trxPath = ctx.ParseResult.GetValueForOption(trxPathOpt)!;
+            var storePathOverride = ctx.ParseResult.GetValueForOption(storePathOpt);
+            await ExecuteAsync(trxPath, storePathOverride);
+        });
+    }
+
+    private static async Task ExecuteAsync(string trxPath, string? storePathOverride)
+    {
+        var repoRoot = RepoPathResolver.FindRepoRoot();
+        var storePath = !string.IsNullOrWhiteSpace(storePathOverride)
+            ? Path.Combine(Path.GetFullPath(storePathOverride), "nexo-patterns.db")
+            : Path.Combine(repoRoot, "nexo-patterns.db");
+
+        var services = new ServiceCollection()
+            .AddLogging(b => b.AddConsole())
+            .AddAdaptationInfrastructure(storePath)
+            .AddSelfContextInfrastructure(storePath)
+            .BuildServiceProvider();
+
+        var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+        var parser = new TrxTestResultParser(loggerFactory.CreateLogger<TrxTestResultParser>());
+        var store = services.GetRequiredService<Nexo.Core.Application.SelfContext.Ports.ITestFailureStore>();
+        var bridge = new TestFailureIngestionBridge(store);
+
+        var trxFiles = ResolveTrxFiles(trxPath);
+        if (trxFiles.Count == 0)
+        {
+            Console.WriteLine($"No TRX files found at: {trxPath}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        Console.WriteLine($"Found {trxFiles.Count} TRX file(s).");
+        var totalIngested = 0;
+
+        foreach (var file in trxFiles)
+        {
+            var results = await parser.ParseAsync(file).ConfigureAwait(false);
+            var ingested = await bridge.IngestAsync(results).ConfigureAwait(false);
+            totalIngested += ingested;
+            Console.WriteLine($"  {file.Name}: {results.Count} result(s), {ingested} failure(s) ingested");
+        }
+
+        Console.WriteLine($"Total: {totalIngested} failure(s) ingested into store.");
+        Environment.ExitCode = 0;
+    }
+
+    private static List<FileInfo> ResolveTrxFiles(string path)
+    {
+        if (File.Exists(path) && path.EndsWith(".trx", StringComparison.OrdinalIgnoreCase))
+            return new List<FileInfo> { new FileInfo(path) };
+
+        if (Directory.Exists(path))
+        {
+            return Directory.GetFiles(path, "*.trx", SearchOption.AllDirectories)
+                .Select(f => new FileInfo(f))
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .ToList();
+        }
+
+        return new List<FileInfo>();
+    }
+}

--- a/src/Nexo.CLI/Program.cs
+++ b/src/Nexo.CLI/Program.cs
@@ -1167,6 +1167,7 @@ static class Program
         root.AddCommand(new ObserveCommand());
         root.AddCommand(new AdaptCommand());
         root.AddCommand(new ImproveCommand());
+        root.AddCommand(new IngestFailuresCommand());
         root.AddCommand(new SelfContextCommand());
         root.AddCommand(new ChangelogCommand());
         root.AddCommand(new RollbackCommand());

--- a/src/Nexo.Infrastructure/SelfImprovement/SelfImprovementServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/SelfImprovement/SelfImprovementServiceCollectionExtensions.cs
@@ -33,6 +33,8 @@ public static class SelfImprovementServiceCollectionExtensions
     {
         services.AddAccessBoundary(null);
         services.TryAddSingleton<ISelfImprovementMetricsStore>(_ => new FileBasedSelfImprovementMetricsStore());
+        services.TryAddSingleton<TestFailureIngestionBridge>(sp =>
+            new TestFailureIngestionBridge(sp.GetRequiredService<ITestFailureStore>()));
         services.AddSingleton<ISelfImprovementLoop>(sp => new SelfImprovementLoop(
             sp.GetRequiredService<ITestFailureStore>(),
             sp.GetRequiredService<Nexo.Core.Application.Analysis.Ports.IBrickStaticAnalyzer>(),

--- a/src/Nexo.Infrastructure/SelfImprovement/TestFailureIngestionBridge.cs
+++ b/src/Nexo.Infrastructure/SelfImprovement/TestFailureIngestionBridge.cs
@@ -1,0 +1,45 @@
+using Nexo.Core.Application.Common.Models;
+using Nexo.Core.Application.SelfContext.Models;
+using Nexo.Core.Application.SelfContext.Ports;
+
+namespace Nexo.Infrastructure.SelfImprovement;
+
+/// <summary>
+/// Bridges parsed test results (from TRX or other formats) into the
+/// ITestFailureStore, enabling the self-improvement loop to pick up
+/// failures from real test runs.
+/// </summary>
+public sealed class TestFailureIngestionBridge
+{
+    private readonly ITestFailureStore _store;
+
+    public TestFailureIngestionBridge(ITestFailureStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>
+    /// Ingests failed test results into the test failure store.
+    /// Only records failures (Passed=false). Returns count of failures ingested.
+    /// </summary>
+    public async Task<int> IngestAsync(
+        IReadOnlyList<TestResult> results,
+        CancellationToken ct = default)
+    {
+        var failures = results.Where(r => !r.Passed).ToList();
+        foreach (var failure in failures)
+        {
+            var record = new TestFailureRecord
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Timestamp = DateTimeOffset.UtcNow,
+                TestName = failure.Name,
+                FilePath = null,
+                ErrorMessage = failure.ErrorMessage ?? failure.Message,
+                StackTrace = failure.StackTrace,
+            };
+            await _store.RecordAsync(record, ct).ConfigureAwait(false);
+        }
+        return failures.Count;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two complementary changes: Path A makes the copilot MVP visible and usable through the portal UI; Path B closes the self-improvement loop so test failures from real runs feed back into adaptation.

## Changes

### Path A — Copilot MVP Portal UI

- **Copilot task history section**: Fetches `GET /api/copilot/tasks`, displays task list with truncated ID, task text, ok/failed badge, and timestamp. Click any task for full JSON details.
- **Audit timeline**: Enhanced audit table with color-coded dots (green for resolved identity, yellow for defaults, red for failures/denials). Shows 15 events instead of 8.
- **Trust status pill**: New pill in header toolbar showing `Trust: active` (green) or `Trust: paused` (yellow) with active trust pack name.
- **First-run detection**: Welcome message when copilot task store is empty, guiding new users.
- **Chat taskId display**: Chat transcript now shows the returned `taskId` from each copilot task.

### Path B — Self-Improvement Loop Closure

- **`TestFailureIngestionBridge`**: Bridges `TestResult` (from TRX parsing) into `ITestFailureStore` by filtering failures and mapping to `TestFailureRecord`.
- **`nexo ingest-failures --trx-path <path>`**: Standalone CLI command that parses TRX files (single file or directory) and ingests failures into the store.
- **`nexo improve --continuous`**: Loops observe → improve → sleep, with `--observe-minutes` (default 5) and `--interval-minutes` (default 5). Exits on Ctrl+C.
- **`RunObservationPhaseAsync`**: Replicates ObserveCommand's pattern detection (FileSystemEventSource + ProcessEventSource + PatternDetector) for each observation window.
- **DI registration**: `TestFailureIngestionBridge` registered via `AddSelfImprovementLoop`.

### The full loop now works

```
nexo test → TRX → nexo ingest-failures → ITestFailureStore
→ nexo improve --self → SelfImprovementLoop → fix → validate → promote
```

Or continuously: `nexo improve --continuous`

## Testing

- `dotnet build Nexo.Kernel.sln` — 0 errors, 0 warnings
- `dotnet build src/Nexo.CLI/Nexo.CLI.csproj` — 0 errors
- `dotnet build src/Nexo.API/Nexo.API.csproj` — 0 errors
- `dotnet test` — 963 tests passed, 0 failed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13d927dc-7952-443c-b4a6-ebf9b8940fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13d927dc-7952-443c-b4a6-ebf9b8940fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

