### PR TITLE
Add pluggable model artifact catalog (Ollama + Docker)

### DIFF
--- a/src/Nexo.Core.Application/ModelArtifacts/ModelArtifactCatalogModels.cs
+++ b/src/Nexo.Core.Application/ModelArtifacts/ModelArtifactCatalogModels.cs
@@ -1,0 +1,18 @@
+namespace Nexo.Core.Application.ModelArtifacts;
+
+/// <summary>Kind of discoverable model-related artifact.</summary>
+public enum ModelArtifactKind
+{
+    OllamaModel,
+    DockerImage
+}
+
+/// <summary>
+/// One entry from a catalog source (e.g. Ollama <c>/api/tags</c> or a Docker-hosted Ollama).
+/// </summary>
+public sealed record ModelArtifactRecord(
+    string Id,
+    string SourceId,
+    ModelArtifactKind Kind,
+    long SizeHintBytes,
+    IReadOnlyDictionary<string, string>? Metadata = null);

--- a/src/Nexo.Core.Application/ModelArtifacts/ModelArtifactCatalogModels.cs
+++ b/src/Nexo.Core.Application/ModelArtifacts/ModelArtifactCatalogModels.cs
@@ -3,7 +3,12 @@ namespace Nexo.Core.Application.ModelArtifacts;
 /// <summary>Kind of discoverable model-related artifact.</summary>
 public enum ModelArtifactKind
 {
+    /// <summary>Installed Ollama model (local daemon or Docker-probed).</summary>
     OllamaModel,
+
+    /// <summary>Model published on the Ollama library (installable via <c>ollama pull</c>).</summary>
+    OllamaRemoteLibraryModel,
+
     DockerImage
 }
 

--- a/src/Nexo.Core.Application/ModelArtifacts/Ports/IModelArtifactCatalogService.cs
+++ b/src/Nexo.Core.Application/ModelArtifacts/Ports/IModelArtifactCatalogService.cs
@@ -1,0 +1,10 @@
+namespace Nexo.Core.Application.ModelArtifacts.Ports;
+
+/// <summary>
+/// Aggregates <see cref="IModelArtifactCatalogSource"/> implementations so callers
+/// can discover models without depending on Ollama vs Docker directly.
+/// </summary>
+public interface IModelArtifactCatalogService
+{
+    Task<IReadOnlyList<ModelArtifactRecord>> ListAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/ModelArtifacts/Ports/IModelArtifactCatalogService.cs
+++ b/src/Nexo.Core.Application/ModelArtifacts/Ports/IModelArtifactCatalogService.cs
@@ -6,5 +6,14 @@ namespace Nexo.Core.Application.ModelArtifacts.Ports;
 /// </summary>
 public interface IModelArtifactCatalogService
 {
+    /// <summary>
+    /// Locally installed or discoverable artifacts (e.g. Ollama <c>/api/tags</c> on this host, Docker Ollama).
+    /// Does not include remote library listings.
+    /// </summary>
     Task<IReadOnlyList<ModelArtifactRecord>> ListAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Models published for install (e.g. Ollama library at ollama.com). Requires network access.
+    /// </summary>
+    Task<IReadOnlyList<ModelArtifactRecord>> ListInstallableAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Nexo.Core.Application/ModelArtifacts/Ports/IModelArtifactCatalogSource.cs
+++ b/src/Nexo.Core.Application/ModelArtifacts/Ports/IModelArtifactCatalogSource.cs
@@ -1,0 +1,15 @@
+namespace Nexo.Core.Application.ModelArtifacts.Ports;
+
+/// <summary>
+/// Optional dependency that lists model artifacts from a concrete backend
+/// (Ollama HTTP API, Docker engine, etc.).
+/// </summary>
+public interface IModelArtifactCatalogSource
+{
+    /// <summary>Stable id for filtering and diagnostics (e.g. <c>ollama-tags</c>).</summary>
+    string SourceId { get; }
+
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ModelArtifactRecord>> ListAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/ModelArtifacts/Ports/IRemoteInstallableModelArtifactSource.cs
+++ b/src/Nexo.Core.Application/ModelArtifacts/Ports/IRemoteInstallableModelArtifactSource.cs
@@ -1,0 +1,9 @@
+namespace Nexo.Core.Application.ModelArtifacts.Ports;
+
+/// <summary>
+/// Marker for catalog sources that query a remote registry of installable models
+/// (as opposed to locally installed artifacts). Excluded from <see cref="IModelArtifactCatalogService.ListAllAsync"/>.
+/// </summary>
+public interface IRemoteInstallableModelArtifactSource : IModelArtifactCatalogSource
+{
+}

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ using Nexo.Infrastructure.Execution.LoadPolicy;
 using Nexo.Infrastructure.Knowledge;
 using Nexo.Infrastructure.Maintenance;
 using Nexo.Infrastructure.NodeCapabilityRuntime;
+using Nexo.Infrastructure.ModelArtifacts;
 using Nexo.Infrastructure.Pipelines;
 using Nexo.Infrastructure.Persistence.Ephemeral;
 using Nexo.Infrastructure.Persistence;
@@ -574,6 +575,12 @@ public static class NexoServiceCollectionExtensions
             services.AddNodeCapabilityRuntimeAndroid(configuration);
         else
             services.AddNodeCapabilityRuntimeLinux(configuration);
+
+        services.AddModelArtifactCatalog(configuration);
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            services.AddDockerOllamaModelArtifactCatalogSource();
+        }
     }
 
     /// <summary>

--- a/src/Nexo.Infrastructure/ModelArtifacts/DockerEngineUriResolver.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/DockerEngineUriResolver.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+internal static class DockerEngineUriResolver
+{
+    public static Uri Resolve()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return new Uri("npipe://./pipe/docker_engine");
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return new Uri("unix:///var/run/docker.sock");
+        }
+
+        throw new PlatformNotSupportedException("Docker engine URI is not defined for this platform.");
+    }
+}

--- a/src/Nexo.Infrastructure/ModelArtifacts/DockerOllamaModelArtifactCatalogOptions.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/DockerOllamaModelArtifactCatalogOptions.cs
@@ -1,0 +1,16 @@
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+/// <summary>Options for discovering Ollama models inside Docker-hosted Ollama containers.</summary>
+public sealed class DockerOllamaModelArtifactCatalogOptions
+{
+    public const string SectionName = "Nexo:ModelArtifactCatalog:DockerOllama";
+
+    /// <summary>When false, <see cref="DockerOllamaModelArtifactCatalogSource"/> returns no entries.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Match <see cref="Docker.DotNet.Models.ContainerListResponse.Image"/> prefix (e.g. <c>ollama/ollama</c>).</summary>
+    public string OllamaImagePrefix { get; set; } = "ollama/ollama";
+
+    /// <summary>Container port that exposes the Ollama HTTP API.</summary>
+    public int OllamaContainerPort { get; set; } = 11434;
+}

--- a/src/Nexo.Infrastructure/ModelArtifacts/DockerOllamaModelArtifactCatalogSource.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/DockerOllamaModelArtifactCatalogSource.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.ModelArtifacts;
+using Nexo.Core.Application.ModelArtifacts.Ports;
+using Nexo.Infrastructure.Execution.Ollama;
+
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+/// <summary>
+/// Lists Ollama models by probing running Ollama Docker containers on the local engine
+/// (<c>GET http://127.0.0.1:&lt;mapped-port&gt;/api/tags</c> per container).
+/// </summary>
+public sealed class DockerOllamaModelArtifactCatalogSource : IModelArtifactCatalogSource, IDisposable
+{
+    public const string HttpClientName = "Nexo.ModelArtifactCatalog.DockerOllamaProbe";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly DockerClient _dockerClient;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<DockerOllamaModelArtifactCatalogOptions> _options;
+    private readonly ILogger<DockerOllamaModelArtifactCatalogSource> _logger;
+    private readonly bool _disposeDockerClient;
+
+    public DockerOllamaModelArtifactCatalogSource(
+        IHttpClientFactory httpClientFactory,
+        IOptions<DockerOllamaModelArtifactCatalogOptions> options,
+        ILogger<DockerOllamaModelArtifactCatalogSource> logger,
+        DockerClient? dockerClient = null)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        if (dockerClient != null)
+        {
+            _dockerClient = dockerClient;
+            _disposeDockerClient = false;
+        }
+        else
+        {
+            _dockerClient = new DockerClientConfiguration(DockerEngineUriResolver.Resolve()).CreateClient();
+            _disposeDockerClient = true;
+        }
+    }
+
+    public string SourceId => "docker-ollama-tags";
+
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.Value.Enabled)
+        {
+            return false;
+        }
+
+        try
+        {
+            await _dockerClient.System.PingAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Docker engine not reachable for model artifact catalog");
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<ModelArtifactRecord>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.Value.Enabled)
+        {
+            return [];
+        }
+
+        try
+        {
+            await _dockerClient.System.PingAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Skipping Docker Ollama catalog: engine unavailable");
+            return [];
+        }
+
+        var prefix = _options.Value.OllamaImagePrefix ?? string.Empty;
+        if (prefix.Length == 0)
+        {
+            return [];
+        }
+
+        var privatePort = _options.Value.OllamaContainerPort;
+        var containers = await _dockerClient.Containers.ListContainersAsync(
+                new ContainersListParameters { All = true },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var http = _httpClientFactory.CreateClient(HttpClientName);
+        var merged = new Dictionary<string, ModelArtifactRecord>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var c in containers)
+        {
+            if (string.IsNullOrEmpty(c.Image) ||
+                !c.Image.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var hostPort = ResolveHostPort(c.Ports, privatePort);
+            if (hostPort is null or <= 0)
+            {
+                continue;
+            }
+
+            var url = $"http://127.0.0.1:{hostPort.Value}/api/tags";
+            try
+            {
+                using var response = await http.GetAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    continue;
+                }
+
+                OllamaTagsResponse? body;
+                await using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    body = await JsonSerializer.DeserializeAsync<OllamaTagsResponse>(stream, JsonOptions, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                if (body?.Models is null)
+                {
+                    continue;
+                }
+
+                foreach (var m in body.Models)
+                {
+                    if (string.IsNullOrWhiteSpace(m.Name))
+                    {
+                        continue;
+                    }
+
+                    var id = m.Name.Trim();
+                    var meta = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["docker_container_id"] = c.ID ?? string.Empty,
+                        ["docker_image"] = c.Image,
+                        ["host_port"] = hostPort.Value.ToString(),
+                        ["modified_at"] = m.ModifiedAt?.ToString("O") ?? string.Empty
+                    };
+
+                    if (!merged.TryGetValue(id, out var existing) || existing.SizeHintBytes < m.Size)
+                    {
+                        merged[id] = new ModelArtifactRecord(
+                            id,
+                            SourceId,
+                            ModelArtifactKind.OllamaModel,
+                            m.Size,
+                            meta);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to read Ollama tags from Docker container {ContainerId} at {Url}", c.ID, url);
+            }
+        }
+
+        return merged.Values.OrderBy(r => r.Id, StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static int? ResolveHostPort(IList<Port>? ports, int privatePort)
+    {
+        if (ports is null || ports.Count == 0)
+        {
+            return null;
+        }
+
+        foreach (var p in ports)
+        {
+            if (p.PrivatePort == privatePort && p.PublicPort > 0)
+            {
+                return p.PublicPort;
+            }
+        }
+
+        return null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposeDockerClient)
+        {
+            _dockerClient.Dispose();
+        }
+    }
+}

--- a/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogService.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogService.cs
@@ -21,11 +21,24 @@ public sealed class ModelArtifactCatalogService : IModelArtifactCatalogService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<IReadOnlyList<ModelArtifactRecord>> ListAllAsync(CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<ModelArtifactRecord>> ListAllAsync(CancellationToken cancellationToken = default) =>
+        ListFromSourcesAsync(static s => s is not IRemoteInstallableModelArtifactSource, cancellationToken);
+
+    public Task<IReadOnlyList<ModelArtifactRecord>> ListInstallableAsync(CancellationToken cancellationToken = default) =>
+        ListFromSourcesAsync(static s => s is IRemoteInstallableModelArtifactSource, cancellationToken);
+
+    private async Task<IReadOnlyList<ModelArtifactRecord>> ListFromSourcesAsync(
+        Func<IModelArtifactCatalogSource, bool> predicate,
+        CancellationToken cancellationToken)
     {
         var list = new List<ModelArtifactRecord>();
         foreach (var source in _sources)
         {
+            if (!predicate(source))
+            {
+                continue;
+            }
+
             try
             {
                 if (!await source.IsAvailableAsync(cancellationToken).ConfigureAwait(false))

--- a/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogService.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogService.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.ModelArtifacts;
+using Nexo.Core.Application.ModelArtifacts.Ports;
+
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+/// <summary>
+/// Merges all registered <see cref="IModelArtifactCatalogSource"/> implementations.
+/// Sources that are unavailable or throw are skipped.
+/// </summary>
+public sealed class ModelArtifactCatalogService : IModelArtifactCatalogService
+{
+    private readonly IEnumerable<IModelArtifactCatalogSource> _sources;
+    private readonly ILogger<ModelArtifactCatalogService> _logger;
+
+    public ModelArtifactCatalogService(
+        IEnumerable<IModelArtifactCatalogSource> sources,
+        ILogger<ModelArtifactCatalogService> logger)
+    {
+        _sources = sources ?? throw new ArgumentNullException(nameof(sources));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<ModelArtifactRecord>> ListAllAsync(CancellationToken cancellationToken = default)
+    {
+        var list = new List<ModelArtifactRecord>();
+        foreach (var source in _sources)
+        {
+            try
+            {
+                if (!await source.IsAvailableAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    continue;
+                }
+
+                var chunk = await source.ListAsync(cancellationToken).ConfigureAwait(false);
+                if (chunk.Count > 0)
+                {
+                    list.AddRange(chunk);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Model artifact catalog source {SourceId} failed; continuing with other sources", source.SourceId);
+            }
+        }
+
+        return list;
+    }
+}

--- a/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.ModelArtifacts.Ports;
+using Nexo.Infrastructure.NodeCapabilityRuntime.Backends;
+
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+public static class ModelArtifactCatalogServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IModelArtifactCatalogService"/> and the default Ollama <c>/api/tags</c> source.
+    /// Call <see cref="AddDockerOllamaModelArtifactCatalogSource"/> from desktop host registrations when Docker discovery is desired.
+    /// </summary>
+    public static IServiceCollection AddModelArtifactCatalog(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+        services.AddOptions<OllamaBackendOptions>()
+            .Bind(configuration.GetSection(OllamaBackendOptions.SectionName));
+        services.AddOptions<DockerOllamaModelArtifactCatalogOptions>()
+            .Bind(configuration.GetSection(DockerOllamaModelArtifactCatalogOptions.SectionName));
+
+        services.AddHttpClient(OllamaTagsModelArtifactCatalogSource.HttpClientName, (sp, client) =>
+        {
+            var ollama = sp.GetRequiredService<IOptions<OllamaBackendOptions>>().Value;
+            client.BaseAddress = new Uri(ollama.BaseUrl.TrimEnd('/') + "/", UriKind.Absolute);
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
+
+        services.AddHttpClient(DockerOllamaModelArtifactCatalogSource.HttpClientName, client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(12);
+        });
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IModelArtifactCatalogSource, OllamaTagsModelArtifactCatalogSource>());
+        services.TryAddSingleton<IModelArtifactCatalogService, ModelArtifactCatalogService>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds Docker engine probing for Ollama containers (same HTTP <c>/api/tags</c> per published port).
+    /// </summary>
+    public static IServiceCollection AddDockerOllamaModelArtifactCatalogSource(this IServiceCollection services)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IModelArtifactCatalogSource, DockerOllamaModelArtifactCatalogSource>());
+        return services;
+    }
+}

--- a/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/ModelArtifactCatalogServiceCollectionExtensions.cs
@@ -24,6 +24,8 @@ public static class ModelArtifactCatalogServiceCollectionExtensions
             .Bind(configuration.GetSection(OllamaBackendOptions.SectionName));
         services.AddOptions<DockerOllamaModelArtifactCatalogOptions>()
             .Bind(configuration.GetSection(DockerOllamaModelArtifactCatalogOptions.SectionName));
+        services.AddOptions<OllamaRemoteLibraryCatalogOptions>()
+            .Bind(configuration.GetSection(OllamaRemoteLibraryCatalogOptions.SectionName));
 
         services.AddHttpClient(OllamaTagsModelArtifactCatalogSource.HttpClientName, (sp, client) =>
         {
@@ -37,7 +39,16 @@ public static class ModelArtifactCatalogServiceCollectionExtensions
             client.Timeout = TimeSpan.FromSeconds(12);
         });
 
+        services.AddHttpClient(OllamaRemoteLibraryModelArtifactCatalogSource.HttpClientName, (sp, client) =>
+        {
+            var opts = sp.GetRequiredService<IOptionsMonitor<OllamaRemoteLibraryCatalogOptions>>().CurrentValue;
+            var baseUrl = string.IsNullOrWhiteSpace(opts.BaseUrl) ? "https://ollama.com" : opts.BaseUrl.Trim();
+            client.BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/", UriKind.Absolute);
+            client.Timeout = opts.RequestTimeout <= TimeSpan.Zero ? TimeSpan.FromSeconds(60) : opts.RequestTimeout;
+        });
+
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IModelArtifactCatalogSource, OllamaTagsModelArtifactCatalogSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IModelArtifactCatalogSource, OllamaRemoteLibraryModelArtifactCatalogSource>());
         services.TryAddSingleton<IModelArtifactCatalogService, ModelArtifactCatalogService>();
         return services;
     }

--- a/src/Nexo.Infrastructure/ModelArtifacts/OllamaRemoteLibraryCatalogOptions.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/OllamaRemoteLibraryCatalogOptions.cs
@@ -1,0 +1,18 @@
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+/// <summary>Options for fetching installable models from the public Ollama library API.</summary>
+public sealed class OllamaRemoteLibraryCatalogOptions
+{
+    public const string SectionName = "Nexo:ModelArtifactCatalog:OllamaRemoteLibrary";
+
+    /// <summary>
+    /// When false, <see cref="OllamaRemoteLibraryModelArtifactCatalogSource"/> reports unavailable (no outbound call).
+    /// Default is true so <c>ListInstallableAsync</c> works out of the box; set false on air-gapped hosts.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>HTTPS origin for the library <c>/api/tags</c> listing (default ollama.com).</summary>
+    public string BaseUrl { get; set; } = "https://ollama.com";
+
+    public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(60);
+}

--- a/src/Nexo.Infrastructure/ModelArtifacts/OllamaRemoteLibraryModelArtifactCatalogSource.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/OllamaRemoteLibraryModelArtifactCatalogSource.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.ModelArtifacts;
+using Nexo.Core.Application.ModelArtifacts.Ports;
+
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+/// <summary>
+/// Lists models published on <see href="https://ollama.com">ollama.com</see> for install via
+/// <c>ollama pull</c>, using the public <c>GET /api/tags</c> document (same shape as the local daemon).
+/// </summary>
+public sealed class OllamaRemoteLibraryModelArtifactCatalogSource : IRemoteInstallableModelArtifactSource
+{
+    public const string HttpClientName = "Nexo.ModelArtifactCatalog.OllamaRemoteLibrary";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<OllamaRemoteLibraryCatalogOptions> _options;
+
+    public OllamaRemoteLibraryModelArtifactCatalogSource(
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<OllamaRemoteLibraryCatalogOptions> options)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public string SourceId => "ollama-remote-library";
+
+    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(_options.CurrentValue.Enabled);
+
+    public async Task<IReadOnlyList<ModelArtifactRecord>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.CurrentValue.Enabled)
+        {
+            return [];
+        }
+
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        using var response = await client.GetAsync("api/tags", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        RemoteWireResponse? body;
+        await using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+        {
+            body = await JsonSerializer.DeserializeAsync<RemoteWireResponse>(stream, JsonOptions, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (body?.Models is null || body.Models.Count == 0)
+        {
+            return [];
+        }
+
+        var list = new List<ModelArtifactRecord>(body.Models.Count);
+        foreach (var m in body.Models)
+        {
+            if (string.IsNullOrWhiteSpace(m.Name))
+            {
+                continue;
+            }
+
+            var id = m.Name.Trim();
+            var meta = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["modified_at"] = m.ModifiedAt?.ToString("O") ?? string.Empty
+            };
+            if (!string.IsNullOrWhiteSpace(m.Digest))
+            {
+                meta["digest"] = m.Digest.Trim();
+            }
+
+            list.Add(new ModelArtifactRecord(
+                id,
+                SourceId,
+                ModelArtifactKind.OllamaRemoteLibraryModel,
+                m.Size,
+                meta));
+        }
+
+        return list;
+    }
+
+    private sealed class RemoteWireResponse
+    {
+        [JsonPropertyName("models")]
+        public List<RemoteWireModel> Models { get; init; } = [];
+    }
+
+    private sealed class RemoteWireModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("size")]
+        public long Size { get; init; }
+
+        [JsonPropertyName("modified_at")]
+        public DateTimeOffset? ModifiedAt { get; init; }
+
+        [JsonPropertyName("digest")]
+        public string? Digest { get; init; }
+    }
+}

--- a/src/Nexo.Infrastructure/ModelArtifacts/OllamaTagsModelArtifactCatalogSource.cs
+++ b/src/Nexo.Infrastructure/ModelArtifacts/OllamaTagsModelArtifactCatalogSource.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using Microsoft.Extensions.Http;
+using Nexo.Core.Application.ModelArtifacts;
+using Nexo.Core.Application.ModelArtifacts.Ports;
+using Nexo.Infrastructure.Execution.Ollama;
+
+namespace Nexo.Infrastructure.ModelArtifacts;
+
+/// <summary>
+/// Lists Ollama models installed on the daemon via <c>GET /api/tags</c> (same as <c>ollama list</c>).
+/// </summary>
+public sealed class OllamaTagsModelArtifactCatalogSource : IModelArtifactCatalogSource
+{
+    public const string HttpClientName = "Nexo.ModelArtifactCatalog.OllamaTags";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public OllamaTagsModelArtifactCatalogSource(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    }
+
+    public string SourceId => "ollama-tags";
+
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var response = await client.GetAsync("api/tags", cancellationToken).ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<ModelArtifactRecord>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        using var response = await client.GetAsync("api/tags", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        OllamaTagsResponse? body;
+        await using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+        {
+            body = await JsonSerializer.DeserializeAsync<OllamaTagsResponse>(stream, JsonOptions, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (body?.Models is null || body.Models.Count == 0)
+        {
+            return [];
+        }
+
+        var list = new List<ModelArtifactRecord>(body.Models.Count);
+        foreach (var m in body.Models)
+        {
+            if (string.IsNullOrWhiteSpace(m.Name))
+            {
+                continue;
+            }
+
+            list.Add(new ModelArtifactRecord(
+                Id: m.Name.Trim(),
+                SourceId: SourceId,
+                Kind: ModelArtifactKind.OllamaModel,
+                SizeHintBytes: m.Size,
+                Metadata: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["modified_at"] = m.ModifiedAt?.ToString("O") ?? string.Empty
+                }));
+        }
+
+        return list;
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/ModelArtifactCatalogServiceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/ModelArtifactCatalogServiceTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.Core.Application.ModelArtifacts;
+using Nexo.Core.Application.ModelArtifacts.Ports;
+using Nexo.Infrastructure.ModelArtifacts;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.ModelArtifacts;
+
+public sealed class ModelArtifactCatalogServiceTests
+{
+    [Fact]
+    public async Task ListAllAsync_MergesAllAvailableSources()
+    {
+        var a = new StubSource("a", true, [new ModelArtifactRecord("m1", "a", ModelArtifactKind.OllamaModel, 1)]);
+        var b = new StubSource("b", false, [new ModelArtifactRecord("m2", "b", ModelArtifactKind.OllamaModel, 2)]);
+        var c = new StubSource("c", true, [new ModelArtifactRecord("m3", "c", ModelArtifactKind.OllamaModel, 3)]);
+
+        var sut = new ModelArtifactCatalogService(
+            new IModelArtifactCatalogSource[] { a, b, c },
+            NullLogger<ModelArtifactCatalogService>.Instance);
+
+        var all = await sut.ListAllAsync();
+
+        all.Should().HaveCount(2);
+        all.Select(x => x.Id).Should().BeEquivalentTo("m1", "m3");
+    }
+
+    private sealed class StubSource : IModelArtifactCatalogSource
+    {
+        private readonly bool _available;
+        private readonly IReadOnlyList<ModelArtifactRecord> _items;
+
+        public StubSource(string sourceId, bool available, IReadOnlyList<ModelArtifactRecord> items)
+        {
+            SourceId = sourceId;
+            _available = available;
+            _items = items;
+        }
+
+        public string SourceId { get; }
+
+        public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(_available);
+
+        public Task<IReadOnlyList<ModelArtifactRecord>> ListAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(_items);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/ModelArtifactCatalogServiceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/ModelArtifactCatalogServiceTests.cs
@@ -10,6 +10,28 @@ namespace Nexo.Tests.Infrastructure.Tests.ModelArtifacts;
 public sealed class ModelArtifactCatalogServiceTests
 {
     [Fact]
+    public async Task ListAllAsync_ExcludesRemoteInstallableSources()
+    {
+        var local = new StubSource("local", true, [new ModelArtifactRecord("m1", "local", ModelArtifactKind.OllamaModel, 1)]);
+        var remote = new StubRemoteSource(
+            "remote",
+            true,
+            [new ModelArtifactRecord("big", "remote", ModelArtifactKind.OllamaRemoteLibraryModel, 999)]);
+
+        var sut = new ModelArtifactCatalogService(
+            new IModelArtifactCatalogSource[] { remote, local },
+            NullLogger<ModelArtifactCatalogService>.Instance);
+
+        var all = await sut.ListAllAsync();
+        all.Should().ContainSingle();
+        all[0].Id.Should().Be("m1");
+
+        var installable = await sut.ListInstallableAsync();
+        installable.Should().ContainSingle();
+        installable[0].Id.Should().Be("big");
+    }
+
+    [Fact]
     public async Task ListAllAsync_MergesAllAvailableSources()
     {
         var a = new StubSource("a", true, [new ModelArtifactRecord("m1", "a", ModelArtifactKind.OllamaModel, 1)]);
@@ -26,7 +48,15 @@ public sealed class ModelArtifactCatalogServiceTests
         all.Select(x => x.Id).Should().BeEquivalentTo("m1", "m3");
     }
 
-    private sealed class StubSource : IModelArtifactCatalogSource
+    private sealed class StubRemoteSource : StubSource, IRemoteInstallableModelArtifactSource
+    {
+        public StubRemoteSource(string sourceId, bool available, IReadOnlyList<ModelArtifactRecord> items)
+            : base(sourceId, available, items)
+        {
+        }
+    }
+
+    private class StubSource : IModelArtifactCatalogSource
     {
         private readonly bool _available;
         private readonly IReadOnlyList<ModelArtifactRecord> _items;

--- a/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/OllamaRemoteLibraryModelArtifactCatalogSourceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/OllamaRemoteLibraryModelArtifactCatalogSourceTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.ModelArtifacts;
+using Nexo.Infrastructure.ModelArtifacts;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.ModelArtifacts;
+
+public sealed class OllamaRemoteLibraryModelArtifactCatalogSourceTests
+{
+    [Fact]
+    public async Task ListAsync_ParsesRemoteTagsResponse()
+    {
+        var handler = new TagsJsonHandler(
+            """{"models":[{"name":"llama3.2:latest","size":2048,"modified_at":"2024-01-02T00:00:00Z","digest":"abc"}]}""");
+
+        var services = new ServiceCollection();
+        services.AddOptions<OllamaRemoteLibraryCatalogOptions>().Configure(o =>
+        {
+            o.Enabled = true;
+            o.BaseUrl = "https://example.test";
+        });
+        services.AddHttpClient(OllamaRemoteLibraryModelArtifactCatalogSource.HttpClientName)
+            .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://example.test/", UriKind.Absolute))
+            .ConfigurePrimaryHttpMessageHandler(() => handler);
+        await using var provider = services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        var options = provider.GetRequiredService<IOptionsMonitor<OllamaRemoteLibraryCatalogOptions>>();
+        var sut = new OllamaRemoteLibraryModelArtifactCatalogSource(factory, options);
+
+        (await sut.IsAvailableAsync()).Should().BeTrue();
+
+        var list = await sut.ListAsync();
+        list.Should().ContainSingle();
+        list[0].Id.Should().Be("llama3.2:latest");
+        list[0].Kind.Should().Be(ModelArtifactKind.OllamaRemoteLibraryModel);
+        list[0].SourceId.Should().Be("ollama-remote-library");
+        list[0].Metadata.Should().NotBeNull();
+        list[0].Metadata!["digest"].Should().Be("abc");
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenDisabled_ReturnsEmpty()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions<OllamaRemoteLibraryCatalogOptions>().Configure(o => o.Enabled = false);
+        services.AddHttpClient(OllamaRemoteLibraryModelArtifactCatalogSource.HttpClientName)
+            .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://example.test/", UriKind.Absolute))
+            .ConfigurePrimaryHttpMessageHandler(() => new TagsJsonHandler("""{"models":[]}"""));
+        await using var provider = services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        var options = provider.GetRequiredService<IOptionsMonitor<OllamaRemoteLibraryCatalogOptions>>();
+        var sut = new OllamaRemoteLibraryModelArtifactCatalogSource(factory, options);
+
+        (await sut.IsAvailableAsync()).Should().BeFalse();
+        (await sut.ListAsync()).Should().BeEmpty();
+    }
+
+    private sealed class TagsJsonHandler : HttpMessageHandler
+    {
+        private readonly string _json;
+
+        public TagsJsonHandler(string json) => _json = json;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri is null ||
+                !string.Equals(request.RequestUri.AbsolutePath.TrimEnd('/'), "/api/tags", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_json, System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/OllamaTagsModelArtifactCatalogSourceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/ModelArtifacts/OllamaTagsModelArtifactCatalogSourceTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Nexo.Infrastructure.ModelArtifacts;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.ModelArtifacts;
+
+public sealed class OllamaTagsModelArtifactCatalogSourceTests
+{
+    [Fact]
+    public async Task ListAsync_ParsesTagsResponse()
+    {
+        var handler = new TagsJsonHandler(
+            """{"models":[{"name":"phi3:mini","size":2048,"modified_at":"2024-01-02T00:00:00Z"}]}""");
+
+        await using var provider = new ServiceCollection()
+            .AddHttpClient(OllamaTagsModelArtifactCatalogSource.HttpClientName)
+            .ConfigureHttpClient(c => c.BaseAddress = new Uri("http://localhost/", UriKind.Absolute))
+            .ConfigurePrimaryHttpMessageHandler(() => handler)
+            .Services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        var sut = new OllamaTagsModelArtifactCatalogSource(factory);
+
+        (await sut.IsAvailableAsync()).Should().BeTrue();
+
+        var list = await sut.ListAsync();
+        list.Should().ContainSingle();
+        list[0].Id.Should().Be("phi3:mini");
+        list[0].SourceId.Should().Be("ollama-tags");
+        list[0].SizeHintBytes.Should().Be(2048);
+    }
+
+    private sealed class TagsJsonHandler : HttpMessageHandler
+    {
+        private readonly string _json;
+
+        public TagsJsonHandler(string json) => _json = json;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri is null ||
+                !string.Equals(request.RequestUri.AbsolutePath.TrimEnd('/'), "/api/tags", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_json, System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a pluggable **model artifact catalog** with:

- **Local installs** — `OllamaTagsModelArtifactCatalogSource` (`GET` local `/api/tags`), **Docker** Ollama containers (same API per published port).
- **Installable / remote library** — `OllamaRemoteLibraryModelArtifactCatalogSource` fetches **`https://ollama.com/api/tags`** (same JSON shape as the daemon). Entries use `ModelArtifactKind.OllamaRemoteLibraryModel`.

## API

- **`IModelArtifactCatalogService.ListAllAsync()`** — local / Docker-discovered only (excludes remote library).
- **`IModelArtifactCatalogService.ListInstallableAsync()`** — remote library only (sources implementing `IRemoteInstallableModelArtifactSource`).

## Configuration

- **`Nexo:ModelArtifactCatalog:OllamaRemoteLibrary:Enabled`** — default `true`; set `false` for air-gapped hosts.
- **`Nexo:ModelArtifactCatalog:OllamaRemoteLibrary:BaseUrl`** — default `https://ollama.com`.
- **`Nexo:ModelArtifactCatalog:OllamaRemoteLibrary:RequestTimeout`**

Existing Docker and Ollama local options unchanged (`Nexo:ModelArtifactCatalog:DockerOllama`, `Nexo:NodeCapabilityRuntime:Ollama`).

## Tests

Unit tests for aggregator split, Ollama tags source, remote library source (including disabled path).

Branch: `cursor/model-artifact-catalog-service-e0c8`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c74db3be-5f99-44c9-9fe0-1006cebee0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c74db3be-5f99-44c9-9fe0-1006cebee0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

