### PR TITLE
Add unified optimize_agent_cluster.sh workflow script with CI gate

### DIFF
--- a/.github/workflows/optimize-agent-cluster-gate.yml
+++ b/.github/workflows/optimize-agent-cluster-gate.yml
@@ -1,0 +1,368 @@
+name: Optimize Agent Cluster Gate
+
+on:
+  push:
+    branches: [master, main, "cursor/**"]
+    paths:
+      - ".github/workflows/optimize-agent-cluster-gate.yml"
+      - "apps/runtime-studio/**"
+      - "scripts/sandbox/**"
+      - "src/Nexo.CLI/**"
+      - "src/Nexo.CLI/Runtime/**"
+  pull_request:
+    paths:
+      - ".github/workflows/optimize-agent-cluster-gate.yml"
+      - "apps/runtime-studio/**"
+      - "scripts/sandbox/**"
+      - "src/Nexo.CLI/**"
+      - "src/Nexo.CLI/Runtime/**"
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  NEXO_STRICT_MODE: 1
+  NEXO_ALLOW_MOCK: 1
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────
+  # 1. Script interface tests (no .NET required — pure bash validation)
+  # ─────────────────────────────────────────────────────────────────────
+  script-interface:
+    name: "Script interface — help · args · flags"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "--help exits 0 and prints usage header"
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT=$(bash apps/runtime-studio/scripts/optimize_agent_cluster.sh --help)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -q "Unified workflow"
+          echo "$OUTPUT" | grep -q "\-\-objective"
+          echo "$OUTPUT" | grep -q "\-\-duration"
+          echo "$OUTPUT" | grep -q "\-\-spec"
+
+      - name: "Unknown argument exits 2"
+        shell: bash
+        run: |
+          set +e
+          bash apps/runtime-studio/scripts/optimize_agent_cluster.sh --not-a-real-flag 2>&1
+          EXIT_CODE=$?
+          set -e
+          if [[ "$EXIT_CODE" -ne 2 ]]; then
+            echo "Expected exit code 2, got $EXIT_CODE"
+            exit 1
+          fi
+
+      - name: "-h is accepted as short help"
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT=$(bash apps/runtime-studio/scripts/optimize_agent_cluster.sh -h)
+          echo "$OUTPUT" | grep -q "Unified workflow"
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 2. Bootstrap-only path (--skip-optimize, no --duration → no daemon)
+  # ─────────────────────────────────────────────────────────────────────
+  bootstrap-only:
+    name: "Bootstrap-only — skip optimize · skip daemon"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run with --skip-optimize (daemon auto-skipped without --duration)
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT=$(bash apps/runtime-studio/scripts/optimize_agent_cluster.sh --skip-optimize 2>&1)
+          echo "$OUTPUT"
+
+          echo "$OUTPUT" | grep -q "Bootstrap Runtime Studio"
+          echo "$OUTPUT" | grep -q "Optimize.*SKIPPED"
+          echo "$OUTPUT" | grep -q "Daemon.*SKIPPED"
+
+      - name: Sandbox directories exist after bootstrap
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d .nexo/agents/workspaces/runtime-studio
+          test -d .nexo/tools/cache/tmp
+          test -d .nexo/tools/cache/nuget
+          test -d .nexo/tools/cache/npm
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 3. Scaffold + Optimize path (provider unavailable — validates flow)
+  # ─────────────────────────────────────────────────────────────────────
+  scaffold-and-optimize:
+    name: "Scaffold + Optimize — workflow lab spec lifecycle"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Restore and build CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet restore src/Nexo.Tests.Infrastructure/scripts/copy-assemblies.csproj
+          dotnet build src/Nexo.CLI/Nexo.CLI.csproj -v minimal
+
+      - name: "Run optimize (no Ollama — expect scaffold success, optimize preflight failure)"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Optimize will fail because there is no Ollama server.
+          # We validate that bootstrap + scaffold succeed and the spec file
+          # is created, and that optimize is attempted (non-zero exit is expected).
+          set +e
+          bash apps/runtime-studio/scripts/optimize_agent_cluster.sh \
+            --skip-daemon \
+            --objective "CI validation" \
+            --verbose 2>&1 | tee "${{ runner.temp }}/optimize-output.txt"
+          OPTIMIZE_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          echo "optimize exit code: $OPTIMIZE_EXIT"
+
+          # Scaffold must have created the spec file
+          test -f .nexo/workflow/workflow_lab.runtime.json
+          echo "PASS: workflow lab spec scaffolded"
+
+          # Output must show the optimize step was attempted
+          grep -q "Optimize agent cluster for local hardware" "${{ runner.temp }}/optimize-output.txt"
+          echo "PASS: optimize step was attempted"
+
+      - name: "Re-run skips scaffold (idempotent)"
+        shell: bash
+        run: |
+          set -euo pipefail
+          SPEC_MTIME_BEFORE=$(stat -c %Y .nexo/workflow/workflow_lab.runtime.json)
+
+          set +e
+          bash apps/runtime-studio/scripts/optimize_agent_cluster.sh \
+            --skip-daemon \
+            --objective "CI validation round 2" 2>&1 | tee "${{ runner.temp }}/optimize-output-2.txt"
+          set -e
+
+          SPEC_MTIME_AFTER=$(stat -c %Y .nexo/workflow/workflow_lab.runtime.json)
+
+          # Spec file must NOT have been re-scaffolded
+          if [[ "$SPEC_MTIME_BEFORE" != "$SPEC_MTIME_AFTER" ]]; then
+            echo "FAIL: spec file was re-scaffolded (mtime changed)"
+            exit 1
+          fi
+          echo "PASS: scaffold is idempotent"
+
+          # Must NOT contain the scaffold message
+          if grep -q "Scaffolding default workflow lab spec" "${{ runner.temp }}/optimize-output-2.txt"; then
+            echo "FAIL: scaffold message appeared on second run"
+            exit 1
+          fi
+          echo "PASS: no scaffold message on re-run"
+
+      - name: "Custom --spec path is honoured"
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/custom-spec"
+
+          set +e
+          bash apps/runtime-studio/scripts/optimize_agent_cluster.sh \
+            --skip-daemon \
+            --spec "${{ runner.temp }}/custom-spec/my_spec.json" 2>&1 | tee "${{ runner.temp }}/custom-spec-output.txt"
+          set -e
+
+          test -f "${{ runner.temp }}/custom-spec/my_spec.json"
+          echo "PASS: custom spec path scaffolded"
+
+      - name: Upload optimize artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: optimize-agent-cluster-gate
+          path: |
+            .nexo/workflow/workflow_lab.runtime.json
+            ${{ runner.temp }}/optimize-output.txt
+            ${{ runner.temp }}/optimize-output-2.txt
+            ${{ runner.temp }}/custom-spec-output.txt
+            ${{ runner.temp }}/custom-spec/
+          retention-days: 14
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 4. Daemon launch path (--skip-optimize --duration 1s)
+  # ─────────────────────────────────────────────────────────────────────
+  daemon-launch:
+    name: "Daemon launch — skip optimize · short duration"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Restore and build CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet restore src/Nexo.Tests.Infrastructure/scripts/copy-assemblies.csproj
+          dotnet build src/Nexo.CLI/Nexo.CLI.csproj -v minimal
+
+      - name: "Launch daemon with --duration 2s --disable-observation"
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash apps/runtime-studio/scripts/optimize_agent_cluster.sh \
+            --skip-optimize \
+            --duration 2s \
+            --disable-observation 2>&1 | tee "${{ runner.temp }}/daemon-output.txt"
+
+          grep -q "Start background agent daemon" "${{ runner.temp }}/daemon-output.txt"
+          echo "PASS: daemon step was reached"
+
+          grep -q "Optimize.*SKIPPED" "${{ runner.temp }}/daemon-output.txt"
+          echo "PASS: optimize was skipped"
+
+      - name: Upload daemon artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daemon-launch-gate
+          path: ${{ runner.temp }}/daemon-output.txt
+          retention-days: 14
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 5. Flag combination matrix
+  # ─────────────────────────────────────────────────────────────────────
+  flag-combinations:
+    name: "Flag combo — ${{ matrix.label }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: "search-strategy-exhaustive"
+            flags: "--skip-daemon --search-strategy exhaustive --max-candidates 2 --objective test"
+            expect_optimize: true
+          - label: "search-strategy-objective-first"
+            flags: "--skip-daemon --search-strategy objective-first --max-candidates 2 --objective test"
+            expect_optimize: true
+          - label: "report-output-json"
+            flags: "--skip-daemon --report-output /tmp/report.json --objective test"
+            expect_optimize: true
+          - label: "provider-override"
+            flags: "--skip-daemon --provider ollama --prefer agentic --objective test"
+            expect_optimize: true
+          - label: "ollama-model-override"
+            flags: "--skip-daemon --ollama-model qwen2.5:7b --objective test"
+            expect_optimize: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Restore and build CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet restore src/Nexo.Tests.Infrastructure/scripts/copy-assemblies.csproj
+          dotnet build src/Nexo.CLI/Nexo.CLI.csproj -v minimal
+
+      - name: "Run optimize_agent_cluster.sh ${{ matrix.flags }}"
+        shell: bash
+        run: |
+          set +e
+          bash apps/runtime-studio/scripts/optimize_agent_cluster.sh \
+            ${{ matrix.flags }} 2>&1 | tee "${{ runner.temp }}/combo-output.txt"
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "exit code: $EXIT_CODE"
+
+          # Spec must be scaffolded
+          test -f .nexo/workflow/workflow_lab.runtime.json
+          echo "PASS: spec exists"
+
+          if [[ "${{ matrix.expect_optimize }}" == "true" ]]; then
+            grep -q "Optimize agent cluster for local hardware" "${{ runner.temp }}/combo-output.txt"
+            echo "PASS: optimize step attempted"
+          fi
+
+      - name: Upload combo artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flag-combo-${{ matrix.label }}
+          path: ${{ runner.temp }}/combo-output.txt
+          retention-days: 14
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Summary gate
+  # ─────────────────────────────────────────────────────────────────────
+  summary:
+    name: "Optimize Agent Cluster — summary"
+    runs-on: ubuntu-latest
+    needs: [script-interface, bootstrap-only, scaffold-and-optimize, daemon-launch, flag-combinations]
+    if: always()
+    steps:
+      - name: Summarize results
+        shell: bash
+        run: |
+          echo "## Optimize Agent Cluster Gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Script interface | ${{ needs.script-interface.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Bootstrap-only | ${{ needs.bootstrap-only.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Scaffold + Optimize | ${{ needs.scaffold-and-optimize.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Daemon launch | ${{ needs.daemon-launch.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Flag combinations | ${{ needs.flag-combinations.result }} |" >> "$GITHUB_STEP_SUMMARY"
+
+          OVERALL=0
+          for status in \
+            "${{ needs.script-interface.result }}" \
+            "${{ needs.bootstrap-only.result }}" \
+            "${{ needs.scaffold-and-optimize.result }}" \
+            "${{ needs.daemon-launch.result }}" \
+            "${{ needs.flag-combinations.result }}"; do
+            if [[ "$status" != "success" ]]; then
+              OVERALL=1
+            fi
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$OVERALL" -eq 0 ]]; then
+            echo "**Result: ALL CHECKS PASSED**" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Result: ONE OR MORE CHECKS FAILED**" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit $OVERALL

--- a/apps/runtime-studio/README.md
+++ b/apps/runtime-studio/README.md
@@ -64,6 +64,47 @@ bash apps/runtime-studio/scripts/bootstrap_runtime_studio.sh
 bash apps/runtime-studio/scripts/run_agent_set_local.sh --duration 5m --disable-observation
 ```
 
+### Optimize for your hardware first (recommended)
+
+A single script bundles the full setup → optimize → run workflow:
+
+```bash
+# Benchmark compositions on your hardware, emit a report, then start the daemon.
+bash apps/runtime-studio/scripts/optimize_agent_cluster.sh \
+  --objective "Plan and deliver iterative runtime improvements" \
+  --report-output .nexo/workflow/optimize-report.md \
+  --duration 5m \
+  --verbose
+```
+
+The script executes three steps:
+
+1. **Bootstrap** — initialises the Runtime Studio sandbox (idempotent).
+2. **Optimize** — scaffolds a workflow lab spec if none exists, runs `nexo workflow optimize` to benchmark composition + model candidates against local hardware, selects and promotes a winner, and writes an optional recommendation report.
+3. **Daemon** — starts the background agent daemon with the agent-set config (only when `--duration` is provided).
+
+Run `--help` for the full option list:
+
+```bash
+bash apps/runtime-studio/scripts/optimize_agent_cluster.sh --help
+```
+
+Common flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--objective <text>` | High-level objective used to prioritise candidates. |
+| `--spec <path>` | Custom workflow lab runtime spec JSON. |
+| `--search-strategy <name>` | `successive-halving` (default), `objective-first`, or `exhaustive`. |
+| `--max-candidates <n>` | Cap evaluated candidates (default 24). |
+| `--report-output <path>` | Write recommendation report (`.md`, `.json`, `.txt`). |
+| `--provider <name>` | Override LLM provider for all profiles. |
+| `--ollama-model <model>` | Override `OLLAMA_MODEL`. |
+| `--duration <dur>` | Daemon duration (e.g. `5m`, `1h`); omit to skip the daemon step. |
+| `--skip-optimize` | Bootstrap + daemon only (skip benchmarking). |
+| `--skip-daemon` | Bootstrap + optimize only (no daemon). |
+| `--verbose` | Emit optimizer progress output. |
+
 Game director quick start:
 
 ```bash

--- a/apps/runtime-studio/scripts/bootstrap_runtime_studio.sh
+++ b/apps/runtime-studio/scripts/bootstrap_runtime_studio.sh
@@ -12,4 +12,10 @@ mkdir -p "${ROOT}/.nexo/agents/workspaces/runtime-studio"
 
 echo
 echo "Runtime Studio bootstrap complete."
-echo "Next: bash apps/runtime-studio/scripts/run_agent_set_local.sh --duration 5m --disable-observation"
+echo
+echo "Next steps:"
+echo "  Optimize for your hardware (scaffold spec → benchmark → recommend → optional daemon):"
+echo "    bash apps/runtime-studio/scripts/optimize_agent_cluster.sh --objective 'your task' --verbose"
+echo
+echo "  Or skip optimization and run the agent set directly:"
+echo "    bash apps/runtime-studio/scripts/run_agent_set_local.sh --duration 5m --disable-observation"

--- a/apps/runtime-studio/scripts/optimize_agent_cluster.sh
+++ b/apps/runtime-studio/scripts/optimize_agent_cluster.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+AGENT_SET_CONFIG="${REPO_ROOT}/apps/runtime-studio/config/agent_set.local.json"
+SPEC_PATH=""
+OBJECTIVE=""
+OBJECTIVE_FILE=""
+SEARCH_STRATEGY="successive-halving"
+MAX_CANDIDATES=24
+DURATION=""
+DISABLE_OBSERVATION=0
+FORMAT_JSON=0
+SKIP_OPTIMIZE=0
+SKIP_DAEMON=0
+REPORT_OUTPUT=""
+PROVIDER=""
+PREFER=""
+OLLAMA_MODEL_OVERRIDE=""
+VERBOSE=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Unified workflow: bootstrap → scaffold spec → optimize compositions for your
+hardware → (optionally) launch the background agent daemon with the tuned config.
+
+Steps executed:
+  1. Bootstrap Runtime Studio sandbox (idempotent).
+  2. Scaffold a workflow lab spec if none exists.
+  3. Run \`nexo workflow optimize\` to benchmark composition/model candidates
+     on local hardware, select a winner, and emit a recommendation report.
+  4. (Optional) Start the background agent daemon with the agent-set config.
+
+Options:
+  --objective <text>          High-level objective for candidate prioritisation.
+  --objective-file <path>     File containing objective text.
+  --spec <path>               Workflow lab runtime spec JSON
+                              (default: .nexo/workflow/workflow_lab.runtime.json).
+  --search-strategy <name>    successive-halving | objective-first | exhaustive
+                              (default: successive-halving).
+  --max-candidates <n>        Maximum candidates to evaluate (default: 24).
+  --report-output <path>      Write recommendation report (.md/.json/.txt).
+  --provider <name>           Override LLM provider for all profile entries.
+  --prefer <mode>             Override model preference (agentic|deterministic|auto).
+  --ollama-model <model>      Override OLLAMA_MODEL env var.
+  --duration <dur>            Daemon duration (e.g. 5m, 1h). If omitted the
+                              daemon step is skipped.
+  --config <path>             Agent-set JSON for the daemon step
+                              (default: apps/runtime-studio/config/agent_set.local.json).
+  --skip-optimize             Skip the optimize step (bootstrap + daemon only).
+  --skip-daemon               Skip the daemon step (bootstrap + optimize only).
+  --disable-observation       Disable observation pipeline in the daemon.
+  --format-json               Emit machine-readable JSON from the daemon.
+  --verbose                   Emit progress output from the optimizer.
+  -h, --help                  Show this help message and exit.
+EOF
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --objective)       OBJECTIVE="${2:-}";        shift 2 ;;
+    --objective-file)  OBJECTIVE_FILE="${2:-}";   shift 2 ;;
+    --spec)            SPEC_PATH="${2:-}";        shift 2 ;;
+    --search-strategy) SEARCH_STRATEGY="${2:-}";  shift 2 ;;
+    --max-candidates)  MAX_CANDIDATES="${2:-24}"; shift 2 ;;
+    --report-output)   REPORT_OUTPUT="${2:-}";    shift 2 ;;
+    --provider)        PROVIDER="${2:-}";         shift 2 ;;
+    --prefer)          PREFER="${2:-}";           shift 2 ;;
+    --ollama-model)    OLLAMA_MODEL_OVERRIDE="${2:-}"; shift 2 ;;
+    --duration)        DURATION="${2:-}";         shift 2 ;;
+    --config)          AGENT_SET_CONFIG="${2:-}"; shift 2 ;;
+    --skip-optimize)   SKIP_OPTIMIZE=1;          shift ;;
+    --skip-daemon)     SKIP_DAEMON=1;            shift ;;
+    --disable-observation) DISABLE_OBSERVATION=1; shift ;;
+    --format-json)     FORMAT_JSON=1;            shift ;;
+    --verbose)         VERBOSE=1;                shift ;;
+    -h|--help)         usage ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Run with --help for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+# If no --duration and no --skip-daemon, default to skipping the daemon so
+# the user doesn't accidentally start a long-lived process.
+if [[ -z "${DURATION}" && "${SKIP_DAEMON}" -eq 0 ]]; then
+  SKIP_DAEMON=1
+fi
+
+export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://127.0.0.1:11434}"
+if [[ -n "${OLLAMA_MODEL_OVERRIDE}" ]]; then
+  export OLLAMA_MODEL="${OLLAMA_MODEL_OVERRIDE}"
+else
+  export OLLAMA_MODEL="${OLLAMA_MODEL:-llama3.1}"
+fi
+
+# ── Step 1: Bootstrap ────────────────────────────────────────────────────
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Step 1/3  Bootstrap Runtime Studio"
+echo "═══════════════════════════════════════════════════════════════"
+bash "${REPO_ROOT}/apps/runtime-studio/scripts/bootstrap_runtime_studio.sh"
+echo
+
+# ── Step 2: Scaffold + Optimize ──────────────────────────────────────────
+DEFAULT_SPEC="${REPO_ROOT}/.nexo/workflow/workflow_lab.runtime.json"
+RESOLVED_SPEC="${SPEC_PATH:-${DEFAULT_SPEC}}"
+
+if [[ "${SKIP_OPTIMIZE}" -eq 0 ]]; then
+  echo "═══════════════════════════════════════════════════════════════"
+  echo "  Step 2/3  Optimize agent cluster for local hardware"
+  echo "═══════════════════════════════════════════════════════════════"
+
+  # Scaffold the spec file if it doesn't exist yet so optimize has input.
+  if [[ ! -f "${RESOLVED_SPEC}" ]]; then
+    echo "Scaffolding default workflow lab spec → ${RESOLVED_SPEC}"
+    dotnet run --project "${REPO_ROOT}/src/Nexo.CLI" -- workflow scaffold \
+      --output "${RESOLVED_SPEC}"
+    echo
+  fi
+
+  OPTIMIZE_CMD=(
+    dotnet run --project "${REPO_ROOT}/src/Nexo.CLI" -- workflow optimize
+    --spec "${RESOLVED_SPEC}"
+    --search-strategy "${SEARCH_STRATEGY}"
+    --max-candidates "${MAX_CANDIDATES}"
+    --auto-pull-models
+    --promote-winner
+    --persist-history
+  )
+
+  [[ -n "${OBJECTIVE}" ]]      && OPTIMIZE_CMD+=(--objective "${OBJECTIVE}")
+  [[ -n "${OBJECTIVE_FILE}" ]] && OPTIMIZE_CMD+=(--objective-file "${OBJECTIVE_FILE}")
+  [[ -n "${REPORT_OUTPUT}" ]]  && OPTIMIZE_CMD+=(--report-output "${REPORT_OUTPUT}")
+  [[ -n "${PROVIDER}" ]]       && OPTIMIZE_CMD+=(--provider "${PROVIDER}")
+  [[ -n "${PREFER}" ]]         && OPTIMIZE_CMD+=(--prefer "${PREFER}")
+  [[ "${VERBOSE}" -eq 1 ]]     && OPTIMIZE_CMD+=(--verbose)
+
+  echo "Running: ${OPTIMIZE_CMD[*]}"
+  echo "  spec:             ${RESOLVED_SPEC}"
+  echo "  search-strategy:  ${SEARCH_STRATEGY}"
+  echo "  max-candidates:   ${MAX_CANDIDATES}"
+  echo "  ollama:           ${OLLAMA_BASE_URL} (${OLLAMA_MODEL})"
+  [[ -n "${OBJECTIVE}" ]]      && echo "  objective:        ${OBJECTIVE}"
+  [[ -n "${OBJECTIVE_FILE}" ]] && echo "  objective-file:   ${OBJECTIVE_FILE}"
+  [[ -n "${REPORT_OUTPUT}" ]]  && echo "  report-output:    ${REPORT_OUTPUT}"
+  echo
+
+  cd "${REPO_ROOT}"
+  "${OPTIMIZE_CMD[@]}"
+  OPTIMIZE_EXIT=$?
+
+  echo
+  if [[ ${OPTIMIZE_EXIT} -eq 0 ]]; then
+    echo "Optimize completed successfully."
+  else
+    echo "Optimize finished with exit code ${OPTIMIZE_EXIT}." >&2
+    echo "Review the output above for details. Continuing to daemon step (if enabled)."
+  fi
+  echo
+else
+  echo "═══════════════════════════════════════════════════════════════"
+  echo "  Step 2/3  Optimize  [SKIPPED]"
+  echo "═══════════════════════════════════════════════════════════════"
+  echo
+fi
+
+# ── Step 3: Daemon ────────────────────────────────────────────────────────
+if [[ "${SKIP_DAEMON}" -eq 0 ]]; then
+  echo "═══════════════════════════════════════════════════════════════"
+  echo "  Step 3/3  Start background agent daemon"
+  echo "═══════════════════════════════════════════════════════════════"
+
+  if [[ ! -f "${AGENT_SET_CONFIG}" ]]; then
+    echo "Missing agent-set config: ${AGENT_SET_CONFIG}" >&2
+    exit 1
+  fi
+
+  DAEMON_CMD=(
+    dotnet run --project "${REPO_ROOT}/src/Nexo.CLI" -- background-agent daemon
+    --config "${AGENT_SET_CONFIG}"
+    --duration "${DURATION}"
+  )
+
+  [[ "${DISABLE_OBSERVATION}" -eq 1 ]] && DAEMON_CMD+=(--disable-observation)
+  [[ "${FORMAT_JSON}" -eq 1 ]]         && DAEMON_CMD+=(--format-json)
+
+  echo "Running agent daemon"
+  echo "  config:      ${AGENT_SET_CONFIG}"
+  echo "  duration:    ${DURATION}"
+  echo "  observation: $([[ "${DISABLE_OBSERVATION}" -eq 1 ]] && echo "disabled" || echo "enabled")"
+  echo "  ollama:      ${OLLAMA_BASE_URL} (${OLLAMA_MODEL})"
+  echo
+
+  cd "${REPO_ROOT}"
+  "${DAEMON_CMD[@]}"
+else
+  echo "═══════════════════════════════════════════════════════════════"
+  echo "  Step 3/3  Daemon  [SKIPPED]"
+  echo "═══════════════════════════════════════════════════════════════"
+  echo "  Pass --duration <dur> to start the agent daemon after optimization."
+  echo
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `apps/runtime-studio/scripts/optimize_agent_cluster.sh` — a single entry-point script that bundles the multi-step agent cluster setup and hardware optimization workflow into one command — and a comprehensive GitHub Actions CI workflow to gate it.

## Changes

- **New script `optimize_agent_cluster.sh`** — orchestrates three steps:
  1. Bootstrap Runtime Studio sandbox (idempotent via existing `bootstrap_runtime_studio.sh`)
  2. Scaffold a workflow lab spec (`nexo workflow scaffold`) if none exists
  3. Run `nexo workflow optimize` to benchmark composition + model candidates against local hardware, select a winner, and optionally emit a recommendation report
  4. (Optional, via `--duration`) Start the background agent daemon with the tuned agent-set config
- **Updated `bootstrap_runtime_studio.sh`** — post-bootstrap output now suggests the new optimize script alongside the existing `run_agent_set_local.sh`.
- **Updated `apps/runtime-studio/README.md`** — documents the new "Optimize for your hardware" workflow with usage examples and a flags table.
- **New CI workflow `.github/workflows/optimize-agent-cluster-gate.yml`** — automated tests across 5 job groups:
  - **Script interface** — `--help` output, unknown arg rejection (exit 2), `-h` short form
  - **Bootstrap-only** — `--skip-optimize` path, sandbox directory creation
  - **Scaffold + Optimize** — spec file lifecycle, idempotent re-run (no re-scaffold), custom `--spec` path
  - **Daemon launch** — short-duration daemon with `--disable-observation`
  - **Flag combination matrix** — search strategies (`exhaustive`, `objective-first`), `--report-output`, `--provider`/`--prefer`/`--ollama-model` overrides
  - **Summary gate** — aggregates all job results into a step summary table

## Testing

- Validated YAML syntax (PyYAML parse, 6 jobs, 3 trigger events).
- Ran all CI test steps locally:
  - `--help` exits 0, prints expected tokens (objective, duration, spec, unified workflow).
  - Unknown argument exits 2.
  - `-h` short form accepted.
  - `--skip-optimize` runs bootstrap, skips optimize and daemon, creates sandbox dirs.
  - Scaffold + optimize path creates spec file, attempts optimize (fails at provider preflight without Ollama — expected).
  - Second optimize run is idempotent (no re-scaffold, mtime unchanged).
  - Custom `--spec` path scaffolds to the specified location.
  - `--skip-optimize --duration 1s --disable-observation` reaches daemon step with correct flags.

## Checklist

- [x] `make test` passes locally
- [x] Documentation updated (if applicable)
- [x] No `TODO` or `NotImplementedException` left unresolved
- [x] Breaking changes are documented
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68e30d37-78dd-4a5f-9a52-c925991623c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68e30d37-78dd-4a5f-9a52-c925991623c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

