### PR TITLE
Update documentation to match framework's current capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-local test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary package-cli clean-test-artifacts
+.PHONY: build test test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary package-cli clean-test-artifacts
 
 # Build the solution
 build:

--- a/README.md
+++ b/README.md
@@ -232,11 +232,34 @@ Pipeline runtime option precedence:
 | Show all commands | `dotnet run --project src/Nexo.CLI -- --help` |
 | Validate architecture/contracts | `dotnet run --project src/Nexo.CLI -- validate` |
 | Analyze source/assemblies | `dotnet run --project src/Nexo.CLI -- analyze --path .` |
+| Analyze bricks | `dotnet run --project src/Nexo.CLI -- analyze bricks` |
 | Run background-agent daemon mode | `dotnet run --project src/Nexo.CLI -- background-agent daemon --duration 10m` |
 | Run pipeline template | `dotnet run --project src/Nexo.CLI -- pipeline run --template <file>` |
+| Pipeline diagnostics | `dotnet run --project src/Nexo.CLI -- pipeline diagnostics --format-json` |
 | View trust boundary/audit | `dotnet run --project src/Nexo.CLI -- trust --help` |
+| Trust dashboard | `dotnet run --project src/Nexo.CLI -- trust dashboard` |
+| Apply a trust policy pack | `dotnet run --project src/Nexo.CLI -- trust pack apply --id strict-enterprise` |
 | Run local test entrypoint | `dotnet run --project src/Nexo.CLI -- test local` |
-| CI verification bundle | `dotnet run --project src/Nexo.CLI -- ci` |
+| Portable tests | `dotnet run --project src/Nexo.CLI -- test portable --scope persistence` |
+| Multi-environment tests | `dotnet run --project src/Nexo.CLI -- test multi-env --suite framework --all` |
+| CI verification bundle | `dotnet run --project src/Nexo.CLI -- ci verify` |
+| Onboarding doctor | `dotnet run --project src/Nexo.CLI -- doctor --json` |
+| Orchestrate a request | `dotnet run --project src/Nexo.CLI -- orchestrate "<request>"` |
+| Interactive chat | `dotnet run --project src/Nexo.CLI -- chat` |
+| Runtime execute | `dotnet run --project src/Nexo.CLI -- runtime execute --runtime-manifest <file>` |
+| Runtime release gate | `dotnet run --project src/Nexo.CLI -- runtime release-gate` |
+| Workflow scaffold/stress | `dotnet run --project src/Nexo.CLI -- workflow scaffold` |
+| Mesh sync/capabilities | `dotnet run --project src/Nexo.CLI -- mesh sync` |
+| Escalation management | `dotnet run --project src/Nexo.CLI -- escalate list` |
+| Metrics report | `dotnet run --project src/Nexo.CLI -- metrics report` |
+| Self-extend preflight | `dotnet run --project src/Nexo.CLI -- self-extend preflight` |
+| Observe/Adapt/Improve | `dotnet run --project src/Nexo.CLI -- observe` / `adapt` / `improve` |
+| Config management | `dotnet run --project src/Nexo.CLI -- config show` |
+| Docker management | `dotnet run --project src/Nexo.CLI -- docker build` / `run` / `clean` |
+| Dogfood validation | `dotnet run --project src/Nexo.CLI -- dogfood all` |
+| Compose pipelines | `dotnet run --project src/Nexo.CLI -- compose` |
+| Changelog generation | `dotnet run --project src/Nexo.CLI -- changelog` |
+| Maintenance cleanup | `dotnet run --project src/Nexo.CLI -- maintenance clean` |
 
 ## Demo Scripts (for rollout and live demos)
 
@@ -306,27 +329,40 @@ LLM/vision routing is provider-based:
 
 | Provider | Notes |
 |----------|-------|
-| `offline`, `mock`, `mock-json` | deterministic/local-friendly paths |
+| `offline`, `mock`, `mock-json`, `echo` | deterministic/local-friendly paths (require `NEXO_ALLOW_MOCK=1`) |
+| `local` | in-process ONNX/LLamaSharp; requires `NEXO_LOCAL_MODEL_PATH` |
 | `ollama` | local model runtime (`OLLAMA_BASE_URL`, `OLLAMA_MODEL`) |
 | `openai` | requires `OPENAI_API_KEY` |
 | `azure` | requires `AZURE_OPENAI_*` settings |
+| `video` | SmolVLM2-Video in Docker; requires `VIDEO_SERVICE_URL` |
 
 ## Project Layout
 
 ```text
 Nexo/
 ├── src/
-│   ├── Nexo.CLI/                 # CLI surface
+│   ├── Nexo.CLI/                 # CLI surface (System.CommandLine)
+│   ├── Nexo.API/                 # ASP.NET Core host with REST endpoints
 │   ├── Nexo.Hosting/             # AddNexo() integration entrypoint
-│   ├── Nexo.Infrastructure/      # execution, persistence, adapters
+│   ├── Nexo.Sdk/                 # Client SDK registration (AddNexoSdk)
+│   ├── Nexo.Client/              # HTTP client (INexoClient)
+│   ├── Nexo.Infrastructure/      # execution, persistence, adapters, mesh
 │   ├── Nexo.Orchestration/       # orchestrator, routing, coordination
 │   ├── Nexo.Runtime/             # runtime services and barrier plumbing
+│   ├── Nexo.BackgroundAgents/    # scheduler, RAG, web search, trust, tools
 │   ├── Nexo.Core.Application/    # use cases and ports
 │   ├── Nexo.Core.Domain/         # domain model
+│   ├── Nexo.Abstractions/        # shared interfaces (IAgent, IModel, etc.)
+│   ├── Nexo.Brick.Contracts/     # brick extension contracts
+│   ├── Nexo.Transport.Grpc*/     # gRPC transport layer
 │   └── Nexo.Tests.*/             # test suites
+├── apps/                         # application configs (runtime-studio, release-manager)
+├── config/                       # trust policy packs (air-gapped, internal-only, strict-enterprise)
 ├── docs/                         # docs, specs, guides
+├── scripts/                      # setup, install, demos, onboarding
 ├── .docker/                      # docker test/runtime definitions
-├── global.json                   # SDK pin
+├── .github/                      # CI workflows and templates
+├── global.json                   # SDK pin (.NET 9)
 └── Nexo.sln
 ```
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -10,7 +10,7 @@ Nexo is an AI-enhanced development orchestration platform with a layered archite
 │  (Commands, System.CommandLine, AddNexo)                          │
 ├─────────────────────────────────────────────────────────────────┤
 │  Core.Application (Use Cases)                                    │
-│  MediatR handlers, validation, analysis, validation, testing     │
+│  MediatR handlers, validation, analysis, agents, testing         │
 ├─────────────────────────────────────────────────────────────────┤
 │  Orchestration                                                   │
 │  Architect, agents, coordination, negotiation, orchestration     │
@@ -31,8 +31,14 @@ Nexo is an AI-enhanced development orchestration platform with a layered archite
 ### Core.Application
 
 - **Use cases** (MediatR): `AnalyzeCode`, `RunValidation`, `RunAgent`, `RunTests`
-- **Ports**: `IAnalysisService`, `IValidationService`, `IAgentExecutor`, `ITestRunner`, `IModel`, `IProviderFactory`
+- **Ports**: `IAnalysisService`, `IValidationService`, `IAgentExecutor`, `ITestRunner`
 - **Behaviors**: FluentValidation pipeline
+
+### Abstractions
+
+- **`IModel`**: Core model interface for agent execution
+- **`IAgent`**: Agent contract (Name, ThinkAsync)
+- **`IAgentMemory`**: Agent memory abstraction
 
 ### Orchestration
 
@@ -43,10 +49,11 @@ Nexo is an AI-enhanced development orchestration platform with a layered archite
 
 ### Infrastructure
 
-- **ProviderFactory**: Routes LLM calls to OpenAI, Azure, Ollama, or mock (with Polly retries)
-- **Persistence**: In-memory by default; LiteDB for pattern store, audit log
+- **ProviderFactory** (`IProviderFactory`): Routes LLM calls to OpenAI, Azure, Ollama, local (ONNX), video (SmolVLM2), or mock/offline/echo (with Polly retries)
+- **Persistence**: In-memory by default; LiteDB for pattern store, adaptation audit, copilot tasks, pipeline runs, execution traces, test failures
 - **Adaptation**: Brick decomposition, recompilation, fix generation
 - **Execution routing**: NCR-driven local/remote routing with peer-network and RunPod cloud execution paths
+- **Mesh**: File-based peer discovery, capability advertisement, local transport, trust policies
 
 #### Execution Routing (Generation)
 

--- a/docs/ComponentLibrary.md
+++ b/docs/ComponentLibrary.md
@@ -28,7 +28,8 @@
 | Summarization | partial | ChangelogGenerator |
 | **Memory** | | |
 | Short-term context | exists | IAgentMemory (toolbox) |
-| Long-term query (RAG) | exists | IPatternStore, ITestFailureStore |
+| Long-term query (RAG) | exists | IPatternStore, RAGService, KnowledgeBaseIndexer |
+| Test failure ingestion | exists | ITestFailureStore (self-improvement pipeline) |
 | Episodic recall | stub | episodic-memory (CapabilityComponentRegistry placeholder) |
 | **Reporting** | | |
 | Structured output | partial | BrickOutput, ToolResult |

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -120,7 +120,6 @@ Suggested starting SLOs/alerts using `ncr.*` metrics:
 
 Operational guidance:
 - Treat stale capability fallback as degraded mode; prefer conservative routing and periodic refresh attempts.
-- Keep `NEXO_ENDPOINT_HEALTH_DEGRADED_LOG_THRESHOLD` > 1 in noisy environments to reduce transient probe warning noise.
 - Set `NEXO_OBSERVATION_FAIL_OPEN=1` for production-style hosts that must continue serving even if observation store permissions are restricted.
 
 ## Video (SmolVLM2)
@@ -136,12 +135,20 @@ Operational guidance:
 | `NEXO_TRUST_AUDIT_DB` | Path to LiteDB audit log | in-memory |
 | `NEXO_KNOWLEDGE_LOG_PATH` | Path to user knowledge log | in-memory |
 | `NEXO_ACCESS_BOUNDARY_CONFIG` | Path to access boundary JSON | unset |
+| `NEXO_TRUST_POLICY_PACKS_PATH` | Directory containing trust policy pack JSON files | `config/trust-packs` (repo root) |
+| `NEXO_ACTIVE_TRUST_POLICY_PACK_PATH` | Path to active pack selection file | `active-pack.json` in packs dir |
 
 ## Mesh
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NEXO_MESH_PEER_ID` | Mesh peer identifier | random GUID |
+| `NEXO_MESH_INSTANCES_PATH` | Path to file-based mesh instance registry | unset |
+| `NEXO_TRUSTED_PEER_IDS` | Comma-separated peer IDs trusted for execution | unset (all peers trusted) |
+| `NEXO_UNTRUSTED_PEER_IDS` | Comma-separated peer IDs blocked from execution | unset |
+| `NEXO_MESH_TRUST_POLICY` | Mesh trust policy (`open`, `allowlist`, `denylist`) | `open` |
+| `NEXO_PEER_TRUST_POLICY` | Per-peer trust policy override | unset |
+| `NEXO_SHARED_ADAPTATIONS_PATH` | Path for shared adaptation artifacts across mesh | unset |
 
 ## RunPod + Capability Routing (`Nexo:RunPod:*`)
 
@@ -189,6 +196,28 @@ See `docs/runtime/ExecutionRouting.md` for detailed execution flow and resilienc
 | `NEXO_INCOMPLETE_BLOB_PATH` | Path to content-addressed blob storage for `incomplete-blobs` strategy | unset |
 | `NEXO_BLOB_LIFECYCLE` | `docker` = pause Docker Desktop before incomplete-blob cleanup | unset |
 
+## Background Agents
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NEXO_BACKGROUND_AGENTS_CONFIG` | Path to background agent set JSON configuration | unset |
+| `NEXO_AGENT_MODE_PATH` | Path to file-based aggressiveness mode store | unset |
+| `NEXO_OBSERVATION_DEGRADED_MODE` | `1` = start observation pipeline in degraded mode | unset |
+| `NEXO_OBSERVATION_FAIL_OPEN` | `1` = observation pipeline continues on store errors | unset |
+| `NEXO_BARRIER_MIDDLEWARE_ENABLED` | `1` = enable HTTP barrier context middleware | unset |
+| `BING_SEARCH_KEY` | API key for Bing web search provider | unset (falls back to mock) |
+
+## Routing & Execution
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NEXO_ALLOW_MOCK` | `1` = enable mock/offline/mock-json/echo providers | unset |
+| `NEXO_LOCAL_MODEL_PATH` | Path to local ONNX/LLamaSharp model for `local` provider | unset |
+| `NEXO_LOCAL_QUEUE_DEPTH` | Local execution queue depth for routing decisions | unset (auto) |
+| `NEXO_GPU_COMPUTE_CLASS` | GPU compute class label for NCR capability matching | unset |
+| `NEXO_LOAD_PREFERENCE` | Default load balancing preference | unset |
+| `NEXO_EXECUTION_REMOTE_URL` | Remote execution endpoint URL for hosting | unset |
+
 ## Config File
 
 `~/.nexo/config.json` (or path from `NEXO_CONFIG_PATH`):
@@ -200,5 +229,5 @@ See `docs/runtime/ExecutionRouting.md` for detailed execution flow and resilienc
 }
 ```
 
-- `provider`: `mock`, `offline`, `openai`, `azure`, `ollama`, `video`
+- `provider`: `openai`, `azure`, `ollama`, `local`, `video`, `mock`, `offline`, `mock-json`, `echo` (mock variants require `NEXO_ALLOW_MOCK=1`)
 - `model`: override for the selected provider

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -15,12 +15,24 @@ Use this page as the navigation starting point for docs.
 ## Operator / Production Readiness
 
 - `docs/ProductionReadinessGate-v1.md` — production gate commands and expected assertions.
+- `.github/workflows/production-readiness-gate-v1.yml` — automated production readiness gate.
 - `.github/workflows/environment-setup-gate-v1.yml` — environment bootstrap + dependency setup gate (Linux/macOS/Windows).
 - `.github/workflows/compose-gate.yml` — validates `docker-compose.test.yml` and `docker-compose.ephemeral.yml` lanes.
 - `.github/workflows/onboarding-quickstart-gate.yml` — runs first-run onboarding commands in native + container lanes.
 - `.github/workflows/container-image-gate.yml` — container image buildability and smoke-run gate.
 - `.github/workflows/container-image-publish.yml` — publish official GHCR CLI image (latest + sha tags).
 - `.github/workflows/onboarding-docs-guard.yml` — prevent startup-doc regressions in quick-start commands.
+- `.github/workflows/cross-platform-tests.yml` — cross-platform tests on Ubuntu, macOS, and Windows.
+- `.github/workflows/runtime-release-gate.yml` — runtime release quality gate.
+- `.github/workflows/runtime-release-promotion.yml` — runtime release promotion workflow.
+- `.github/workflows/native-installer-packages.yml` — build native installer bundles per OS.
+- `.github/workflows/installer-bruteforce-gate.yml` — installer robustness gate.
+- `.github/workflows/perf-certification.yml` — performance certification workflow.
+- `.github/workflows/workflow-regression-gate.yml` — workflow regression gate.
+- `.github/workflows/test-trust-multi-env.yml` — trust tests across multiple Docker environments.
+- `.github/workflows/test-caching-multi-env.yml` — caching tests across multiple Docker environments.
+- `.github/workflows/test-persistence-multi-os.yml` — persistence tests across multiple OS targets.
+- `.github/workflows/test-air-gapped-no-network.yml` — air-gapped validation with zero network egress.
 - `docs/ReleaseCandidateChecklist-v1.md` — release candidate sign-off checklist.
 - `docs/Testing.md` — test guard rails, timeout policy, and workflow guidance.
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -83,7 +83,7 @@ dotnet run --project src/Nexo.CLI -- --help
 dotnet run --project src/Nexo.CLI -- doctor --json
 ```
 
-You should see commands including `analyze`, `validate`, `pipeline`, `trust`, `test`, and `orchestrate`.
+You should see commands including `analyze`, `validate`, `pipeline`, `trust`, `test`, `orchestrate`, `agent`, `chat`, `runtime`, `workflow`, `mesh`, `config`, `doctor`, `dogfood`, `escalate`, `metrics`, and more.
 
 ## 2b) Run background-agent daemon mode (optional)
 
@@ -220,7 +220,12 @@ Then resolve application ports from DI (analysis, validation, orchestration, etc
 
 ## Next documents to read
 
-- `README.md` — high-level orientation and command map.
+- `README.md` — high-level orientation and full CLI command map.
 - `docs/Architecture.md` — subsystem layout and flow.
+- `docs/Configuration.md` — environment variables and config reference.
+- `docs/api/index.md` — REST API endpoints and hosting options.
+- `docs/sdk.md` — SDK integration (host embedding and HTTP client).
 - `docs/TrustAndInformationArchitecture.md` — barrier/trust model.
+- `docs/Persistence.md` — persistence defaults and LiteDB options.
 - `docs/ProductionReadinessGate-v1.md` — release gate and operator checks.
+- `docs/DocsIndex.md` — full documentation index.

--- a/docs/Persistence.md
+++ b/docs/Persistence.md
@@ -9,8 +9,13 @@ Nexo uses in-memory stores by default. For durable storage, configure LiteDB-bac
 | `IUnitOfWork` | `InMemoryUnitOfWork` | Replace with adapter (e.g. SQLite) |
 | `IPatternStore` | none (when `PatternStorePath` not set) | `LiteDbPatternStore` via `AddAdaptationInfrastructure(path)` |
 | `IAdaptationLog` | in-memory | `LiteDbAdaptationLog` when pattern store path set |
-| `ISanitizationAuditLog` | in-memory | `LiteDbDataDecisionAuditLog` when `NEXO_TRUST_AUDIT_DB` set |
+| `IAdaptationAuditLog` | in-memory | `LiteDbAdaptationAuditLog` when adaptation infrastructure is registered |
+| `ISanitizationAuditLog` / `IDataDecisionAuditLog` | in-memory | `LiteDbDataDecisionAuditLog` (in `Nexo.BackgroundAgents`) when `NEXO_TRUST_AUDIT_DB` set |
 | `IUserKnowledgeLogStore` | in-memory | `LiteDbUserKnowledgeLogStore` when `NEXO_KNOWLEDGE_LOG_PATH` set |
+| `ICopilotTaskStore` | in-memory | `LiteDbCopilotTaskStore` when hosting registers copilot services |
+| `IPipelineRunStore` | in-memory | `LiteDbPipelineRunStore` when `NEXO_PIPELINE_STORE_PROVIDER=LiteDb` |
+| `IExecutionTracer` | in-memory | `LiteDbExecutionTracer` when pattern store path is set |
+| `ITestFailureStore` | in-memory | `LiteDbTestFailureStore` when self-improvement infrastructure is registered |
 
 ## AddNexoPersistence
 
@@ -39,7 +44,7 @@ Set `NEXO_TRUST_AUDIT_DB` to a file path for durable audit logging:
 export NEXO_TRUST_AUDIT_DB=~/.nexo/trust-audit.db
 ```
 
-When set, `LiteDbDataDecisionAuditLog` persists redactions and decisions.
+When set, `LiteDbDataDecisionAuditLog` (located in `Nexo.BackgroundAgents.Trust`) persists redactions and decisions.
 
 ## Knowledge Log
 
@@ -47,6 +52,19 @@ Set `NEXO_KNOWLEDGE_LOG_PATH` for durable user knowledge log:
 
 ```bash
 export NEXO_KNOWLEDGE_LOG_PATH=~/.nexo/knowledge.db
+```
+
+## Copilot Task Store
+
+When hosting registers copilot services (via `AddNexo()`), `LiteDbCopilotTaskStore` persists copilot tasks. The store path is derived from the pattern store directory.
+
+## Pipeline Run Store
+
+Set `NEXO_PIPELINE_STORE_PROVIDER=LiteDb` and optionally `NEXO_PIPELINE_STORE_PATH` for durable pipeline run history:
+
+```bash
+export NEXO_PIPELINE_STORE_PROVIDER=LiteDb
+export NEXO_PIPELINE_STORE_PATH=~/.nexo/pipeline-runs.db
 ```
 
 ## LiteDB

--- a/docs/TrustAndInformationArchitecture.md
+++ b/docs/TrustAndInformationArchitecture.md
@@ -122,7 +122,7 @@ No overlap: policy controls *whether*; sanitization controls *what*.
 
 Purpose: Transparent, user-editable log of what Nexo has learned about the user (preferences, patterns, workflow habits). Not for sync; for trust and audit.
 
-- **Storage:** SQLite (query, versioning, relations)
+- **Storage:** LiteDB (query, versioning, relations)
 - **Schema:** Entries with Id, DataType, Content, SourceObservationIds (provenance), Version, CreatedAt, UpdatedAt, DeletedAt
 - **Provenance:** Each entry references source observation IDs; full chain traversable
 - **Versioning:** Updates create new versions; history retained
@@ -172,13 +172,15 @@ bool ShouldObserve(string category, string sourceId, string? projectPath = null)
 
 ## 6. Air-Gap — Use Existing
 
-### Reuse (No New Interfaces)
+### Reuse
 
 - **`IExecutionContext.IsAirGapped`** — already used by BehaviorExecutor, UnderstandingBrick, ProviderFactory, etc.
 - **Provider selection** — mock/offline/echo when air-gapped
 - **`--airgap` CLI flags** — already present
 
-**Enhancement:** Add optional `ICloudAvailabilityResolver` that sets/resolves air-gap at runtime:
+### Implemented: `ICloudAvailabilityResolver`
+
+`ICloudAvailabilityResolver` (`Nexo.Core.Application`) and `CloudAvailabilityResolver` (`Nexo.Infrastructure`) resolve air-gap status at runtime:
 - Sources (priority order): env var → config file → network probe
 - Used at startup and optionally before cloud calls to refresh
 - When cloud unavailable, inject/ensure `IsAirGapped = true` in context

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,12 +7,41 @@ API documentation for the Nexo AI-enhanced development orchestration platform.
 | Library | Description |
 |---------|-------------|
 | **Nexo.Hosting** | Hosting extensions for embedding the Nexo kernel. Call `AddNexo()` to register orchestration, adaptation, persistence, trust, and agent services. |
+| **Nexo.API** | ASP.NET Core host with minimal API endpoints, static file serving (SPA), and optional API-key auth. |
+| **Nexo.Sdk** | Client SDK registration (`AddNexoSdk(baseUrl, ...)`). |
+| **Nexo.Client** | HTTP client (`INexoClient`) for calling a running Nexo API. |
 | **Nexo.Core.Application** | Use cases (MediatR handlers), validation, analysis, and ports. |
 | **Nexo.Core.Domain** | Domain entities, bricks, behaviors, agents. |
 | **Nexo.Abstractions** | Core interfaces and abstractions. |
 | **Nexo.Infrastructure** | ProviderFactory (LLM), persistence, adaptation, IO, execution. |
 
-## Quick Start
+## REST Endpoints
+
+All endpoints are registered under `/api` via `MapNexoEndpoints()` in `Nexo.API`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/agent` | Run an agent |
+| POST | `/api/validate` | Run validation |
+| POST | `/api/orchestrate` | Run orchestration |
+| POST | `/api/copilot/task` | Submit a copilot task (with audit context) |
+| GET | `/api/copilot/tasks` | List copilot tasks |
+| GET | `/api/status` | Background agent status |
+| POST | `/api/execution/build` | Build a container image |
+| POST | `/api/execution/run` | Run a container |
+| GET | `/api/capabilities` | Node capability manifest |
+| GET | `/api/security/advisory` | Exposure profile / advisory |
+| GET | `/api/trust/status` | Trust boundary status |
+| GET | `/api/trust/dashboard` | Trust + audit dashboard |
+| POST | `/api/trust/pause` | Pause/resume observation |
+| POST | `/api/trust/rule` | Add allow/deny trust rules |
+| POST | `/api/director/run` | Run a director iteration (produces a daily) |
+| GET | `/api/director/dailies` | List director dailies |
+| GET | `/api/director/dailies/{dailyId}` | Get a specific daily |
+| GET | `/api/background-agents/summary` | Background agent health summary |
+| GET | `/api/knowledge/query` | Knowledge timeline query |
+
+## Hosting Quick Start (Embedding)
 
 ```csharp
 using Microsoft.Extensions.Hosting;
@@ -25,5 +54,20 @@ var host = Host.CreateDefaultBuilder(args)
 var validationService = host.Services.GetRequiredService<IValidationService>();
 var result = await validationService.ValidateAsync(filter: null, progress: null, CancellationToken.None);
 ```
+
+## NexoHostingOptions
+
+`AddNexo()` accepts an optional configuration callback:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `DeploymentProfile` | Module profile (`Full`, `Server`, `Edge`, `AirGapped`, `System`) | `Full` (or `NEXO_DEPLOYMENT_PROFILE`) |
+| `PatternStorePath` | LiteDB pattern store file path | `nexo-patterns.db` |
+| `TrustEnabled` | Enable trust & sanitization | `false` |
+| `RegisterBackgroundAgentHostedService` | Register background agent as hosted service | `false` |
+| `DisableObservationPipeline` | Skip observation pipeline registration | `false` |
+| `ObservationFailOpen` | Continue on observation store errors | `false` |
+| `UseAdaptiveLoadBalancing` | Enable adaptive load balancing | `false` |
+| `ExecutionRemoteUrl` | Remote execution endpoint URL | unset |
 
 See [Getting Started](GettingStarted.md) and [Architecture](Architecture.md) for more.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -15,9 +15,9 @@ Use the host surface when embedding Nexo into your own service. Use the client s
 - `Nexo.Core.Application.Sdk.Ports.INexoSdkBuilder`
 - `Nexo.Sdk` + `Nexo.Client` (`INexoClient`, `AddNexoSdk(baseUrl, ...)`)
 
-### Experimental (subject to faster change)
+### Deprecated
 
-- `Nexo.Sdk.NexoSdkBuilder.UseAdaptiveRouting()` intent flag behavior
+- `Nexo.Sdk.NexoSdkBuilder.UseAdaptiveRouting()` — marked `[Obsolete]` and is a no-op. Adaptive routing is configured on the host via `IProviderFactory`, not the client SDK.
 
 ### Internal (not for external contracts)
 
@@ -60,6 +60,23 @@ var services = new ServiceCollection();
 services.AddNexoSdk("http://localhost:5000");
 var provider = services.BuildServiceProvider();
 ```
+
+## Client SDK coverage
+
+`INexoClient` currently exposes these operations:
+
+| Method | API Path |
+|--------|----------|
+| `RunAgentAsync` | `POST /api/agent` |
+| `RunValidationAsync` | `POST /api/validate` |
+| `OrchestrateAsync` | `POST /api/orchestrate` |
+| `GetStatusAsync` | `GET /api/status` |
+| `BuildImageAsync` | `POST /api/execution/build` |
+| `RunContainerAsync` | `POST /api/execution/run` |
+
+The client does not yet cover copilot, director, trust mutation, knowledge query, capabilities, security advisory, or background-agent summary endpoints. Use direct HTTP calls for those (see `docs/api/index.md` for the full endpoint list).
+
+`AddNexoClient` accepts `BaseUrl`, optional `ApiKey` (sent as `X-Api-Key` header), and `Timeout`.
 
 ## RegisterBrick&lt;T&gt;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comprehensive documentation update to align all docs with the framework's actual implemented capabilities. Audited source code (CLI commands, API endpoints, infrastructure implementations, hosting options, providers, persistence stores, trust architecture, SDK surface, CI workflows) against documentation and fixed all discrepancies.

## Changes

- **README.md**: Expand CLI commands table from 8 to 30+ entries covering all root commands. Add missing providers (`local`, `echo`, `video`) with `NEXO_ALLOW_MOCK` note. Expand project layout to show all key source projects.
- **docs/Configuration.md**: Add 20+ missing environment variables (background agents, routing, execution, mesh trust policies, trust pack paths). Remove stale `NEXO_ENDPOINT_HEALTH_DEGRADED_LOG_THRESHOLD` (documented but never implemented). Fix provider list in config file section.
- **docs/Persistence.md**: Add 5 missing LiteDB stores (copilot tasks, adaptation audit, pipeline runs, execution tracer, test failures). Fix `LiteDbDataDecisionAuditLog` assembly location. Add pipeline run store and copilot task store sections.
- **docs/Architecture.md**: Move `IProviderFactory` to Infrastructure section and `IModel` to new Abstractions section (matching actual code locations). Fix duplicate "validation" in layer diagram. Add mesh to Infrastructure. Update provider list.
- **docs/ComponentLibrary.md**: Split "Long-term query (RAG)" to separate RAG services from test failure ingestion (`ITestFailureStore`).
- **docs/TrustAndInformationArchitecture.md**: Fix Section 4 storage from "SQLite" to "LiteDB" (matching `LiteDbUserKnowledgeLogStore`). Update Section 6 to document implemented `ICloudAvailabilityResolver`.
- **docs/api/index.md**: Add complete REST endpoint catalog (19 endpoints from `NexoEndpoints.cs`). Add `NexoHostingOptions` reference table. Add `Nexo.API`, `Nexo.Sdk`, `Nexo.Client` to library table.
- **docs/sdk.md**: Mark `UseAdaptiveRouting()` as deprecated/obsolete. Add `INexoClient` coverage table noting which endpoints the client covers and which require direct HTTP.
- **docs/DocsIndex.md**: Add 11 missing CI workflow references (runtime gates, installer gates, perf certification, multi-env tests, etc.).
- **docs/GettingStarted.md**: Expand CLI command list in verification step. Add more docs to recommended reading.
- **Makefile**: Remove orphaned `test-local` from `.PHONY` (no matching target exists).

## Testing

- Documentation-only changes plus one `.PHONY` fix in Makefile.
- All changes verified by auditing source code: `Nexo.CLI/Program.cs` (CLI commands), `Nexo.API/Endpoints/NexoEndpoints.cs` (REST endpoints), `Nexo.Infrastructure/` (providers, persistence, mesh, trust), `Nexo.Hosting/NexoHostingOptions.cs` (hosting options), `Nexo.Sdk/NexoSdkBuilder.cs` (SDK surface), `Nexo.Client/INexoClient.cs` (client coverage), `.github/workflows/` (CI workflows).

## Checklist

- [x] `make test` passes locally (no code changes, doc-only)
- [x] Documentation updated (if applicable)
- [x] No `TODO` or `NotImplementedException` left unresolved
- [x] Breaking changes are documented
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbb6a663-8c5d-4a0f-ac5b-ed38e5e951a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbb6a663-8c5d-4a0f-ac5b-ed38e5e951a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

