### PR TITLE
Agent phase 4: transport invocation hooks and DI composition

### DIFF
--- a/src/Nexo.Orchestration/Coordination/Orchestrator.cs
+++ b/src/Nexo.Orchestration/Coordination/Orchestrator.cs
@@ -15,6 +15,7 @@ using Nexo.Orchestration.Negotiation;
 using Nexo.Orchestration.Barriers;
 using Nexo.Orchestration.Resilience;
 using Nexo.Orchestration.Models;
+using Nexo.Orchestration.Transport;
 using Nexo.Core.Application.Common.Ports;
 
 namespace Nexo.Orchestration.Coordination;
@@ -62,6 +63,7 @@ public sealed class Orchestrator
     private readonly IBarrierContextAccessor? _barrierContextAccessor;
     private readonly BarrierHierarchy? _barrierHierarchy;
     private readonly BarrierGuard? _barrierGuard;
+    private readonly IReadOnlyList<IAgentTransportInvocationHook> _invocationHooks;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Orchestrator"/> class.
@@ -85,6 +87,7 @@ public sealed class Orchestrator
     /// <param name="barrierHierarchy">Optional barrier hierarchy for fallback/default routing context.</param>
     /// <param name="barrierAuditLog">Optional barrier audit log for invocation events.</param>
     /// <param name="barrierOptions">Optional barrier options for guard behavior.</param>
+    /// <param name="invocationHooks">Optional hooks that run before each transport send and after successful invocations.</param>
     public Orchestrator(
         IArchitectAgent architect,
         AgentFactory agentFactory,
@@ -105,7 +108,8 @@ public sealed class Orchestrator
         IBarrierContextAccessor? barrierContextAccessor = null,
         BarrierHierarchy? barrierHierarchy = null,
         IBarrierAuditLog? barrierAuditLog = null,
-        IOptions<BarrierOptions>? barrierOptions = null)
+        IOptions<BarrierOptions>? barrierOptions = null,
+        IEnumerable<IAgentTransportInvocationHook>? invocationHooks = null)
     {
         _architect = architect ?? throw new ArgumentNullException(nameof(architect));
         _agentFactory = agentFactory ?? throw new ArgumentNullException(nameof(agentFactory));
@@ -144,6 +148,7 @@ public sealed class Orchestrator
                 barrierHierarchy,
                 barrierOptions.Value)
             : null;
+        _invocationHooks = invocationHooks?.ToArray() ?? Array.Empty<IAgentTransportInvocationHook>();
     }
 
     /// <summary>
@@ -358,7 +363,21 @@ public sealed class Orchestrator
                         },
                         DependencyOutputs: dependencyOutputs);
 
-                    var result = await SendThroughTransportAsync(invocation, token);
+                    var transportRequest = invocation;
+                    if (_invocationHooks.Count > 0)
+                    {
+                        foreach (var hook in _invocationHooks)
+                        {
+                            var hookContext = new AgentInvocationContext(
+                                correlationId,
+                                request,
+                                container.Agent.Spec,
+                                transportRequest);
+                            transportRequest = await hook.BeforeSendAsync(hookContext, token).ConfigureAwait(false);
+                        }
+                    }
+
+                    var result = await SendThroughTransportAsync(transportRequest, token);
                     if (!result.Success)
                     {
                         var errorCode = GetErrorCode(result) ?? "UNKNOWN";
@@ -377,6 +396,19 @@ public sealed class Orchestrator
                     }
 
                     var output = result.Output ?? new { };
+                    if (_invocationHooks.Count > 0)
+                    {
+                        var hookContext = new AgentInvocationContext(
+                            correlationId,
+                            request,
+                            container.Agent.Spec,
+                            transportRequest);
+                        foreach (var hook in _invocationHooks)
+                        {
+                            output = await hook.AfterSuccessAsync(hookContext, output, token).ConfigureAwait(false);
+                        }
+                    }
+
                     var agentDuration = result.Duration ?? (DateTimeOffset.UtcNow - agentStartTime);
                     
                     outputs[agentId] = output;

--- a/src/Nexo.Orchestration/ServiceCollectionExtensions.cs
+++ b/src/Nexo.Orchestration/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Nexo.Abstractions;
 using Nexo.Core.Application.Common.Ports;
 using Nexo.Core.Application.Common.Services;
@@ -16,10 +18,12 @@ using Nexo.Orchestration.Metrics;
 using Nexo.Orchestration.Negotiation;
 using Nexo.Orchestration.Barriers;
 using Nexo.Orchestration.Routing;
+using Nexo.Orchestration.Transport;
 using Nexo.Orchestration.Validation;
 using Nexo.Orchestration.Models;
 using Nexo.Abstractions.Barriers;
 using Nexo.Abstractions.Routing;
+using Nexo.Abstractions.Transport;
 
 namespace Nexo.Orchestration;
 
@@ -35,6 +39,7 @@ namespace Nexo.Orchestration;
 /// - Metrics and orchestrator
 /// 
 /// Call AddNexoOrchestration() to register all orchestration services.
+/// Register optional <c>IAgentTransportInvocationHook</c> implementations (singleton or scoped) to extend transport invocations.
 /// </summary>
 public static class ServiceCollectionExtensions
 {
@@ -100,8 +105,29 @@ public static class ServiceCollectionExtensions
         // Metrics
         services.AddSingleton<OrchestrationMetrics>();
 
-        // Orchestrator
-        services.AddScoped<Orchestrator>();
+        // Orchestrator (resolve invocation hooks from DI so hosts can add policy/metadata pipelines)
+        services.AddScoped(sp => new Orchestrator(
+            sp.GetRequiredService<IArchitectAgent>(),
+            sp.GetRequiredService<AgentFactory>(),
+            sp.GetRequiredService<LifecycleManager>(),
+            sp.GetRequiredService<DependencyResolver>(),
+            sp.GetRequiredService<ConflictDetector>(),
+            sp.GetRequiredService<ResourceAllocator>(),
+            sp.GetRequiredService<ProgressTracker>(),
+            sp.GetRequiredService<EscalationManager>(),
+            sp.GetRequiredService<OutputIntegrator>(),
+            sp.GetRequiredService<IAgentBus>(),
+            sp.GetRequiredService<IAgentTransport>(),
+            sp.GetRequiredService<ILoopKernel>(),
+            sp.GetRequiredService<ILogger<Orchestrator>>(),
+            negotiationProtocol: sp.GetService<NegotiationProtocol>(),
+            metrics: sp.GetService<OrchestrationMetrics>(),
+            runtimeSpecAccessor: sp.GetService<IOrchestrationRuntimeSpecAccessor>(),
+            barrierContextAccessor: sp.GetService<IBarrierContextAccessor>(),
+            barrierHierarchy: sp.GetService<BarrierHierarchy>(),
+            barrierAuditLog: sp.GetService<IBarrierAuditLog>(),
+            barrierOptions: sp.GetService<IOptions<BarrierOptions>>(),
+            invocationHooks: sp.GetServices<IAgentTransportInvocationHook>()));
 
         return services;
     }

--- a/src/Nexo.Orchestration/Transport/AgentInvocationContext.cs
+++ b/src/Nexo.Orchestration/Transport/AgentInvocationContext.cs
@@ -1,0 +1,13 @@
+using Nexo.Abstractions.Transport;
+using Nexo.Orchestration.Architect.Models;
+
+namespace Nexo.Orchestration.Transport;
+
+/// <summary>
+/// Context passed to agent transport invocation hooks (metadata policy, tracing, etc.).
+/// </summary>
+public sealed record AgentInvocationContext(
+    string CorrelationId,
+    string OrchestratorRequest,
+    AgentSpawnSpec Spec,
+    AgentInvocationRequest Request);

--- a/src/Nexo.Orchestration/Transport/IAgentTransportInvocationHook.cs
+++ b/src/Nexo.Orchestration/Transport/IAgentTransportInvocationHook.cs
@@ -1,0 +1,28 @@
+using Nexo.Abstractions.Transport;
+
+namespace Nexo.Orchestration.Transport;
+
+/// <summary>
+/// Extensibility point around transport-level agent invocation. Register multiple
+/// implementations in DI; <see cref="BeforeSendAsync"/> runs in registration order,
+/// then <see cref="AfterSuccessAsync"/> runs in registration order on successful results.
+/// </summary>
+public interface IAgentTransportInvocationHook
+{
+    /// <summary>
+    /// Transform or enrich the invocation before it is passed to retry/circuit-breaker and transport.
+    /// </summary>
+    Task<AgentInvocationRequest> BeforeSendAsync(
+        AgentInvocationContext context,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(context.Request);
+
+    /// <summary>
+    /// Optional post-processing of the successful output payload before dependency recording and bus publish.
+    /// </summary>
+    Task<object> AfterSuccessAsync(
+        AgentInvocationContext context,
+        object output,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(output);
+}

--- a/src/Nexo.Tests.Orchestration/Coordination/OrchestratorTransportTests.cs
+++ b/src/Nexo.Tests.Orchestration/Coordination/OrchestratorTransportTests.cs
@@ -13,6 +13,7 @@ using Nexo.Orchestration.Communication;
 using Nexo.Orchestration.Coordination;
 using Nexo.Orchestration.Coordination.Conflicts;
 using Nexo.Orchestration.Metrics;
+using Nexo.Orchestration.Transport;
 using Xunit;
 
 namespace Nexo.Tests.Orchestration.Coordination;
@@ -297,7 +298,78 @@ public sealed class OrchestratorTransportTests
         };
     }
 
-    private static Orchestrator CreateOrchestrator(IArchitectAgent architect, IAgentTransport transport)
+    [Fact]
+    public async Task OrchestrateAsync_InvocationHooks_BeforeSendRunsInOrder_AndEnrichesTransportRequest()
+    {
+        AgentInvocationRequest? capturedRequest = null;
+        var transportMock = new Mock<IAgentTransport>(MockBehavior.Strict);
+        transportMock
+            .Setup(t => t.SendAsync(It.IsAny<AgentInvocationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentInvocationRequest, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(new AgentResult(Success: true, Output: new { v = 1 }));
+
+        var hook1 = new MetadataAppendHook("hookOrder", "1");
+        var hook2 = new MetadataAppendHook("hookOrder", "2", append: false);
+
+        var sut = CreateOrchestrator(
+            CreateArchitectMock(CreateSingleAgentDecomposition()).Object,
+            transportMock.Object,
+            new IAgentTransportInvocationHook[] { hook1, hook2 });
+
+        var result = await sut.OrchestrateAsync("hooks");
+
+        result.Success.Should().BeTrue();
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.Metadata!["hookOrder"].Should().Be("2");
+    }
+
+    [Fact]
+    public async Task OrchestrateAsync_InvocationHooks_AfterSuccessTransformsOutput()
+    {
+        var transportMock = new Mock<IAgentTransport>(MockBehavior.Strict);
+        transportMock
+            .Setup(t => t.SendAsync(It.IsAny<AgentInvocationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResult(Success: true, Output: new { n = 3 }));
+
+        var sut = CreateOrchestrator(
+            CreateArchitectMock(CreateSingleAgentDecomposition()).Object,
+            transportMock.Object,
+            new IAgentTransportInvocationHook[] { new OutputWrapHook() });
+
+        var result = await sut.OrchestrateAsync("wrap");
+
+        result.Success.Should().BeTrue();
+        result.IntegratedOutput.Should().NotBeNull();
+        result.IntegratedOutput!.AgentOutputs["agent-1"].GetType().GetProperty("wrapped").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task OrchestrateAsync_InvocationHooks_AfterSuccessNotCalled_WhenTransportFails()
+    {
+        var transportMock = new Mock<IAgentTransport>(MockBehavior.Strict);
+        transportMock
+            .Setup(t => t.SendAsync(It.IsAny<AgentInvocationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResult(
+                Success: false,
+                ErrorMessage: "fail",
+                Metadata: new Dictionary<string, string> { ["errorCode"] = "AGENT_NOT_FOUND" }));
+
+        var counter = new CountingInvocationHook();
+        var sut = CreateOrchestrator(
+            CreateArchitectMock(CreateSingleAgentDecomposition()).Object,
+            transportMock.Object,
+            new IAgentTransportInvocationHook[] { counter });
+
+        await sut.OrchestrateAsync("fail");
+
+        counter.BeforeSendCount.Should().Be(1);
+        counter.AfterSuccessCount.Should().Be(0);
+    }
+
+    private static Orchestrator CreateOrchestrator(
+        IArchitectAgent architect,
+        IAgentTransport transport,
+        IReadOnlyList<IAgentTransportInvocationHook>? invocationHooks = null)
     {
         var provider = new ServiceCollection()
             .AddLogging()
@@ -341,6 +413,72 @@ public sealed class OrchestratorTransportTests
             transport,
             loops,
             provider.GetRequiredService<ILogger<Orchestrator>>(),
-            metrics: metrics);
+            metrics: metrics,
+            invocationHooks: invocationHooks);
+    }
+
+    private sealed class MetadataAppendHook : IAgentTransportInvocationHook
+    {
+        private readonly string _key;
+        private readonly string _value;
+        private readonly bool _append;
+
+        public MetadataAppendHook(string key, string value, bool append = true)
+        {
+            _key = key;
+            _value = value;
+            _append = append;
+        }
+
+        public Task<AgentInvocationRequest> BeforeSendAsync(
+            AgentInvocationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            var md = context.Request.Metadata != null
+                ? new Dictionary<string, string>(context.Request.Metadata, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (_append && md.TryGetValue(_key, out var existing))
+            {
+                md[_key] = existing + "," + _value;
+            }
+            else
+            {
+                md[_key] = _value;
+            }
+
+            return Task.FromResult(context.Request with { Metadata = md });
+        }
+    }
+
+    private sealed class OutputWrapHook : IAgentTransportInvocationHook
+    {
+        public Task<object> AfterSuccessAsync(
+            AgentInvocationContext context,
+            object output,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<object>(new { wrapped = output });
+    }
+
+    private sealed class CountingInvocationHook : IAgentTransportInvocationHook
+    {
+        public int BeforeSendCount;
+        public int AfterSuccessCount;
+
+        public Task<AgentInvocationRequest> BeforeSendAsync(
+            AgentInvocationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            BeforeSendCount++;
+            return Task.FromResult(context.Request);
+        }
+
+        public Task<object> AfterSuccessAsync(
+            AgentInvocationContext context,
+            object output,
+            CancellationToken cancellationToken = default)
+        {
+            AfterSuccessCount++;
+            return Task.FromResult(output);
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a composable **agent transport invocation hook** pipeline around orchestrator-driven `IAgentTransport` calls: hooks can enrich or validate `AgentInvocationRequest` before retry/circuit-breaker/transport, and transform successful outputs before dependency recording and bus publish.

## Changes

- **`AgentInvocationContext`:** correlation id, original user orchestration request string, `AgentSpawnSpec`, and current `AgentInvocationRequest`.
- **`IAgentTransportInvocationHook`:** `BeforeSendAsync` and `AfterSuccessAsync` with default pass-through implementations.
- **`Orchestrator`:** optional `IEnumerable<IAgentTransportInvocationHook>` constructor parameter; hooks run in **enumeration order** before `SendThroughTransportAsync`; `AfterSuccessAsync` runs only on **successful** transport results, in the same order.
- **`AddNexoOrchestration`:** registers `Orchestrator` via a scoped factory and passes `sp.GetServices<IAgentTransportInvocationHook>()` so hosts can add hooks with `services.AddSingleton<IAgentTransportInvocationHook, T>()` (or scoped).
- **Tests:** hook ordering / metadata enrichment, output wrapping into integrated `AgentOutputs`, and verification that `AfterSuccess` is not invoked when transport fails.

## Testing

- `dotnet build src/Nexo.Hosting/Nexo.Hosting.csproj`
- `dotnet test src/Nexo.Tests.Orchestration/Nexo.Tests.Orchestration.csproj`

## Checklist

- [ ] `make test` passes locally
- [ ] Documentation updated (if applicable)
- [ ] No `TODO` or `NotImplementedException` left unresolved
- [x] Breaking changes are documented

**Note:** `Orchestrator` constructor gained an optional trailing parameter; existing manual `new Orchestrator(...)` call sites remain valid. `AddNexoOrchestration` now uses an explicit factory delegate instead of `AddScoped<Orchestrator>()` so injected hooks are honored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f1a5adc-ef45-4711-9c17-0e574f625246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f1a5adc-ef45-4711-9c17-0e574f625246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

