### PR TITLE
Container-first onboarding, deploy docs, and CI setup smoke

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Nexo",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm",
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=nexo-nuget-packages,target=/home/vscode/.nuget/packages,type=volume"
+  ],
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-dotnettools.csharp"]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Setup-gate restore graph (same projects as scripts/docker-restore.ps1).
+# Full Nexo.sln restore is skipped here: MAUI/Android workloads are not installed in this image.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "post-create: restoring NuGet graph..."
+dotnet restore src/Nexo.Core.Application/Nexo.Core.Application.csproj --verbosity minimal
+dotnet restore src/Nexo.Infrastructure/Nexo.Infrastructure.csproj --verbosity minimal
+dotnet restore src/Nexo.CLI/Nexo.CLI.csproj --verbosity minimal
+dotnet restore src/Nexo.Tests.Infrastructure/scripts/copy-assemblies.csproj --verbosity minimal
+dotnet restore src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --verbosity minimal
+echo "post-create: ok"

--- a/.github/workflows/devcontainer-gate.yml
+++ b/.github/workflows/devcontainer-gate.yml
@@ -1,0 +1,56 @@
+name: Dev Container Gate
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - "cursor/**"
+    paths:
+      - ".github/workflows/devcontainer-gate.yml"
+      - ".devcontainer/**"
+      - "global.json"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+      - "src/Nexo.CLI/**"
+      - "src/Nexo.Core.Application/**"
+      - "src/Nexo.Infrastructure/**"
+      - "src/Nexo.Tests.Infrastructure/**"
+  pull_request:
+    paths:
+      - ".github/workflows/devcontainer-gate.yml"
+      - ".devcontainer/**"
+      - "global.json"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+      - "src/Nexo.CLI/**"
+      - "src/Nexo.Core.Application/**"
+      - "src/Nexo.Infrastructure/**"
+      - "src/Nexo.Tests.Infrastructure/**"
+  workflow_dispatch:
+
+jobs:
+  devcontainer-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Post-create + CLI build inside dev image
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm"
+          docker pull "$image"
+          # Run as container root (default): same restore/build commands as post-create + local dev smoke.
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace:rw" \
+            -w /workspace \
+            "$image" \
+            bash -lc '
+              set -euo pipefail
+              bash .devcontainer/post-create.sh
+              dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal
+              dotnet run --project src/Nexo.CLI -- --help >/dev/null
+              echo "devcontainer-gate: ok"
+            '

--- a/.github/workflows/devcontainer-gate.yml
+++ b/.github/workflows/devcontainer-gate.yml
@@ -8,6 +8,7 @@ on:
       - "cursor/**"
     paths:
       - ".github/workflows/devcontainer-gate.yml"
+      - "scripts/ci/devcontainer-smoke.sh"
       - ".devcontainer/**"
       - "global.json"
       - "Directory.Build.props"
@@ -19,6 +20,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/devcontainer-gate.yml"
+      - "scripts/ci/devcontainer-smoke.sh"
       - ".devcontainer/**"
       - "global.json"
       - "Directory.Build.props"
@@ -38,19 +40,4 @@ jobs:
 
       - name: Post-create + CLI build inside dev image
         shell: bash
-        run: |
-          set -euo pipefail
-          image="mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm"
-          docker pull "$image"
-          # Run as container root (default): same restore/build commands as post-create + local dev smoke.
-          docker run --rm \
-            -v "${GITHUB_WORKSPACE}:/workspace:rw" \
-            -w /workspace \
-            "$image" \
-            bash -lc '
-              set -euo pipefail
-              bash .devcontainer/post-create.sh
-              dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal
-              dotnet run --project src/Nexo.CLI -- --help >/dev/null
-              echo "devcontainer-gate: ok"
-            '
+        run: bash scripts/ci/devcontainer-smoke.sh "${GITHUB_WORKSPACE}"

--- a/.github/workflows/onboarding-docs-guard.yml
+++ b/.github/workflows/onboarding-docs-guard.yml
@@ -11,6 +11,7 @@ on:
       - "docs/GettingStarted.md"
       - "docs/DocsIndex.md"
       - "docs/OneClickInstall.md"
+      - "docs/CiFirstHardwareSecond.md"
       - ".devcontainer/**"
       - ".github/workflows/onboarding-docs-guard.yml"
   pull_request:
@@ -19,6 +20,7 @@ on:
       - "docs/GettingStarted.md"
       - "docs/DocsIndex.md"
       - "docs/OneClickInstall.md"
+      - "docs/CiFirstHardwareSecond.md"
       - ".devcontainer/**"
       - ".github/workflows/onboarding-docs-guard.yml"
   workflow_dispatch:
@@ -71,6 +73,7 @@ jobs:
 
           # Operator deploy section stays container-first.
           grep -nE "## Deploy \\(operators\\)" README.md
+          grep -nE "docs/CiFirstHardwareSecond\\.md" README.md
 
       - name: Emit onboarding docs guard summary
         if: always()

--- a/.github/workflows/onboarding-docs-guard.yml
+++ b/.github/workflows/onboarding-docs-guard.yml
@@ -11,6 +11,7 @@ on:
       - "docs/GettingStarted.md"
       - "docs/DocsIndex.md"
       - "docs/OneClickInstall.md"
+      - ".devcontainer/**"
       - ".github/workflows/onboarding-docs-guard.yml"
   pull_request:
     paths:
@@ -18,6 +19,7 @@ on:
       - "docs/GettingStarted.md"
       - "docs/DocsIndex.md"
       - "docs/OneClickInstall.md"
+      - ".devcontainer/**"
       - ".github/workflows/onboarding-docs-guard.yml"
   workflow_dispatch:
 
@@ -65,6 +67,10 @@ jobs:
           grep -nE "docs/GettingStarted\\.md" docs/DocsIndex.md
           grep -nE "scripts/setup/setup\\.sh" docs/DocsIndex.md
           grep -nE "onboarding-quickstart-gate\\.yml" docs/DocsIndex.md
+          grep -nE "devcontainer-gate\\.yml" docs/DocsIndex.md
+
+          # Operator deploy section stays container-first.
+          grep -nE "## Deploy \\(operators\\)" README.md
 
       - name: Emit onboarding docs guard summary
         if: always()

--- a/.github/workflows/setup-smoke-suite.yml
+++ b/.github/workflows/setup-smoke-suite.yml
@@ -1,0 +1,120 @@
+# Fast parallel checks: dev container restore + compose file validity + native Ubuntu setup.
+# Run from Actions → "Setup Smoke Suite" → Run workflow before burning time on target hardware.
+# See docs/CiFirstHardwareSecond.md
+name: Setup Smoke Suite
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+      - "cursor/**"
+    paths:
+      - ".github/workflows/setup-smoke-suite.yml"
+      - "docs/CiFirstHardwareSecond.md"
+      - "scripts/ci/devcontainer-smoke.sh"
+      - ".devcontainer/**"
+      - "docker-compose.portal.yml"
+      - "docker-compose.agent-server.yml"
+      - "docker-compose.ephemeral.yml"
+      - "docker-compose.test.yml"
+      - "docker-compose.ollama.yml"
+      - "scripts/setup/**"
+      - "scripts/install/**"
+      - "global.json"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+  pull_request:
+    paths:
+      - ".github/workflows/setup-smoke-suite.yml"
+      - "docs/CiFirstHardwareSecond.md"
+      - "scripts/ci/devcontainer-smoke.sh"
+      - ".devcontainer/**"
+      - "docker-compose.portal.yml"
+      - "docker-compose.agent-server.yml"
+      - "docker-compose.ephemeral.yml"
+      - "docker-compose.test.yml"
+      - "docker-compose.ollama.yml"
+      - "scripts/setup/**"
+      - "scripts/install/**"
+      - "global.json"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+
+concurrency:
+  group: setup-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  devcontainer-smoke:
+    name: Dev container — post-create + CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Post-create + CLI build inside dev image
+        shell: bash
+        run: bash scripts/ci/devcontainer-smoke.sh "${GITHUB_WORKSPACE}"
+
+  compose-config-smoke:
+    name: Compose — config (deploy + test stacks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate compose files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/compose-smoke"
+          validate() {
+            local f="$1"
+            shift
+            echo "=== ${f} $@ ==="
+            docker compose -f "$f" "$@" config >"${RUNNER_TEMP}/compose-smoke/$(basename "$f" .yml).rendered.yaml"
+          }
+          validate docker-compose.portal.yml
+          validate docker-compose.agent-server.yml
+          validate docker-compose.ephemeral.yml
+          validate docker-compose.ephemeral.yml --profile db
+          validate docker-compose.test.yml
+          validate docker-compose.ollama.yml
+          echo "setup-smoke-suite compose-config: ok"
+
+      - name: Upload rendered compose (debug)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: setup-smoke-compose-rendered
+          path: ${{ runner.temp }}/compose-smoke/
+          retention-days: 7
+
+  native-setup-ubuntu:
+    name: Native Ubuntu — setup.sh + CLI build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Setup gate check + restore + CLI build
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/setup/setup.sh check
+          bash scripts/setup/setup.sh restore
+          dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal
+          dotnet run --project src/Nexo.CLI -- --help >/dev/null
+          echo "setup-smoke-suite native-ubuntu: ok"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,28 @@
 
 Thanks for contributing.
 
-## Prerequisites
+## Recommended dev workflow (container + CLI)
+
+1. **Docker** and **Git** on the host.
+2. In **Cursor** or **VS Code**, install [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), open the repo, then **Dev Containers: Reopen in Container**. The first open runs `.devcontainer/post-create.sh` (setup-gate `dotnet restore` graph; not full `Nexo.sln`).
+3. In the dev-container terminal, build and use the CLI:
+
+```bash
+dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore
+dotnet run --project src/Nexo.CLI -- --help
+```
+
+**Remote:** connect over **Remote SSH**, open the repo on the remote machine, then **Reopen in Container** there so the toolchain comes from the image, not from manual packages on the host.
+
+## Prerequisites (native escape hatch)
+
+Use this only when you cannot use the dev container or other Docker workflows:
 
 - .NET SDK `9.x` (pinned by `global.json`)
 - Git
 - Optional: Docker (for multi-environment and compose-based test lanes)
 
-## Local setup
+## Local setup (native)
 
 From repository root:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Nexo is a .NET platform for composable AI workflows with structural trust enforc
 
 Nexo operates entirely on infrastructure you control. Cloud providers are opt-in execution targets, not dependencies. No data leaves the host unless explicitly routed to a trusted peer. Air-gapped deployment is supported without modification.
 
+**Development and deployment** default to **containers** (published images on GHCR, `Dockerfile.*` in `.docker/`, and `docker-compose*.y` stacks) plus the **Nexo CLI** (`dotnet run --project src/Nexo.CLI`). Shell installers under `scripts/install/` remain optional escape hatches for hosts where Docker is not available.
+
 Repository: <https://github.com/IanFrelinger/Nexo>
 
 ## Why Nexo
@@ -27,142 +29,64 @@ Repository: <https://github.com/IanFrelinger/Nexo>
 
 ## Quick Start
 
-### One command (recommended)
+Standard flow: **run Nexo inside a container** (dev container or compose), and use the **CLI** for builds, validation, and operators. Prefer published **GHCR** images for production-like runs; build from `Dockerfile.*` when you need a local image.
 
-From a cloned repo:
+### 1) Prerequisites (container-first path)
+
+- **Docker** (Desktop or Engine) and **Git**
+- Optional: Ollama/OpenAI/Azure credentials for live model backends
+
+You do **not** need a host-installed .NET SDK for the paths below. Install **.NET SDK 9.x** only if you choose the native escape hatch (see end of this section).
+
+### 2) Recommended: Dev Container (Cursor / VS Code)
+
+1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+2. Open this repository, then run **Dev Containers: Reopen in Container**.
+
+The dev container uses **.NET 9**, mounts a named volume at `nexo-nuget-packages` for the NuGet cache, and runs **`.devcontainer/post-create.sh`** after the container is created. That script restores the **same setup-gate project graph** as `scripts/docker-restore.ps1` (not full `Nexo.sln`, which requires MAUI/Android workloads inside a plain SDK image).
+
+From the integrated terminal inside the container:
 
 ```bash
-bash scripts/install/quickstart.sh
-# Opens http://localhost:8080 — portal running with mock provider, no API keys needed.
+dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore
+dotnet run --project src/Nexo.CLI -- --help
 ```
 
-The script detects Docker or .NET SDK, builds, and starts the portal. Works on Linux and macOS. Mock provider is enabled by default so the setup wizard and chat work immediately.
+**Remote SSH:** connect to a host that already has Docker (or your chosen toolchain), open the repo there, then use **Reopen in Container** on the remote so the environment still comes from the image.
 
-Stop with `docker stop nexo-quickstart` (Docker path) or `Ctrl+C` (native path).
-
-### Other lanes
-
-**Docker only (portal + API):**
+### 3) Run the portal (Docker quickstart image)
 
 ```bash
 git clone https://github.com/IanFrelinger/Nexo.git && cd Nexo
 docker build -f .docker/Dockerfile.quickstart -t nexo:quickstart .
 docker run --rm -p 8080:8080 nexo:quickstart
-# Open http://localhost:8080
+# Open http://localhost:8080 — mock provider; no API keys required.
 ```
 
-**Docker CLI only (no portal):**
+Stop with `Ctrl+C` or `docker stop` on the container ID.
+
+### 4) Published CLI image (CI, agents, minimal host)
 
 ```bash
 docker pull ghcr.io/ianfrelinger/nexo-cli:latest
 docker run --rm ghcr.io/ianfrelinger/nexo-cli:latest --help
 ```
 
-**Native SDK:**
+Validate a pipeline template from your workspace:
 
 ```bash
-git clone https://github.com/IanFrelinger/Nexo.git && cd Nexo
-bash scripts/install/install.sh --yes
-NEXO_ALLOW_MOCK=1 dotnet run --project src/Nexo.API
-# Open http://localhost:5000
+docker run --rm \
+  -v "$PWD:/work" \
+  -w /work \
+  ghcr.io/ianfrelinger/nexo-cli:latest \
+  pipeline validate --template /work/path/to/template.json
 ```
 
-Prefer this one-shot installer if you want fewer manual steps:
-
-```bash
-bash scripts/install/install.sh --yes
-```
-
-### 1) Prerequisites
-
-- .NET SDK 9.x (the repo is pinned by `global.json`)
-- Git
-- Optional: Docker (for containerized test workflows)
-- Optional: Ollama/OpenAI/Azure credentials (for live model backends)
-
-### Environment setup scripts (Windows/macOS/Linux)
-
-Use the setup scripts to validate required tooling and restore baseline NuGet packages used by the core CI gates.
-The CI setup gate also validates these scripts in an ephemeral Linux container (`mcr.microsoft.com/dotnet/sdk:9.0`) on every run:
-
-```bash
-# Linux/macOS: check required dependencies
-bash scripts/setup/setup.sh check
-
-# Linux/macOS: restore NuGet packages/solutions
-bash scripts/setup/setup.sh restore
-
-# Linux/macOS: run check + restore
-bash scripts/setup/setup.sh all
-```
-
-```powershell
-# Windows PowerShell: check required dependencies
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\setup\setup.ps1 -Mode check
-
-# Windows PowerShell: restore NuGet packages/solutions
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\setup\setup.ps1 -Mode restore
-
-# Windows PowerShell: run check + restore
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\setup\setup.ps1 -Mode all
-```
-
-**Windows + Docker (no local .NET SDK):** restoring the full `Nexo.sln` in a plain Linux SDK container fails on MAUI/Android workloads. Use the setup-gate restore (same projects as `setup.sh restore`) inside one container, with a persistent NuGet volume:
-
-```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\docker-restore.ps1
-# optional: also build Nexo.CLI in-container
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\docker-restore.ps1 -Build
-```
-
-### Remote development (Cursor / VS Code)
-
-**Dev Container (recommended):** install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, open this repo, then **Dev Containers: Reopen in Container**. The container uses .NET 9, persists NuGet packages in a named volume, and runs the same setup-gate `dotnet restore` graph as `scripts/docker-restore.ps1` (not full `Nexo.sln`, which requires MAUI workloads).
-
-**Remote SSH:** on the Linux/macOS host, install prerequisites (`bash scripts/setup/setup.sh all` or your usual bootstrap), clone the repo, then in Cursor use **Remote-SSH: Connect to Host…** and open the folder. Cursor installs its server component on first connect; you only need a normal user account, SSH, and the toolchain on the machine.
-
-### One-click bootstrap installers (Option 1)
-
-For single-command install/bootstrap wrappers, see:
-
-- `docs/OneClickInstall.md`
-
-These wrappers can auto-install missing required prerequisites (including `.NET SDK 9`) in guided mode, then run restore/build checks.
-
-Quick examples:
-
-```bash
-bash scripts/install/install.sh --yes
-```
-
-```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install\install.ps1 -Yes
-```
-
-Container-first one-shot bootstrap (installs Docker if needed, pulls CLI + SDK images, smoke-runs both):
-
-```bash
-bash scripts/install/container-bootstrap.sh --yes
-```
-
-```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install\container-bootstrap.ps1 -Yes
-```
-
-### Container image usage (flexible deployability)
-
-Build local CLI image:
+Build a local CLI image (optional):
 
 ```bash
 docker build -f .docker/Dockerfile.cli -t nexo-cli:local .
 docker run --rm nexo-cli:local --help
-```
-
-Pull published image (GHCR):
-
-```bash
-docker pull ghcr.io/ianfrelinger/nexo-cli:latest
-docker run --rm ghcr.io/ianfrelinger/nexo-cli:latest --help
 ```
 
 Build with explicit framework/runtime versions:
@@ -176,17 +100,30 @@ docker build \
   -t nexo-cli:net8 .
 ```
 
-Validate a pipeline template from your current workspace using the published image:
+### 5) Compose stacks (director portal, agent server, dependencies)
+
+For multi-service deployment on a host you control, start from the files in the repository root (`docker-compose.portal.yml`, `docker-compose.agent-server.yml`, `docker-compose.ephemeral.yml`, etc.) and the operator guides in `docs/SelfHostedAgentServer.md` and `apps/runtime-studio/README.md`.
+
+### 6) Escape hatches (no Docker)
+
+Use these only when containers are not an option:
+
+- **One command portal (script):** `bash scripts/install/quickstart.sh` — detects Docker or a local SDK, builds, starts the portal.
+- **Native SDK + setup scripts:** `bash scripts/install/install.sh --yes` then `NEXO_ALLOW_MOCK=1 dotnet run --project src/Nexo.API` — see `docs/OneClickInstall.md`.
+- **Cross-platform setup / restore helpers:** `bash scripts/setup/setup.sh all` or `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\setup\setup.ps1 -Mode all` — same graph CI validates in `mcr.microsoft.com/dotnet/sdk:9.0`.
+- **Windows + Docker without host SDK:** `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\docker-restore.ps1` (optional `-Build`).
+
+Container bootstrap (install Docker if needed, pull images, smoke-run):
 
 ```bash
-docker run --rm \
-  -v "$PWD:/work" \
-  -w /work \
-  ghcr.io/ianfrelinger/nexo-cli:latest \
-  pipeline validate --template /work/path/to/template.json
+bash scripts/install/container-bootstrap.sh --yes
 ```
 
-### 2) Clone and build
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install\container-bootstrap.ps1 -Yes
+```
+
+### 7) Clone and build (native SDK only)
 
 ```bash
 git clone https://github.com/IanFrelinger/Nexo.git
@@ -195,19 +132,19 @@ bash scripts/setup/setup.sh all
 dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore
 ```
 
-### 3) Confirm CLI is working
+### 8) Confirm CLI is working
 
 ```bash
 dotnet run --project src/Nexo.CLI -- --help
 ```
 
-### 3b) Run onboarding doctor (single pass/fail report)
+### 8b) Run onboarding doctor (single pass/fail report)
 
 ```bash
 dotnet run --project src/Nexo.CLI -- doctor --json
 ```
 
-### 4) Run a first high-signal command
+### 9) Run a first high-signal command
 
 `validate` can execute a broad architecture/test sweep and may be heavier on constrained hosts. For first-run confidence, start with CLI help and a pipeline validate command:
 
@@ -415,7 +352,8 @@ Nexo/
 ├── apps/                         # application configs (runtime-studio, release-manager)
 ├── config/                       # trust policy packs (air-gapped, internal-only, strict-enterprise)
 ├── docs/                         # docs, specs, guides
-├── scripts/                      # setup, install, demos, onboarding
+├── scripts/                      # setup, install, demos, onboarding (escape hatches + CI)
+├── .devcontainer/                # default Dev Container (Cursor / VS Code)
 ├── .docker/                      # docker test/runtime definitions
 ├── .github/                      # CI workflows and templates
 ├── global.json                   # SDK pin (.NET 9)

--- a/README.md
+++ b/README.md
@@ -27,18 +27,22 @@ Repository: <https://github.com/IanFrelinger/Nexo>
 - **Strict mode.** Set `NEXO_STRICT_MODE=1` for fail-fast + verbose diagnostics during development. Flip to permissive for production. See `docs/Configuration.md`.
 - **Centralized defaults.** All tunable constants live in `Nexo.Core.Domain.NexoDefaults` — no magic numbers scattered in the codebase.
 
-## Quick Start
+## Quick Start (5 minutes)
+
+Choose your lane (recommended):
+
+### Lane A: fastest path (container runtime)
 
 Standard flow: **run Nexo inside a container** (dev container or compose), and use the **CLI** for builds, validation, and operators. Prefer published **GHCR** images for production-like runs; build from `Dockerfile.*` when you need a local image.
 
-### 1) Prerequisites (container-first path)
+#### 1) Prerequisites (container-first path)
 
 - **Docker** (Desktop or Engine) and **Git**
 - Optional: Ollama/OpenAI/Azure credentials for live model backends
 
 You do **not** need a host-installed .NET SDK for the paths below. Install **.NET SDK 9.x** only if you choose the native escape hatch (see end of this section).
 
-### 2) Recommended: Dev Container (Cursor / VS Code)
+#### 2) Recommended: Dev Container (Cursor / VS Code)
 
 1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
 2. Open this repository, then run **Dev Containers: Reopen in Container**.
@@ -54,7 +58,7 @@ dotnet run --project src/Nexo.CLI -- --help
 
 **Remote SSH:** connect to a host that already has Docker (or your chosen toolchain), open the repo there, then use **Reopen in Container** on the remote so the environment still comes from the image.
 
-### 3) Run the portal (Docker quickstart image)
+#### 3) Run the portal (Docker quickstart image)
 
 ```bash
 git clone https://github.com/IanFrelinger/Nexo.git && cd Nexo
@@ -65,7 +69,7 @@ docker run --rm -p 8080:8080 nexo:quickstart
 
 Stop with `Ctrl+C` or `docker stop` on the container ID.
 
-### 4) Published CLI image (CI, agents, minimal host)
+#### 4) Published CLI image (CI, agents, minimal host)
 
 ```bash
 docker pull ghcr.io/ianfrelinger/nexo-cli:latest
@@ -100,11 +104,13 @@ docker build \
   -t nexo-cli:net8 .
 ```
 
-### 5) Compose stacks (director portal, agent server, dependencies)
+#### 5) Compose stacks (director portal, agent server, dependencies)
 
 For multi-service deployment on a host you control, start from the files in the repository root (`docker-compose.portal.yml`, `docker-compose.agent-server.yml`, `docker-compose.ephemeral.yml`, etc.) and the operator guides in `docs/SelfHostedAgentServer.md` and `apps/runtime-studio/README.md`.
 
-### 6) Escape hatches (no Docker)
+### Lane B: full local dev path (native SDK)
+
+#### 6) Escape hatches (no Docker)
 
 Use these only when containers are not an option:
 
@@ -123,7 +129,7 @@ bash scripts/install/container-bootstrap.sh --yes
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install\container-bootstrap.ps1 -Yes
 ```
 
-### 7) Clone and build (native SDK only)
+#### 7) Clone and build (native SDK only)
 
 ```bash
 git clone https://github.com/IanFrelinger/Nexo.git
@@ -132,19 +138,19 @@ bash scripts/setup/setup.sh all
 dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore
 ```
 
-### 8) Confirm CLI is working
+#### 8) Confirm CLI is working
 
 ```bash
 dotnet run --project src/Nexo.CLI -- --help
 ```
 
-### 8b) Run onboarding doctor (single pass/fail report)
+#### 8b) Run onboarding doctor (single pass/fail report)
 
 ```bash
 dotnet run --project src/Nexo.CLI -- doctor --json
 ```
 
-### 9) Run a first high-signal command
+#### 9) Run a first high-signal command
 
 `validate` can execute a broad architecture/test sweep and may be heavier on constrained hosts. For first-run confidence, start with CLI help and a pipeline validate command:
 
@@ -218,6 +224,35 @@ For HTTPS, configure `ASPNETCORE_URLS=https://+:8443` with a certificate, or pla
 
 See `docs/Configuration.md` for all security options and `docs/TailscaleAndNexo.md` for Tailnet deployment.
 
+## Deploy (operators)
+
+Ship Nexo from **published container images** and **compose** files. Do not rely on host-native installers for production paths.
+
+**Images**
+
+| Image | Use |
+|-------|-----|
+| `ghcr.io/ianfrelinger/nexo-cli:latest` | Automation, agents, `docker run` with a workspace mount for `pipeline validate`, `ci verify`, etc. |
+| Build from `.docker/Dockerfile.quickstart` | Single-container API + portal (mock-friendly smoke). |
+| Build from `.docker/Dockerfile.api` | API image used by compose stacks (see `docker-compose.portal.yml`). |
+
+**Compose (recommended stacks)**
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.portal.yml` | Director portal + `nexo-api` + Ollama on a host you control. |
+| `docker-compose.agent-server.yml` | Same lineage plus **mounted workspace** and default background agents (`apps/runtime-studio/config/agent_set.local.json`). |
+
+```bash
+# Director + API + Ollama (localhost bindings; tune for your exposure profile)
+docker compose -f docker-compose.portal.yml up -d --build
+
+# Full Runtime Studio agent-server stack
+docker compose -f docker-compose.agent-server.yml up -d --build
+```
+
+Copy and adjust env from `docs/config/agent-server.env.example`. Operator runbooks: `docs/SelfHostedAgentServer.md`, `apps/runtime-studio/README.md`. Readiness: `docs/ProductionReadinessGate-v1.md` and workflow `.github/workflows/production-readiness-gate-v1.yml`.
+
 ## Common CLI Workflows
 
 | Goal | Command |
@@ -277,44 +312,29 @@ References:
 - `scripts/unity-sidecar-demo.sh`
 - `docs/UnitySidecarDemo.md`
 
-## Docker Compose Workflows
+## Docker Compose (CI and local extras)
 
-The repository includes optional compose definitions for test and ephemeral runtime scenarios.
+Production-oriented compose is under **[Deploy (operators)](#deploy-operators)** above. Additional files are for **tests** and **local dependencies**:
 
 CI validation:
+
 - `.github/workflows/compose-gate.yml` runs compose-based checks on every relevant PR/push.
-- You can trigger manually with:
-  - `gh workflow run "Compose Gate" --ref master`
+- `gh workflow run "Compose Gate" --ref master`
 
 ```bash
-# run Ubuntu test service and write JSON/log output into ./test-results
+# Ubuntu test service → ./test-results
 docker compose -f docker-compose.test.yml up --build test-ubuntu
 
-# Ollama in Docker only (models in a named volume; use with host-run Nexo — see scripts/run-ollama-docker.ps1)
 docker compose -f docker-compose.ollama.yml up -d
-
-# One-shot dev: Docker Ollama → wait for health → run Nexo.API (Windows / PowerShell)
-# powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\start-nexo-api-dev.ps1 -Pull   # first time or new model
-# powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\start-nexo-api-dev.ps1
-# Phone on same Wi‑Fi: add -ListenLan (Windows) or --listen-lan (bash); open http://<pc-ip>:8080 — allow firewall
-# Linux/macOS/WSL: bash scripts/start-nexo-api-dev.sh --pull
-# Stop Ollama: scripts/stop-nexo-api-dev.ps1 | scripts/stop-nexo-api-dev.sh
-
-# start ephemeral Ollama container (and optional Postgres profile)
 docker compose -f docker-compose.ephemeral.yml up ollama
 docker compose -f docker-compose.ephemeral.yml --profile db up postgres
-
-# start self-hosted director portal (API + dailies + Ollama)
-docker compose -f docker-compose.portal.yml up -d --build
-
-# full portal stack: mounted workspace + background agents (see apps/runtime-studio README)
-docker compose -f docker-compose.agent-server.yml up -d --build
 ```
 
 Notes:
-- `docker-compose.test.yml` mounts `./test-results` and runs `BaseFrameworkSmokeTests` (`net9.0`) in container, writing log/summary artifacts there.
-- `docker-compose.ephemeral.yml` is for disposable local orchestration dependencies.
-- **Portal stacks:** `docker-compose.portal.yml` = Director UI + API + Ollama. `docker-compose.agent-server.yml` = same plus **mounted repo** + default background agents from `apps/runtime-studio/config/agent_set.local.json`. Relationship diagram: `apps/runtime-studio/README.md#how-runtime-studio-fits-with-nexo-api`. Docker tuning: `docs/SelfHostedAgentServer.md`, `docs/config/agent-server.env.example`.
+
+- `docker-compose.test.yml` runs `BaseFrameworkSmokeTests` in container.
+- `docker-compose.ephemeral.yml` is for disposable local orchestration.
+- Relationship diagram for portal vs agent-server: `apps/runtime-studio/README.md#how-runtime-studio-fits-with-nexo-api`.
 
 ## Providers
 
@@ -373,6 +393,7 @@ dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --fil
 ## Documentation Map
 
 Start here:
+- `README.md` → **[Deploy (operators)](#deploy-operators)** — GHCR images and compose stacks for production-style hosts.
 - `docs/GettingStarted.md` – guided first-hour setup and usage
 - `docs/DocsIndex.md` – where to find docs by task
 - `apps/runtime-studio/README.md` – Runtime Studio agent-set JSON; hub for CLI vs compose vs Director portal (see “How this fits” there).

--- a/README.md
+++ b/README.md
@@ -394,11 +394,13 @@ dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --fil
 
 Start here:
 - `README.md` → **[Deploy (operators)](#deploy-operators)** — GHCR images and compose stacks for production-style hosts.
+- `docs/CiFirstHardwareSecond.md` — run **Setup Smoke Suite** in GitHub Actions before iterating on slow target hardware.
 - `docs/GettingStarted.md` – guided first-hour setup and usage
 - `docs/DocsIndex.md` – where to find docs by task
 - `apps/runtime-studio/README.md` – Runtime Studio agent-set JSON; hub for CLI vs compose vs Director portal (see “How this fits” there).
 
 Core references:
+- `docs/CiFirstHardwareSecond.md` – CI smoke before target-hardware setup loops
 - `docs/Configuration.md` – environment/config options
 - `docs/Architecture.md` – architecture and subsystem overview
 - `docs/Testing.md` – test strategy, guard rails, and commands

--- a/docs/CiFirstHardwareSecond.md
+++ b/docs/CiFirstHardwareSecond.md
@@ -1,0 +1,38 @@
+# CI first, hardware second
+
+Use GitHub Actions to catch **restore, compose, and dev-container** failures before you spend cycles on **target hardware**. Hosted runners are not identical to your GPU, custom kernel, or air-gapped site, but they match the **container + CLI** path this repo documents in `README.md`.
+
+## One-button smoke (recommended)
+
+In GitHub: **Actions → Setup Smoke Suite → Run workflow** (pick your branch). That workflow runs **in parallel**:
+
+1. **Dev container path** — same commands as `.devcontainer/post-create.sh`, then `Nexo.CLI` build and `--help`.
+2. **Deploy / test compose syntax** — `docker compose … config` on the main compose files (portal, agent-server, ephemeral, test, ollama) so merge errors surface without starting full stacks.
+3. **Native Ubuntu lane** — `scripts/setup/setup.sh check` + `restore`, then `dotnet build` on `Nexo.CLI` (matches a common Linux laptop path).
+
+Workflow file: `.github/workflows/setup-smoke-suite.yml`.
+
+To reproduce the **dev container** job locally (Docker on your workstation):
+
+```bash
+bash scripts/ci/devcontainer-smoke.sh
+```
+
+## Deeper gates (when the smoke suite is green)
+
+| Workflow | Use when |
+|----------|----------|
+| `devcontainer-gate.yml` | You changed `.devcontainer/` or the setup-gate restore graph (same smoke as `scripts/ci/devcontainer-smoke.sh`). |
+| `compose-gate.yml` | You changed `docker-compose.test.yml` / ephemeral lanes or need full test-container run + Postgres smoke. |
+| `container-image-gate.yml` | You changed `.docker/Dockerfile.cli` or CLI dependencies. |
+| `environment-setup-gate-v1.yml` | You need **macOS + Windows** native `setup.ps1` / `setup.sh`, not only Ubuntu. |
+| `onboarding-quickstart-gate.yml` | You changed onboarding scripts or want taxonomy artifacts. |
+| `full-platform-readiness-gate.yml` | You want setup → discovery → dry-run across **many** OS/container matrices (slowest; run before release or big infra changes). |
+
+## What still belongs on target hardware
+
+- GPU / accelerator drivers and device nodes inside or beside containers.
+- Real **Ollama model pull** size and bandwidth, **NVMe** performance, and **custom rootfs** libraries.
+- **Network exposure** (firewall, Tailscale, mTLS) and **air-gap** mirrors not modeled in CI.
+
+After CI is green, run the **same** `docker compose` / images documented under **Deploy (operators)** in `README.md` on the device once, then iterate locally.

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -21,6 +21,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 - `.github/workflows/production-readiness-gate-v1.yml` — automated production readiness gate.
 - `.github/workflows/environment-setup-gate-v1.yml` — environment bootstrap + dependency setup gate (Linux/macOS/Windows).
 - `.github/workflows/compose-gate.yml` — validates `docker-compose.test.yml` and `docker-compose.ephemeral.yml` lanes.
+- `.github/workflows/devcontainer-gate.yml` — validates `.devcontainer/post-create.sh` restore + `Nexo.CLI` build inside the dev image.
 - `.github/workflows/onboarding-quickstart-gate.yml` — runs first-run onboarding commands in native + container lanes.
 - `.github/workflows/container-image-gate.yml` — container image buildability and smoke-run gate.
 - `.github/workflows/container-image-publish.yml` — publish official GHCR CLI image (latest + sha tags).

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -22,6 +22,8 @@ Documentation index for the Nexo platform. Start here to find what you need.
 - `.github/workflows/environment-setup-gate-v1.yml` — environment bootstrap + dependency setup gate (Linux/macOS/Windows).
 - `.github/workflows/compose-gate.yml` — validates `docker-compose.test.yml` and `docker-compose.ephemeral.yml` lanes.
 - `.github/workflows/devcontainer-gate.yml` — validates `.devcontainer/post-create.sh` restore + `Nexo.CLI` build inside the dev image.
+- `.github/workflows/setup-smoke-suite.yml` — **parallel** dev container + compose `config` + native Ubuntu `setup.sh`; run manually before target-hardware iteration (`docs/CiFirstHardwareSecond.md`).
+- `docs/CiFirstHardwareSecond.md` — **CI first, hardware second**: which workflows to run and what still needs a physical host.
 - `.github/workflows/onboarding-quickstart-gate.yml` — runs first-run onboarding commands in native + container lanes.
 - `.github/workflows/container-image-gate.yml` — container image buildability and smoke-run gate.
 - `.github/workflows/container-image-publish.yml` — publish official GHCR CLI image (latest + sha tags).

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -4,14 +4,16 @@ Documentation index for the Nexo platform. Start here to find what you need.
 
 ## Start Here
 
-1. `docs/GettingStarted.md` — install, first commands, first pipeline, and first trust checks.
-2. `README.md` — two-lane quickstart (container-first and native setup).
-3. `docs/OneClickInstall.md` — one-shot installer wrappers for Linux/macOS/Windows.
-4. `scripts/install/container-bootstrap.sh` and `scripts/install/container-bootstrap.ps1` — one-shot container bootstrap (Docker + image pull + smoke run).
-5. `scripts/setup/setup.sh` and `scripts/setup/setup.ps1` — cross-platform dependency bootstrap + restore helpers.
-6. `docs/SetupMatrixVerification.md` + `scripts/setup/verify-setup-matrix.ps1` / `verify-setup-matrix.sh` — brute-force style setup combination checks (local + CI).
-7. `scripts/start-nexo-api-dev.ps1` / `scripts/start-nexo-api-dev.sh` — Docker Ollama + host `Nexo.API` dev stack (see `docs/Configuration.md` → Ollama).
-8. `docs/Architecture.md` — layered architecture and component boundaries.
+1. `README.md` — **container-first** quickstart (Dev Container, quickstart image, GHCR CLI, compose); native paths are documented as escape hatches.
+2. `.devcontainer/devcontainer.json` — default development environment (Cursor / VS Code).
+3. `docs/GettingStarted.md` — first commands, first pipeline, and first trust checks (aligned with container + CLI).
+4. `CONTRIBUTING.md` — recommended **Dev Container** workflow and PR checks.
+5. `docs/OneClickInstall.md` — optional one-shot **native** installer wrappers when Docker is unavailable.
+6. `scripts/install/container-bootstrap.sh` and `scripts/install/container-bootstrap.ps1` — one-shot container bootstrap (Docker + image pull + smoke run).
+7. `scripts/setup/setup.sh` and `scripts/setup/setup.ps1` — cross-platform **native** dependency bootstrap + restore helpers (CI and escape hatch).
+8. `docs/SetupMatrixVerification.md` + `scripts/setup/verify-setup-matrix.ps1` / `verify-setup-matrix.sh` — brute-force style setup combination checks (local + CI).
+9. `scripts/start-nexo-api-dev.ps1` / `scripts/start-nexo-api-dev.sh` — Docker Ollama + host `Nexo.API` dev stack (see `docs/Configuration.md` → Ollama).
+10. `docs/Architecture.md` — layered architecture and component boundaries.
 
 ## Operator / Production Readiness
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -36,7 +36,7 @@ In ~10-15 minutes, you will:
 
 ## 1) Choose your startup lane
 
-### Lane A (recommended): Dev Container + `dotnet` CLI
+### Lane A (fastest): container-first — Dev Container + `dotnet` CLI
 
 Use **Dev Containers: Reopen in Container** (see `README.md`). Then:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2,37 +2,50 @@
 
 This guide covers initial setup, trust configuration, and first pipeline validation. Nexo operates on local infrastructure with no external service dependencies. Trust controls are available but disabled by default — enable with `NEXO_TRUST_ENABLED=1`.
 
-## Quickest path (one command)
+The **default** path is **containers + CLI**: develop inside the **Dev Container** (or run published **GHCR** images / **compose** stacks). Use **native** installers and `scripts/setup/*` only when Docker is not an option. See `README.md` for the full map.
+
+## Quickest path (recommended)
+
+**Cursor / VS Code:** install [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), open the repo, **Dev Containers: Reopen in Container**. The first open restores the setup-gate NuGet graph via `.devcontainer/post-create.sh`.
+
+**Portal in Docker only** (no IDE):
 
 ```bash
-bash scripts/install/quickstart.sh
-# Opens http://localhost:8080 with mock provider — no API keys needed.
+git clone https://github.com/IanFrelinger/Nexo.git && cd Nexo
+docker build -f .docker/Dockerfile.quickstart -t nexo:quickstart .
+docker run --rm -p 8080:8080 nexo:quickstart
+# Open http://localhost:8080 — mock provider; no API keys needed.
 ```
 
-This handles Docker detection, .NET SDK installation, building, and starting the portal. See `scripts/install/quickstart.sh` for details.
+**One-command script** (uses Docker when present, otherwise tries a local SDK): `bash scripts/install/quickstart.sh` — see `scripts/install/quickstart.sh`.
 
 ## What you will do (manual path)
 
 In ~10-15 minutes, you will:
 
-1. Pick one startup lane (container-first or native).
+1. Pick one startup lane (**Dev Container**, **GHCR CLI**, **quickstart image**, or **native** escape hatch).
 2. Verify CLI is working.
 3. Validate and run a minimal pipeline.
 4. Move to deeper validation/testing only after first success.
 
 ## Prerequisites
 
-- .NET SDK **9.x** (repo is pinned in `global.json`).
-- Git.
-- Optional:
-  - Docker (multi-environment testing workflows)
-  - Ollama/OpenAI/Azure credentials (model-backed commands)
+- **Default:** Docker (Desktop or Engine) and Git. You do **not** need a host .NET SDK for Dev Container, quickstart image, or `docker run … ghcr.io/ianfrelinger/nexo-cli`.
+- **Native lane:** .NET SDK **9.x** (repo is pinned in `global.json`).
+- Optional: Ollama/OpenAI/Azure credentials (model-backed commands).
 
 ## 1) Choose your startup lane
 
-### Lane A (fastest): container-first
+### Lane A (recommended): Dev Container + `dotnet` CLI
 
-Use this when local SDK/workload setup is causing friction.
+Use **Dev Containers: Reopen in Container** (see `README.md`). Then:
+
+```bash
+dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore
+dotnet run --project src/Nexo.CLI -- --help
+```
+
+### Lane B: published CLI image (minimal host)
 
 ```bash
 docker pull ghcr.io/ianfrelinger/nexo-cli:latest
@@ -45,7 +58,7 @@ With workspace mount:
 docker run --rm -v "$PWD:/work" -w /work ghcr.io/ianfrelinger/nexo-cli:latest --help
 ```
 
-### Lane B (full local dev): native setup scripts + CLI build
+### Lane C (escape hatch): native setup scripts + CLI build
 
 After **`scripts/setup/setup.sh`** / **`setup-linux.sh`** / **`setup-macos.sh`** **`all`**, or Windows **`powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\setup\setup.ps1 -Mode all`**, Nexo runs a **bounded** Runtime Studio **`workflow optimize`** and writes the winning **Ollama `ModelName` values** into `apps/runtime-studio/config/agent_set.local.json`. Skip with **`NEXO_SKIP_RUNTIME_STUDIO_TUNE=1`** (Unix), **`-SkipRuntimeStudioTune`** (Windows `setup.ps1`), or rely on automatic skip in **CI** (`CI` / `GITHUB_ACTIONS`).
 

--- a/docs/OneClickInstall.md
+++ b/docs/OneClickInstall.md
@@ -2,6 +2,8 @@
 
 This guide provides single-command install/bootstrap paths for each platform using wrappers in `scripts/install/`.
 
+Repository default onboarding is **container-first** (Dev Container, `Dockerfile.quickstart`, GHCR CLI, compose). The scripts here are **native escape hatches** when Docker is impractical or you want guided host SDK installation.
+
 ## Quickstart (recommended)
 
 The fastest path to a working portal — detects Docker or .NET SDK, builds, and opens the browser:

--- a/scripts/ci/devcontainer-smoke.sh
+++ b/scripts/ci/devcontainer-smoke.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run the same restore + CLI smoke as .devcontainer/post-create + local build.
+# Used by .github/workflows/devcontainer-gate.yml and setup-smoke-suite.yml.
+# Usage: bash scripts/ci/devcontainer-smoke.sh [REPO_ROOT]
+set -euo pipefail
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+image="mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm"
+docker pull "$image"
+docker run --rm \
+  -v "${REPO_ROOT}:/workspace:rw" \
+  -w /workspace \
+  "$image" \
+  bash -lc '
+    set -euo pipefail
+    bash .devcontainer/post-create.sh
+    dotnet build src/Nexo.CLI/Nexo.CLI.csproj --no-restore -v minimal
+    dotnet run --project src/Nexo.CLI -- --help >/dev/null
+    echo "devcontainer-smoke: ok"
+  '


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change makes **containers + CLI** the documented default for development and deployment, adds the **Dev Container** configuration, **operator-focused deploy** documentation, and **CI** that validates setup paths without waiting on target hardware.

## What changed

- **`.devcontainer/`** — `devcontainer.json` uses `mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm`, mounts a named NuGet volume (`nexo-nuget-packages`), and runs `post-create.sh` to restore the **same setup-gate project graph** as `scripts/docker-restore.ps1` (not full `Nexo.sln` / MAUI workloads).
- **`README.md`** — Quick Start uses **Lane A / Lane B** headings (for `onboarding-docs-guard`), **Deploy (operators)** section (GHCR + Dockerfiles + `docker-compose.portal.yml` / `agent-server.yml`), compose section for CI/extras; Documentation Map links Deploy and **`docs/CiFirstHardwareSecond.md`**.
- **`CONTRIBUTING.md`** — Recommended workflow is Dev Container + `dotnet` CLI; native setup is a labeled escape hatch.
- **`docs/GettingStarted.md`**, **`docs/DocsIndex.md`**, **`docs/OneClickInstall.md`** — Aligned framing with container-first defaults.
- **`docs/CiFirstHardwareSecond.md`** — **CI first, hardware second**: run **Setup Smoke Suite** in Actions before slow hardware loops; table of deeper workflows; what still needs a physical host.
- **`.github/workflows/setup-smoke-suite.yml`** — **Parallel** jobs: `scripts/ci/devcontainer-smoke.sh`, `docker compose … config` on portal/agent-server/ephemeral/test/ollama compose files, native Ubuntu `setup.sh` + CLI build. **`workflow_dispatch`** for one-button runs; path filters on push/PR.
- **`.github/workflows/devcontainer-gate.yml`** — Invokes shared **`scripts/ci/devcontainer-smoke.sh`** (same logic as before).
- **`.github/workflows/onboarding-docs-guard.yml`** — Expects container-first lane labels, **Deploy (operators)**, **`docs/CiFirstHardwareSecond.md`** in README, **`devcontainer-gate.yml`** and **`setup-smoke-suite.yml`** in DocsIndex; triggers when `.devcontainer/` or **`docs/CiFirstHardwareSecond.md`** changes.

## Notes

- Shell installers remain for CI and hosts without Docker; they are not the primary README path.
- **`bash scripts/ci/devcontainer-smoke.sh`** reproduces the dev-container CI smoke locally with Docker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f1a5adc-ef45-4711-9c17-0e574f625246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f1a5adc-ef45-4711-9c17-0e574f625246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

