### PR TITLE
Fix mesh trust tier serialization causing DogfoodBlock9 test failures

### DIFF
--- a/docs/bricks/unknown.md
+++ b/docs/bricks/unknown.md
@@ -2,7 +2,7 @@
 
 ## Behavior
 
-Adapted from promotion 90e1650581be4ddc9f0e2cc328faeb0b.
+Adapted from promotion c0ca119973f14488b4e10de1a6c38798.
 
 **Last updated:** 2026-04-12
 
@@ -13,7 +13,7 @@ Adapted from promotion 90e1650581be4ddc9f0e2cc328faeb0b.
 
 ## 2026-04-11 – 2026-04-12
 
-- **unknown**: Fixed EmptyCatch in EmptyCatch.cs (2026-04-12 22:22)
+- **unknown**: Fixed EmptyCatch in EmptyCatch.cs (2026-04-12 22:43)
 
 
 ```

--- a/src/Nexo.Infrastructure/Mesh/FileBasedCapabilityAdvertisement.cs
+++ b/src/Nexo.Infrastructure/Mesh/FileBasedCapabilityAdvertisement.cs
@@ -71,7 +71,12 @@ public sealed class FileBasedCapabilityAdvertisement : ICapabilityAdvertisement
             TrustTier = _trustTier
         });
 
-        File.WriteAllText(_instancesPath, JsonSerializer.Serialize(entries, new JsonSerializerOptions { WriteIndented = true }));
+        var serializerOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        File.WriteAllText(_instancesPath, JsonSerializer.Serialize(entries, serializerOptions));
         return Task.CompletedTask;
     }
 

--- a/src/Nexo.Infrastructure/Mesh/FileBasedInstanceDiscovery.cs
+++ b/src/Nexo.Infrastructure/Mesh/FileBasedInstanceDiscovery.cs
@@ -48,10 +48,16 @@ public sealed class FileBasedInstanceDiscovery : IInstanceDiscovery
                 var trustTier = PeerTrustTier.Unknown;
                 if (peer.TryGetProperty("trustTier", out var trustTierElement))
                 {
-                    var parsed = trustTierElement.GetString();
-                    if (Enum.TryParse<PeerTrustTier>(parsed, true, out var tier))
+                    if (trustTierElement.ValueKind == JsonValueKind.String)
                     {
-                        trustTier = tier;
+                        if (Enum.TryParse<PeerTrustTier>(trustTierElement.GetString(), true, out var tier))
+                            trustTier = tier;
+                    }
+                    else if (trustTierElement.ValueKind == JsonValueKind.Number &&
+                             trustTierElement.TryGetInt32(out var numericTier) &&
+                             Enum.IsDefined(typeof(PeerTrustTier), numericTier))
+                    {
+                        trustTier = (PeerTrustTier)numericTier;
                     }
                 }
                 var effectiveTier = _trustPolicyResolver.ResolveTier(new PeerInfo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes 2 consistently failing tests in `DogfoodBlock9Tests` and `DogfoodBlock9LocalIpcTests` caused by a JSON serialization mismatch in the mesh peer trust tier.

## Changes

- `FileBasedCapabilityAdvertisement.cs` — Add `JsonStringEnumConverter` to serializer options so `PeerTrustTier` is written as a string (e.g. `"Unknown"`) instead of a numeric value (e.g. `0`) in `instances.json`.
- `FileBasedInstanceDiscovery.cs` — Handle both string and numeric `trustTier` values when reading `instances.json`, so discovery works regardless of which serializer wrote the file.

## Root Cause

`AdvertiseAsync` serialized `PeerTrustTier` as a numeric JSON value using the default `System.Text.Json` serializer. `DiscoverAsync` then called `GetString()` on the numeric JSON element, which threw `InvalidOperationException`. The `catch` block silently returned an empty peer list, causing both tests to fail on `Assert.NotEmpty`.

## Testing

- `dotnet test --filter DogfoodBlock9` — 2/2 passing on net8.0, 2/2 passing on net9.0
- Full `Nexo.Kernel.sln` test suite — 1,205 tests, 0 failures across all frameworks

## Checklist

- [x] `make test` passes locally
- [x] Documentation updated (if applicable)
- [x] No `TODO` or `NotImplementedException` left unresolved
- [x] Breaking changes are documented
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbb6a663-8c5d-4a0f-ac5b-ed38e5e951a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbb6a663-8c5d-4a0f-ac5b-ed38e5e951a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

