### PR TITLE
Reframe docs around north star: private, traceable, self-extending

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Nexo
 
-Nexo is a .NET framework and CLI for building AI-enabled software with orchestration, trust controls, adaptive pipelines, and test automation.
+Private, traceable AI computing that runs on your hardware and extends itself.
+
+Nexo is a .NET platform where AI capabilities are modular components with standardized contracts. You compose them into pipelines, the platform generates new ones when it detects capability gaps, and everything it produces follows enforced standards so it's readable, auditable, and extractable from the core. No cloud dependency. No data leaves your machines unless you explicitly route it to a trusted peer.
 
 Repository: <https://github.com/IanFrelinger/Nexo>
 
 ## Why Nexo
 
-- Build AI-powered workflows as composable, testable runtime pipelines.
-- Mix deterministic and agentic execution with fallback chains.
-- Enforce trust boundaries (barriers, audit, routing policy).
-- Run validation and multi-environment checks from one CLI.
+- **Your data stays yours.** Runs entirely on hardware you control. Cloud providers are opt-in capabilities, not dependencies. Air-gapped mode works out of the box.
+- **It builds what you need.** Describe a capability. The platform generates it, validates it against regression, and adds it to its own registry — under policy constraints with a full audit trail.
+- **Everything it produces is clean.** Generated components follow configurable, enforced standards. They're readable, testable, and decoupled from the core. You can extract and use them independently.
+- **Trace where your data goes.** Every decision, every routing choice, every adaptation is logged with provenance. Barrier identity resolution determines trust level per-request. Audit sinks record everything.
+- **Share across trusted hardware.** Any machine running .NET can join the mesh, advertise its capabilities, and serve requests from peers — with trust tiers controlling who can send work where.
 
 ## Quick Start (5 minutes)
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Nexo is an AI-enhanced development orchestration platform with a layered architecture.
+Nexo is a private AI platform where capabilities are modular components (bricks) with standardized contracts, composed into pipelines, and extended autonomously under policy constraints. The trust layer is structural — data provenance, barrier enforcement, and audit logging are woven into the execution pipeline, not bolted on. The mesh layer federates capabilities across trusted .NET peers so any machine on the network can share what it has.
 
 ## Layers
 

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -1,6 +1,6 @@
 # Nexo Documentation Index
 
-Use this page as the navigation starting point for docs.
+Private AI computing that extends itself. Start here to find what you need.
 
 ## Start Here
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,6 +1,6 @@
 # Getting Started with Nexo
 
-This guide is for first-time users who want to run Nexo quickly and understand the core workflows.
+Nexo runs on your hardware, keeps your data private, and extends its own capabilities over time. This guide gets you from zero to a working setup with trust controls active and a first pipeline validated.
 
 ## What you will do
 

--- a/docs/NorthStarGapAnalysis.md
+++ b/docs/NorthStarGapAnalysis.md
@@ -1,6 +1,6 @@
 # North Star Gap Analysis
 
-**North Star:** Self-improving adaptive framework with immutable core, full productivity application suite, runtime agent composition, instance networking, and ambient intelligence.
+**North Star:** Private, traceable AI computing that extends itself. Modular capabilities with standardized contracts, composed into pipelines, generated autonomously under policy constraints. Data stays on hardware you control. Trust is structural. Everything produced is clean, auditable, and extractable. Capabilities federate across trusted .NET peers.
 
 **Last Updated:** Reconciliation with codebase — several items previously marked MISSING or PARTIAL are now implemented.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Embeds the north star into the existing docs instead of creating a separate vision doc. Five files, 12 lines changed.

## Changes

- **README**: Opening and "Why Nexo" rewritten to lead with value — your data stays yours, it builds what you need, everything it produces is clean, trace where your data goes, share across trusted hardware.
- **Architecture.md**: Opening describes the platform in terms of what it does, not just how it's layered.
- **GettingStarted.md**: Opens with the promise, not the procedure.
- **NorthStarGapAnalysis.md**: North star statement rewritten to reflect the actual design philosophy.
- **DocsIndex.md**: Tagline updated.

No separate vision doc. The principles are embedded in how the existing docs talk about the project.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13d927dc-7952-443c-b4a6-ebf9b8940fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13d927dc-7952-443c-b4a6-ebf9b8940fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

