### PR TITLE
Federated brick catalog HTTP API and optional peer mesh

### DIFF
--- a/src/Nexo.API/BrickCatalogWireMapper.cs
+++ b/src/Nexo.API/BrickCatalogWireMapper.cs
@@ -1,0 +1,97 @@
+using Nexo.BrickContracts;
+using Nexo.BrickContracts.Capabilities;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.API;
+
+internal static class BrickCatalogWireMapper
+{
+    public static BrickCatalogEntryDto ToEntry(Brick brick, NodeCapabilityManifestDto? hostCapabilities)
+    {
+        return new BrickCatalogEntryDto
+        {
+            Id = brick.Id,
+            Name = brick.Name,
+            Version = brick.Version,
+            Icon = brick.Icon,
+            Category = brick.Category.ToString(),
+            Description = brick.Description,
+            HostBaseUrl = null,
+            Interface = new BrickInterfaceDto
+            {
+                Inputs = brick.Interface.Inputs.Select(i => new BrickInputDefinitionDto
+                {
+                    Name = i.Name,
+                    Type = i.Type,
+                    Description = i.Description,
+                    Required = i.Required,
+                    Default = i.Default
+                }).ToList(),
+                Outputs = brick.Interface.Outputs.Select(o => new BrickOutputDefinitionDto
+                {
+                    Name = o.Name,
+                    Type = o.Type,
+                    Description = o.Description
+                }).ToList()
+            },
+            HasDeterministic = brick.Implementations.Deterministic != null,
+            HasAgentic = brick.Implementations.Agentic != null,
+            Metadata = new BrickMetadataDto
+            {
+                Author = brick.Metadata.Author,
+                License = brick.Metadata.License,
+                Repository = brick.Metadata.Repository,
+                UsageCount = brick.Metadata.UsageCount,
+                LastUpdated = brick.Metadata.LastUpdated
+            },
+            DomainKnowledge = ToDomainKnowledgeDto(brick.DomainKnowledge),
+            HostCapabilities = hostCapabilities
+        };
+    }
+
+    private static DomainKnowledgeDto? ToDomainKnowledgeDto(DomainKnowledge? dk)
+    {
+        if (dk is null) return null;
+        return new DomainKnowledgeDto
+        {
+            Standards = dk.Standards.ToList(),
+            Rules = dk.Rules.Select(r => new DomainRuleDto
+            {
+                Id = r.Id,
+                Description = r.Description,
+                Pattern = r.Pattern,
+                Severity = r.Severity,
+                CweId = r.CweId
+            }).ToList(),
+            ReferenceData = new Dictionary<string, string>(dk.ReferenceData),
+            LearnedPatterns = dk.LearnedPatterns.Select(p => new LearnedPatternDto
+            {
+                Pattern = p.Pattern,
+                Outcome = p.Outcome,
+                Confidence = p.Confidence,
+                OccurrenceCount = p.OccurrenceCount
+            }).ToList(),
+            ExecutionCount = dk.ExecutionCount
+        };
+    }
+
+    public static Nexo.Infrastructure.Execution.ExecutionContext ToExecutionContext(ExecutionContextDto? dto)
+    {
+        if (dto is null)
+            return new Nexo.Infrastructure.Execution.ExecutionContext();
+
+        return new Nexo.Infrastructure.Execution.ExecutionContext
+        {
+            AgentId = dto.AgentId ?? string.Empty,
+            BehaviorId = dto.BehaviorId ?? string.Empty,
+            IsAirGapped = dto.IsAirGapped,
+            AuditMode = dto.AuditMode,
+            Provider = dto.Provider ?? "openai",
+            Variables = dto.Variables != null
+                ? new Dictionary<string, object>(dto.Variables)
+                : new Dictionary<string, object>()
+        };
+    }
+}

--- a/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Nexo.BrickContracts;
 using Nexo.BrickContracts.Capabilities;
 using Nexo.Contracts;
 using Nexo.Core.Application.Copilot.Models;
@@ -20,12 +21,15 @@ using Nexo.BackgroundAgents.Objectives;
 using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.RuntimeStudio;
 using Nexo.Infrastructure.Testing.ExecutionPlatform;
+using Nexo.Infrastructure.Execution;
 using Nexo.API.Security;
 using Nexo.Orchestration.Coordination;
 using Nexo.Orchestration.Models;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
 
 namespace Nexo.API.Endpoints;
 
@@ -104,6 +108,24 @@ public static class NexoEndpoints
             .WithName("GetCapabilities")
             .WithSummary("Get node capability manifest for brick routing")
             .Produces<NodeCapabilityManifestDto>(StatusCodes.Status200OK);
+
+        group.MapGet("/bricks", ListBricksAsync)
+            .WithName("ListBricks")
+            .WithSummary("List bricks on this node (catalog for federated mesh)")
+            .Produces<BrickCatalogResponseDto>(StatusCodes.Status200OK);
+
+        group.MapGet("/bricks/{brickId}", GetBrickAsync)
+            .WithName("GetBrick")
+            .WithSummary("Get one brick catalog entry")
+            .Produces<BrickCatalogEntryDto>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPost("/bricks/{brickId}/execute", ExecuteBrickAsync)
+            .WithName("ExecuteBrick")
+            .WithSummary("Execute a brick on this node (used by RemoteBrick from peers)")
+            .Produces<BrickExecuteResponseDto>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapGet("/security/advisory", GetSecurityAdvisory)
             .WithName("GetSecurityAdvisory")
@@ -457,6 +479,85 @@ public static class NexoEndpoints
         await Task.CompletedTask;
         var manifest = runtime.GetCapabilityManifest();
         return Results.Ok(ToDto(manifest));
+    }
+
+    private static async Task<IResult> ListBricksAsync(
+        [FromServices] IBrickRegistry brickRegistry,
+        [FromServices] INodeCapabilityRuntime runtime,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask;
+        var hostCaps = ToDto(runtime.GetCapabilityManifest());
+        var bricks = brickRegistry.GetAllBricks()
+            .Select(b => BrickCatalogWireMapper.ToEntry(b, hostCaps))
+            .ToList();
+        return Results.Ok(new BrickCatalogResponseDto { Bricks = bricks });
+    }
+
+    private static async Task<IResult> GetBrickAsync(
+        string brickId,
+        [FromServices] IBrickRegistry brickRegistry,
+        [FromServices] INodeCapabilityRuntime runtime,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask;
+        if (string.IsNullOrWhiteSpace(brickId))
+            return Results.BadRequest(new ProblemDetails { Title = "brickId is required" });
+
+        var brick = brickRegistry.GetBrick(brickId);
+        if (brick is null)
+            return Results.NotFound();
+
+        var hostCaps = ToDto(runtime.GetCapabilityManifest());
+        return Results.Ok(BrickCatalogWireMapper.ToEntry(brick, hostCaps));
+    }
+
+    private static async Task<IResult> ExecuteBrickAsync(
+        string brickId,
+        [FromBody] BrickExecuteRequestDto? request,
+        [FromServices] IBrickRegistry brickRegistry,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(brickId))
+            return Results.BadRequest(new ProblemDetails { Title = "brickId is required" });
+        if (request is null)
+            return Results.BadRequest(new ProblemDetails { Title = "Request body is required" });
+        if (!string.IsNullOrEmpty(request.BrickId) &&
+            !string.Equals(request.BrickId, brickId, StringComparison.OrdinalIgnoreCase))
+        {
+            return Results.BadRequest(new ProblemDetails { Title = "BrickId in body must match route" });
+        }
+
+        var brick = brickRegistry.GetBrick(brickId);
+        if (brick is null)
+            return Results.NotFound();
+
+        if (!Enum.TryParse<ImplementationType>(request.Implementation, true, out var implementation))
+            implementation = ImplementationType.Deterministic;
+
+        var context = BrickCatalogWireMapper.ToExecutionContext(request.ExecutionContext);
+        var input = BrickValueSerializer.FromWireToBrickInput(request.Input);
+
+        try
+        {
+            var output = await brick.ExecuteAsync(input, implementation, context, cancellationToken).ConfigureAwait(false);
+            return Results.Ok(new BrickExecuteResponseDto
+            {
+                Success = true,
+                Summary = output.Summary,
+                Output = BrickValueSerializer.ToWireDictionary(output)
+            });
+        }
+        catch (Exception ex)
+        {
+            return Results.Ok(new BrickExecuteResponseDto
+            {
+                Success = false,
+                Error = ex.Message
+            });
+        }
     }
 
     private static async Task<IResult> RunDirectorWorkflowAsync(

--- a/src/Nexo.API/Nexo.API.csproj
+++ b/src/Nexo.API/Nexo.API.csproj
@@ -20,9 +20,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nexo.BackgroundAgents.HostRunners\Nexo.BackgroundAgents.HostRunners.csproj" />
+    <ProjectReference Include="..\Nexo.Brick.Contracts\Nexo.Brick.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Contracts\Nexo.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Hosting\Nexo.Hosting.csproj" />
     <ProjectReference Include="..\Nexo.GameDomain\Nexo.GameDomain.csproj" />
+    <ProjectReference Include="..\Nexo.Infrastructure\Nexo.Infrastructure.csproj" />
   </ItemGroup>
 
 

--- a/src/Nexo.Brick.Contracts/BrickCatalogEntryDto.cs
+++ b/src/Nexo.Brick.Contracts/BrickCatalogEntryDto.cs
@@ -22,6 +22,9 @@ public class BrickCatalogEntryDto
     public bool HasAgentic { get; set; }
     public BrickMetadataDto Metadata { get; set; } = new();
 
+    /// <summary>Codified domain knowledge for federation and operator UIs.</summary>
+    public DomainKnowledgeDto? DomainKnowledge { get; set; }
+
     /// <summary>Network-wide usage statistics (populated by central catalog when available).</summary>
     public BrickUsageStatsDto? UsageStats { get; set; }
 

--- a/src/Nexo.Brick.Contracts/DomainKnowledgeDto.cs
+++ b/src/Nexo.Brick.Contracts/DomainKnowledgeDto.cs
@@ -1,0 +1,30 @@
+namespace Nexo.BrickContracts;
+
+/// <summary>
+/// Wire DTO for codified domain knowledge attached to a brick (federated catalog / portal).
+/// </summary>
+public sealed class DomainKnowledgeDto
+{
+    public IReadOnlyList<string> Standards { get; set; } = [];
+    public IReadOnlyList<DomainRuleDto> Rules { get; set; } = [];
+    public IReadOnlyDictionary<string, string> ReferenceData { get; set; } = new Dictionary<string, string>();
+    public IReadOnlyList<LearnedPatternDto> LearnedPatterns { get; set; } = [];
+    public long ExecutionCount { get; set; }
+}
+
+public sealed class DomainRuleDto
+{
+    public string Id { get; set; } = "";
+    public string Description { get; set; } = "";
+    public string? Pattern { get; set; }
+    public string? Severity { get; set; }
+    public string? CweId { get; set; }
+}
+
+public sealed class LearnedPatternDto
+{
+    public string Pattern { get; set; } = "";
+    public string Outcome { get; set; } = "";
+    public double Confidence { get; set; }
+    public int OccurrenceCount { get; set; }
+}

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -228,6 +228,9 @@ public static class NexoServiceCollectionExtensions
         if (modules.IncludeAdaptation)
             services.AddAdaptationInfrastructure(options.PatternStorePath);
 
+        if (modules.IncludeAdaptation)
+            services.AddNexoFederatedBrickMesh(configuration);
+
         // ── Copilot task store ──────────────────────────────────────────
         // LiteDB file is co-located with the pattern store directory
         // (or the repo root as fallback) to keep all Nexo-generated

--- a/src/Nexo.Infrastructure/Adaptation/AdaptationServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Adaptation/AdaptationServiceCollectionExtensions.cs
@@ -31,7 +31,7 @@ public static class AdaptationServiceCollectionExtensions
 
         services.AddOptions<AdaptationBrickOptions>();
 
-        services.AddSingleton<Nexo.Core.Domain.Execution.IBrickRegistry>(sp =>
+        services.AddSingleton<Nexo.Infrastructure.Execution.BrickRegistry>(sp =>
         {
             var bricks = new List<Brick>();
             if (patternStorePath != null)
@@ -60,6 +60,8 @@ public static class AdaptationServiceCollectionExtensions
 
             return new Nexo.Infrastructure.Execution.BrickRegistry(bricks);
         });
+        services.AddSingleton<Nexo.Core.Domain.Execution.IBrickRegistry>(sp =>
+            sp.GetRequiredService<Nexo.Infrastructure.Execution.BrickRegistry>());
 
         services.AddSingleton<IBrickDecomposer, BrickDecomposer>();
         services.AddSingleton<IFixGenerator, FixGenerator>();

--- a/src/Nexo.Infrastructure/Execution/NexoFederatedBrickMeshServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Execution/NexoFederatedBrickMeshServiceCollectionExtensions.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.Infrastructure.Execution;
+
+/// <summary>
+/// Optional wiring so each Nexo host resolves bricks from peers over HTTP
+/// (<see cref="HttpRemoteBrickCatalog"/> + <see cref="CompositeBrickRegistry"/>).
+/// Dynamic compute scaling for a single task is handled separately by
+/// <see cref="Routing.NcrCapabilityRouter"/> and peer HTTP execution when RunPod capability routing is enabled;
+/// this extension only federates brick catalogs and execution delegation via <see cref="RemoteBrick"/>.
+/// </summary>
+public static class NexoFederatedBrickMeshServiceCollectionExtensions
+{
+    /// <summary>
+    /// When <see cref="BrickHostOptions.RemoteCatalogBaseUrls"/> is non-empty, replaces
+    /// <see cref="IBrickRegistry"/> with <see cref="CompositeBrickRegistry"/> backed by the
+    /// local <see cref="BrickRegistry"/> plus remote catalogs. Requires adaptation to be
+    /// registered (concrete <see cref="BrickRegistry"/>).
+    /// </summary>
+    public static IServiceCollection AddNexoFederatedBrickMesh(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+        services.AddOptions<BrickHostOptions>().Bind(configuration.GetSection(BrickHostOptions.SectionName));
+
+        services.AddSingleton<IBrickRegistry>(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<BrickHostOptions>>().Value;
+            var urls = (opts.RemoteCatalogBaseUrls ?? Array.Empty<string>())
+                .Select(u => u?.Trim() ?? "")
+                .Where(u => u.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var local = sp.GetService<BrickRegistry>();
+            if (local is null)
+                throw new InvalidOperationException(
+                    "Federated brick mesh requires a local BrickRegistry (enable adaptation in the deployment profile).");
+
+            if (urls.Count == 0)
+                return local;
+
+            foreach (var baseUrl in urls)
+            {
+                if (!Uri.TryCreate(baseUrl.Trim(), UriKind.Absolute, out var uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                {
+                    throw new InvalidOperationException(
+                        $"BrickHost.RemoteCatalogBaseUrls contains invalid URL: '{baseUrl}'.");
+                }
+            }
+
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            var logger = sp.GetService<ILogger<CompositeBrickRegistry>>();
+            var catalogs = new List<IRemoteBrickCatalog>(urls.Count);
+            foreach (var baseUrl in urls)
+            {
+                var normalized = baseUrl.TrimEnd('/') + "/";
+                var client = factory.CreateClient();
+                client.BaseAddress = new Uri(normalized, UriKind.Absolute);
+                if (opts.UseAuth && !string.IsNullOrEmpty(opts.ApiKeyValue) && !string.IsNullOrEmpty(opts.ApiKeyHeader))
+                    client.DefaultRequestHeaders.TryAddWithoutValidation(opts.ApiKeyHeader, opts.ApiKeyValue);
+                catalogs.Add(new HttpRemoteBrickCatalog(client, sp.GetService<ILogger<HttpRemoteBrickCatalog>>()));
+            }
+
+            return new CompositeBrickRegistry(local, catalogs, factory.CreateClient(), logger);
+        });
+
+        return services;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change implements the HTTP surface that `HttpRemoteBrickCatalog` and `RemoteBrick` already expected (`GET /api/bricks`, `GET /api/bricks/{id}`, `POST /api/bricks/{id}/execute`) on **Nexo.API**, so nodes can expose their local bricks to peers and execute bricks invoked remotely.

It also wires an optional **federated brick registry**: when `BrickHost:RemoteCatalogBaseUrls` lists peer API base URLs, `IBrickRegistry` resolves to `CompositeBrickRegistry` (local `BrickRegistry` plus remote catalogs). Domain knowledge is included in catalog DTOs via new `DomainKnowledgeDto` on `BrickCatalogEntryDto`.

Concrete `BrickRegistry` is now registered in DI (with `IBrickRegistry` forwarding to it) so the mesh layer can wrap the same local instance.

## Dynamic compute

Elastic routing for **generation-style** workloads remains in the existing NCR / `NexoPeerBrickExecutor` path (`instances.json` HTTP endpoints, queue/VRAM hints). This PR does not change that router; it focuses on **brick catalog federation** and **remote brick execution** over HTTP.

## Configuration

- Set peer catalog URLs under **`BrickHost:RemoteCatalogBaseUrls`** (environment variable prefix `BrickHost__RemoteCatalogBaseUrls__0`, etc., or JSON config section `BrickHost`).
- Optional auth: `BrickHost:UseAuth`, `BrickHost:ApiKeyHeader`, `BrickHost:ApiKeyValue`.

## Testing

- `dotnet build` Nexo.API, Nexo.Hosting, Nexo.CLI
- `dotnet test` … `--filter FullyQualifiedName~HttpRemoteBrickCatalog` (net8.0)
- `dotnet test` … `--filter FullyQualifiedName~AdaptationBrickRegistrationTests` (net8.0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88ee4d3f-c5b1-49cc-8033-90050c229f4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88ee4d3f-c5b1-49cc-8033-90050c229f4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

