### PR TITLE
docs(ops): friend-mesh Docker Compose prefab for shared Nexo.API hub

### DIFF
--- a/.github/workflows/friend-mesh-prefab-gate.yml
+++ b/.github/workflows/friend-mesh-prefab-gate.yml
@@ -1,0 +1,119 @@
+name: Friend mesh prefab gate
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - "cursor/**"
+    paths:
+      - ".github/workflows/friend-mesh-prefab-gate.yml"
+      - "docker-compose.friend-mesh.yml"
+      - ".docker/Dockerfile.api"
+      - "docs/config/friend-mesh.env.example"
+      - "docs/FriendMeshPrefab.md"
+      - "src/Nexo.API/**"
+  pull_request:
+    paths:
+      - ".github/workflows/friend-mesh-prefab-gate.yml"
+      - "docker-compose.friend-mesh.yml"
+      - ".docker/Dockerfile.api"
+      - "docs/config/friend-mesh.env.example"
+      - "docs/FriendMeshPrefab.md"
+      - "src/Nexo.API/**"
+  workflow_dispatch:
+
+jobs:
+  friend-mesh-smoke:
+    name: Friend mesh Compose build + auth smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      COMPOSE_PROJECT_NAME: nexo_friend_mesh_ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify Docker and Compose
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker --version
+          docker compose version
+
+      - name: Write CI env file for friend-mesh stack
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEY="ci-friend-mesh-${GITHUB_RUN_ID}-${GITHUB_SHA}"
+          KEY="${KEY:0:64}"
+          {
+            echo "NEXO_FRIEND_MESH_PORT_PUBLISH=127.0.0.1:18080"
+            echo "Nexo__Security__ExposureProfile=Tailnet"
+            echo "Nexo__Security__AuthorizationMode=ApiKey"
+            echo "Nexo__Security__AuthorizationScope=MutatingApi"
+            echo "Nexo__Security__ApiKey=${KEY}"
+            echo "Nexo__Security__ApiKeyHeaderName=X-Nexo-Api-Key"
+            echo "Nexo__Security__CustomAdvisory=CI friend-mesh gate"
+            echo "Nexo__Security__ShowAdvisoryInPortal=true"
+          } > .env.friend-mesh.ci
+          echo "FRIEND_MESH_CI_API_KEY=${KEY}" >> "$GITHUB_ENV"
+
+      - name: Validate compose file
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh.ci config -q
+
+      - name: Build and start friend-mesh stack
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh.ci up -d --build
+
+      - name: Wait for health endpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 60); do
+            if curl -fsS "http://127.0.0.1:18080/health" >/dev/null; then
+              echo "health ok after ${i} attempts"
+              exit 0
+            fi
+            echo "waiting for health ($i/60)..."
+            sleep 5
+          done
+          echo "::error::Nexo.API did not become healthy in time"
+          docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh.ci logs
+          exit 1
+
+      - name: Mutating request without API key is rejected
+        shell: bash
+        run: |
+          set -euo pipefail
+          code=$(curl -sS -o /tmp/body.txt -w "%{http_code}" \
+            -X POST "http://127.0.0.1:18080/api/preferences" \
+            -H "Content-Type: application/json" \
+            -d '{"displayName":"ci","theme":"dark","defaultFocus":null,"preferredProvider":null}')
+          echo "HTTP ${code}"; cat /tmp/body.txt
+          test "${code}" = "401"
+
+      - name: Mutating request with API key succeeds
+        shell: bash
+        run: |
+          set -euo pipefail
+          code=$(curl -sS -o /tmp/body2.txt -w "%{http_code}" \
+            -X POST "http://127.0.0.1:18080/api/preferences" \
+            -H "Content-Type: application/json" \
+            -H "X-Nexo-Api-Key: ${FRIEND_MESH_CI_API_KEY}" \
+            -d '{"displayName":"ci-gate","theme":"dark","defaultFocus":null,"preferredProvider":null}')
+          echo "HTTP ${code}"; cat /tmp/body2.txt
+          test "${code}" = "200"
+
+      - name: Stop friend-mesh stack
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh.ci down -v || true
+          rm -f .env.friend-mesh.ci

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ backup/
 **/obj/
 /test-reports/
 appsettings.local.json
+.env.friend-mesh
 
 /NEXO_AGENT_NOTES.md
 

--- a/docker-compose.friend-mesh.yml
+++ b/docker-compose.friend-mesh.yml
@@ -1,0 +1,35 @@
+# Prefab: small shared Nexo.API for two (or a few) people over Tailscale / VPN / TLS reverse proxy.
+#
+# Security model:
+#   - Nexo.API listens on HTTP inside the container; you terminate TLS at a reverse proxy OR bind only on Tailscale/LAN.
+#   - Set strong Nexo__Security__* secrets via docs/config/friend-mesh.env.example (copy to .env.friend-mesh).
+#
+# From repo root:
+#   cp docs/config/friend-mesh.env.example .env.friend-mesh
+#   # edit .env.friend-mesh — replace CHANGE_ME_* placeholders
+#   docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh up -d --build
+#
+# Default publish: 127.0.0.1:8080 (loopback). For Tailscale on the same host, bind Tailscale to the host and
+# keep loopback, or set NEXO_FRIEND_MESH_PORT_PUBLISH to your tailnet bind pattern (see docs/FriendMeshPrefab.md).
+
+services:
+  nexo-api:
+    build:
+      context: ${NEXO_BUILD_CONTEXT:-.}
+      dockerfile: ${NEXO_FRIEND_MESH_DOCKERFILE:-.docker/Dockerfile.api}
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      ASPNETCORE_CONTENTROOT: /app
+      Nexo__Security__ExposureProfile: ${Nexo__Security__ExposureProfile:-Tailnet}
+      Nexo__Security__AuthorizationMode: ${Nexo__Security__AuthorizationMode:-ApiKey}
+      Nexo__Security__AuthorizationScope: ${Nexo__Security__AuthorizationScope:-MutatingApi}
+      Nexo__Security__ApiKey: ${Nexo__Security__ApiKey}
+      Nexo__Security__ApiKeyHeaderName: ${Nexo__Security__ApiKeyHeaderName:-X-Nexo-Api-Key}
+      Nexo__Security__CustomAdvisory: ${Nexo__Security__CustomAdvisory:-Friend mesh: share secrets only out-of-band; use TLS or Tailscale.}
+      Nexo__Security__ShowAdvisoryInPortal: ${Nexo__Security__ShowAdvisoryInPortal:-true}
+      # Optional: when mesh HTTP hardening is enabled in your Nexo build, set these to the same or distinct secrets.
+      Nexo__Security__Mesh__MeshMutatingToken: ${Nexo__Security__Mesh__MeshMutatingToken:-}
+      Nexo__Security__Mesh__BrickExecuteToken: ${Nexo__Security__Mesh__BrickExecuteToken:-}
+    ports:
+      - "${NEXO_FRIEND_MESH_PORT_PUBLISH:-127.0.0.1:8080}:8080"
+    restart: unless-stopped

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -48,6 +48,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 
 ## Security / Trust
 
+- `docs/FriendMeshPrefab.md` — prefab Docker Compose + env template for a small shared **Nexo.API** hub (friends / tailnet).
 - `docs/TrustAndInformationArchitecture.md` — sanitization, audit, access boundaries.
 - `docs/TailscaleAndNexo.md` — Tailscale + Nexo exposure profile, ACL guidance, advisory endpoint.
 - `docs/config/security-exposure.env.example` — `Nexo__Security__*` env template for operators.

--- a/docs/FriendMeshPrefab.md
+++ b/docs/FriendMeshPrefab.md
@@ -45,8 +45,13 @@ If your Nexo build exposes **`/api/mesh/*`**, each friend can run a worker and r
 - **In-memory mesh state** (when enabled) lives in the director process; restarting the container clears fleet/task registries unless you add persistence later.
 - **`Nexo.API` feature set** depends on your branch; this prefab only configures **security posture** for the shipped API.
 
+## CI regression gate
+
+GitHub Actions workflow **`.github/workflows/friend-mesh-prefab-gate.yml`** validates **`docker compose … config`**, builds the stack, waits for **`GET /health`**, and checks that **`POST /api/preferences`** returns **401** without **`X-Nexo-Api-Key`** and **200** with the configured key.
+
 ## Revision history
 
 | Date | Change |
 |------|--------|
 | 2026-04-23 | Initial friend-mesh compose + env example + runbook. |
+| 2026-04-23 | Add friend-mesh-prefab GitHub Actions gate. |

--- a/docs/FriendMeshPrefab.md
+++ b/docs/FriendMeshPrefab.md
@@ -1,0 +1,52 @@
+# Friend mesh prefab (Docker Compose)
+
+This is a **small, opinionated** way to run **Nexo.API** so you and a friend can share a **single hub** over a **private path** (Tailscale, WireGuard, or a TLS reverse proxy). It is **not** a substitute for network access control: you still choose who can reach the TCP port.
+
+## What you get
+
+- **`docker-compose.friend-mesh.yml`** — builds **`Nexo.API`** from **`.docker/Dockerfile.api`** and enables **API key auth** for mutating `/api/*` routes by default.
+- **`docs/config/friend-mesh.env.example`** — copy to **`.env.friend-mesh`** (gitignored), fill in secrets, pass to Compose.
+
+## Quick start
+
+```bash
+cd /path/to/Nexo
+cp docs/config/friend-mesh.env.example .env.friend-mesh
+# Edit .env.friend-mesh: set Nexo__Security__ApiKey (and optional mesh tokens if your build supports them).
+
+docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh up -d --build
+```
+
+Health check: `curl -sS http://127.0.0.1:8080/health` (or your published host/port).
+
+Mutating API example (replace key):
+
+```bash
+curl -sS -H "X-Nexo-Api-Key: YOUR_KEY" -H "Content-Type: application/json" \
+  -d '{"task":"ping"}' \
+  http://127.0.0.1:8080/api/copilot/task
+```
+
+## Recommended connectivity (in order of preference)
+
+1. **Tailscale** — both of you on the same tailnet; ACLs limit who hits port 8080. See **`docs/TailscaleAndNexo.md`**.
+2. **WireGuard** — same idea, manual peers.
+3. **Public internet** — only with **TLS** (Caddy, nginx, Traefik, cloud LB) in front of Nexo; never expose plain HTTP to `0.0.0.0` on the raw internet.
+
+Default **`NEXO_FRIEND_MESH_PORT_PUBLISH`** is **`127.0.0.1:8080`** so the container is not wide open until you change it on purpose.
+
+## Workers and mesh director
+
+If your Nexo build exposes **`/api/mesh/*`**, each friend can run a worker and register with the hub using the same auth headers your deployment expects. From a headless machine, **`nexo mesh director`** can call the hub when **`NEXO_MESH_*`** env vars are set — see **`docs/MeshPhase7EdgeAlignment.md`** (if present on your branch).
+
+## Limitations
+
+- **TLS is not inside this compose file** — terminate TLS at a proxy or use a VPN that already encrypts transport.
+- **In-memory mesh state** (when enabled) lives in the director process; restarting the container clears fleet/task registries unless you add persistence later.
+- **`Nexo.API` feature set** depends on your branch; this prefab only configures **security posture** for the shipped API.
+
+## Revision history
+
+| Date | Change |
+|------|--------|
+| 2026-04-23 | Initial friend-mesh compose + env example + runbook. |

--- a/docs/IntegratorGuide.md
+++ b/docs/IntegratorGuide.md
@@ -49,7 +49,7 @@ To run a custom set locally:
 dotnet run --project src/Nexo.CLI -- background-agent daemon --config path/to/your/agent_set.json
 ```
 
-Match sensitivity and exfiltration settings to your deployment tier. For mesh-related peer lists used at runtime, see `nexo mesh` commands and `NEXO_MESH_INSTANCES_PATH` if you relocate `instances.json`.
+Match sensitivity and exfiltration settings to your deployment tier. For mesh-related peer lists used at runtime, see `nexo mesh` commands and `NEXO_MESH_INSTANCES_PATH` if you relocate `instances.json`. To call a remote mesh **director** HTTP API from a headless host (CI, bare metal worker), use **`nexo mesh director`** with **`NEXO_MESH_DIRECTOR_BASE_URL`** and optional **`NEXO_MESH_MUTATING_TOKEN`** / **`NEXO_MESH_API_KEY`** — see **`docs/MeshPhase7EdgeAlignment.md`** when that doc exists on your branch. For a **prefab two-person hub** (Compose + API key defaults), see **`docs/FriendMeshPrefab.md`** and **`docker-compose.friend-mesh.yml`**.
 
 ## Compatibility matrix (placeholder)
 

--- a/docs/config/friend-mesh.env.example
+++ b/docs/config/friend-mesh.env.example
@@ -1,0 +1,26 @@
+# Copy to repo root as `.env.friend-mesh` (gitignored) and pass to Compose:
+#   docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh up -d --build
+#
+# Replace every CHANGE_ME value. Share the API key and mesh tokens only via a private channel.
+
+# --- Optional: override image build ---
+# NEXO_BUILD_CONTEXT=.
+# NEXO_FRIEND_MESH_DOCKERFILE=.docker/Dockerfile.api
+
+# --- Host publish (default: loopback only) ---
+# Loopback (safest default — use SSH tunnel or reverse proxy):
+NEXO_FRIEND_MESH_PORT_PUBLISH=127.0.0.1:8080
+# LAN example (only on trusted networks):
+# NEXO_FRIEND_MESH_PORT_PUBLISH=0.0.0.0:8080
+
+# --- Nexo.API security (required for friend mesh) ---
+Nexo__Security__ExposureProfile=Tailnet
+Nexo__Security__AuthorizationMode=ApiKey
+Nexo__Security__AuthorizationScope=MutatingApi
+Nexo__Security__ApiKey=CHANGE_ME_LONG_RANDOM_API_KEY
+Nexo__Security__ApiKeyHeaderName=X-Nexo-Api-Key
+Nexo__Security__CustomAdvisory=Friend mesh — TLS or Tailscale in front; rotate keys if leaked.
+
+# When your Nexo build includes mesh HTTP hardening (Nexo:Security:Mesh), set these so peers can call /api/mesh:
+# Nexo__Security__Mesh__MeshMutatingToken=CHANGE_ME_MESH_MUTATING
+# Nexo__Security__Mesh__BrickExecuteToken=CHANGE_ME_BRICK_EXECUTE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **prefab** for running a small shared **Nexo.API** instance that two or more people can use over **Tailscale, VPN, or a TLS reverse proxy**, with **API key auth** enabled by default for mutating `/api/*` routes.

Adds a **GitHub Actions regression gate** so the prefab and API auth wiring do not silently break.

## Changes

- **`docker-compose.friend-mesh.yml`** — builds from **`.docker/Dockerfile.api`**, wires **`Nexo__Security__*`** from env, optional **`Nexo__Security__Mesh__*`** placeholders when a build supports mesh HTTP hardening.
- **`docs/config/friend-mesh.env.example`** — copy to **`.env.friend-mesh`** (gitignored), pass to Compose.
- **`docs/FriendMeshPrefab.md`** — quick start, connectivity guidance, limitations, **CI gate** section.
- **`.gitignore`** — ignore **`.env.friend-mesh`**.
- **`docs/DocsIndex.md`**, **`docs/IntegratorGuide.md`** — discoverability.
- **`.github/workflows/friend-mesh-prefab-gate.yml`** — on push/PR when relevant paths change: `compose config`, `up --build`, wait for **`GET /health`**, assert **`POST /api/preferences`** returns **401** without API key and **200** with **`X-Nexo-Api-Key`**.

## Testing

- CI: **Friend mesh prefab gate** workflow (see workflow file).
- Local optional: `docker compose -f docker-compose.friend-mesh.yml --env-file .env.friend-mesh config -q`

## Notes

- TLS is **not** embedded; use Tailscale/VPN or terminate TLS in front of the service.
- Default port publish is **loopback** until **`NEXO_FRIEND_MESH_PORT_PUBLISH`** is overridden.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88ee4d3f-c5b1-49cc-8033-90050c229f4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88ee4d3f-c5b1-49cc-8033-90050c229f4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

