### PR TITLE
Add openai_compat provider for OpenAI-compatible HTTP backends

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -106,8 +106,21 @@ Pipeline options resolve in this order: defaults, config (`Nexo:Pipelines:*`), t
 |----------|-------------|---------|
 | `OPENAI_API_KEY` | API key | required for `openai` provider |
 | `OPENAI_MODEL` | Model name | `gpt-4o-mini` |
-| `OPENAI_BASE_URL` | Base URL | `https://api.openai.com/v1/chat/completions` |
+| `OPENAI_BASE_URL` | Chat completions URL or API root (`https://api.openai.com`, `https://api.openai.com/v1`, or full `.../v1/chat/completions`); normalized to `POST .../v1/chat/completions` | `https://api.openai.com/v1/chat/completions` |
 | `OPENAI_VISION_MODEL` | Vision model | `OPENAI_MODEL` |
+
+## OpenAI-compatible (`openai_compat` provider)
+
+Use **`openai_compat`** when the backend implements OpenAI-style **`POST /v1/chat/completions`** with **`Authorization: Bearer`** (vLLM, LiteLLM, llama.cpp server, etc.). Separate from **`openai`** so local gateways do not overwrite official OpenAI env vars.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPENAI_COMPAT_API_KEY` | Bearer token (required for this provider; use a placeholder if the server ignores auth) | unset |
+| `OPENAI_COMPAT_BASE_URL` | Origin (`http://127.0.0.1:8000`), API root (`.../v1`), or full completions URL; normalized like `OPENAI_BASE_URL` | unset |
+| `OPENAI_COMPAT_MODEL` | Text model id | `default` (see `NexoDefaults.OpenAiCompatDefaultModel`) |
+| `OPENAI_COMPAT_VISION_MODEL` | Vision model when `OPENAI_COMPAT_MODEL` is not suitable for image input | `OPENAI_COMPAT_MODEL` |
+
+Per-request **`config.model`** overrides the vision model when set.
 
 ## Azure OpenAI
 

--- a/src/Nexo.Core.Domain/NexoDefaults.cs
+++ b/src/Nexo.Core.Domain/NexoDefaults.cs
@@ -60,6 +60,14 @@ public static class NexoDefaults
     /// Override: <c>Nexo:OpenAi:VisionModel</c>.</summary>
     public const string OpenAiDefaultVisionModel = "gpt-4o-mini";
 
+    // ── OpenAI-compatible (vLLM, LiteLLM, llama.cpp server, etc.) ─────
+
+    /// <summary>Default model id when <c>provider=openai_compat</c> and <c>OPENAI_COMPAT_MODEL</c> is unset.</summary>
+    public const string OpenAiCompatDefaultModel = "default";
+
+    /// <summary>Default vision model when <c>OPENAI_COMPAT_VISION_MODEL</c> and <c>OPENAI_COMPAT_MODEL</c> are unset.</summary>
+    public const string OpenAiCompatDefaultVisionModel = "default";
+
     // ── Azure OpenAI ──────────────────────────────────────────────────
 
     /// <summary>API version sent in Azure OpenAI requests.

--- a/src/Nexo.Infrastructure/Execution/ExecutionContext.cs
+++ b/src/Nexo.Infrastructure/Execution/ExecutionContext.cs
@@ -15,7 +15,7 @@ public class ExecutionContext : IExecutionContext
     public bool IsAirGapped { get; init; }
     /// <summary>When true, log decisions for audit trail.</summary>
     public bool AuditMode { get; init; }
-    /// <summary>LLM provider name: ollama, openai, azure, mock, offline, video.</summary>
+    /// <summary>LLM provider name: ollama, openai, openai_compat, azure, mock, offline, video.</summary>
     public string Provider { get; init; } = "openai";
     /// <summary>Key-value variables for this execution (e.g. brick outputs).</summary>
     public Dictionary<string, object> Variables { get; init; } = new();

--- a/src/Nexo.Infrastructure/Execution/OpenAiCompatibleEndpoint.cs
+++ b/src/Nexo.Infrastructure/Execution/OpenAiCompatibleEndpoint.cs
@@ -1,0 +1,52 @@
+namespace Nexo.Infrastructure.Execution;
+
+/// <summary>
+/// Normalizes user-supplied base URLs to a full OpenAI-style chat completions URL.
+/// </summary>
+public static class OpenAiCompatibleEndpoint
+{
+    /// <summary>
+    /// Returns an absolute URI for <c>POST .../v1/chat/completions</c>.
+    /// Accepts a full completions URL, an API root ending in <c>/v1</c>, or an origin only.
+    /// </summary>
+    public static Uri NormalizeChatCompletionsUrl(string baseUrlOrFull)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrlOrFull))
+        {
+            throw new ArgumentException("Base URL is required.", nameof(baseUrlOrFull));
+        }
+
+        var trimmed = baseUrlOrFull.Trim();
+        if (!trimmed.Contains("://", StringComparison.Ordinal))
+        {
+            trimmed = "http://" + trimmed;
+        }
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            throw new ArgumentException("Invalid URL.", nameof(baseUrlOrFull));
+        }
+
+        var path = uri.AbsolutePath.TrimEnd('/');
+        if (path.EndsWith("/v1/chat/completions", StringComparison.OrdinalIgnoreCase))
+        {
+            return uri;
+        }
+
+        if (path.EndsWith("/chat/completions", StringComparison.OrdinalIgnoreCase))
+        {
+            return uri;
+        }
+
+        if (path.Equals("/v1", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+        {
+            var origin = uri.GetLeftPart(UriPartial.Authority);
+            var basePath = path.EndsWith("/", StringComparison.Ordinal) ? path : path + "/";
+            return new Uri(origin + basePath.TrimEnd('/') + "/chat/completions");
+        }
+
+        var root = uri.GetLeftPart(UriPartial.Authority);
+        return new Uri(root + (path.Length > 0 ? path + "/" : "/") + "v1/chat/completions");
+    }
+}

--- a/src/Nexo.Infrastructure/Execution/ProviderFactory.cs
+++ b/src/Nexo.Infrastructure/Execution/ProviderFactory.cs
@@ -21,7 +21,7 @@ namespace Nexo.Infrastructure.Execution;
 /// variables (e.g. <c>NEXO_PROVIDER</c>) → user configuration → compile-time
 /// defaults in <see cref="NexoDefaults"/>.</para>
 ///
-/// <para><b>Available providers:</b> openai, azure, ollama, local
+/// <para><b>Available providers:</b> openai, openai_compat, azure, ollama, local
 /// (in-process ONNX/LLamaSharp), video (SmolVLM2-Video in Docker), and the
 /// test-only mock/offline/mock-json/echo set. To add a new provider, add its
 /// key to <c>_availableProviders</c>, implement availability detection in
@@ -75,6 +75,7 @@ public class ProviderFactory : IProviderFactory
     private readonly HashSet<string> _availableProviders = new()
     {
         "openai",
+        "openai_compat",
         "azure",
         "ollama",
         "local", // In-process ONNX/LLamaSharp; requires NEXO_LOCAL_MODEL_PATH
@@ -128,6 +129,8 @@ public class ProviderFactory : IProviderFactory
         return provider switch
         {
             "openai" => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OPENAI_API_KEY")),
+            "openai_compat" => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OPENAI_COMPAT_API_KEY"))
+                             && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OPENAI_COMPAT_BASE_URL")),
             "azure" => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
                        && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY"))
                        && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT")),
@@ -154,7 +157,7 @@ public class ProviderFactory : IProviderFactory
         if (provider is "mock" or "offline" or "mock-json" or "echo")
         {
             if (!AllowMock)
-                throw new ModelUnavailableException("Mock providers are disabled. Set NEXO_ALLOW_MOCK=1 for tests/demos, or use a real provider (ollama, openai, azure, local).");
+                throw new ModelUnavailableException("Mock providers are disabled. Set NEXO_ALLOW_MOCK=1 for tests/demos, or use a real provider (ollama, openai, openai_compat, azure, local).");
             await Task.Delay(NexoDefaults.MockDelayMs, cancellationToken);
             return GenerateMockJsonResponse(systemPrompt, userPrompt);
         }
@@ -168,6 +171,21 @@ public class ProviderFactory : IProviderFactory
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new InvalidOperationException("OPENAI_API_KEY is not set. Set it or use provider mock/offline.");
             return await ExecuteOpenAiAsync(apiKey, systemPrompt, userPrompt, cancellationToken);
+        }
+
+        if (provider is "openai_compat")
+        {
+            var apiKey = Environment.GetEnvironmentVariable("OPENAI_COMPAT_API_KEY");
+            var baseUrl = Environment.GetEnvironmentVariable("OPENAI_COMPAT_BASE_URL");
+            if (string.IsNullOrWhiteSpace(apiKey) || string.IsNullOrWhiteSpace(baseUrl))
+            {
+                throw new InvalidOperationException(
+                    "OPENAI_COMPAT_API_KEY and OPENAI_COMPAT_BASE_URL must be set for provider openai_compat (e.g. vLLM, LiteLLM, llama.cpp server).");
+            }
+
+            var model = Environment.GetEnvironmentVariable("OPENAI_COMPAT_MODEL") ?? NexoDefaults.OpenAiCompatDefaultModel;
+            var url = OpenAiCompatibleEndpoint.NormalizeChatCompletionsUrl(baseUrl).ToString();
+            return await ExecuteOpenAiChatCompletionAsync(url, apiKey, model, systemPrompt, userPrompt, cancellationToken);
         }
 
         if (provider is "azure")
@@ -186,14 +204,25 @@ public class ProviderFactory : IProviderFactory
         if (provider is "local")
             return await LocalModelProvider.ExecuteAsync(systemPrompt, userPrompt, config, cancellationToken);
 
-        throw new InvalidOperationException($"Unknown or unsupported provider: {provider}. Use ollama, openai, azure, local, or mock (NEXO_ALLOW_MOCK=1).");
+        throw new InvalidOperationException($"Unknown or unsupported provider: {provider}. Use ollama, openai, openai_compat, azure, local, or mock (NEXO_ALLOW_MOCK=1).");
     }
 
     private async Task<string> ExecuteOpenAiAsync(string apiKey, string systemPrompt, string userPrompt, CancellationToken ct)
     {
         var model = Environment.GetEnvironmentVariable("OPENAI_MODEL") ?? NexoDefaults.OpenAiDefaultModel;
-        var url = Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? NexoDefaults.OpenAiDefaultBaseUrl;
+        var rawUrl = Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? NexoDefaults.OpenAiDefaultBaseUrl;
+        var url = OpenAiCompatibleEndpoint.NormalizeChatCompletionsUrl(rawUrl).ToString();
+        return await ExecuteOpenAiChatCompletionAsync(url, apiKey, model, systemPrompt, userPrompt, ct);
+    }
 
+    private static async Task<string> ExecuteOpenAiChatCompletionAsync(
+        string requestUrl,
+        string apiKey,
+        string model,
+        string systemPrompt,
+        string userPrompt,
+        CancellationToken ct)
+    {
         var payload = new
         {
             model,
@@ -208,7 +237,7 @@ public class ProviderFactory : IProviderFactory
 
         using var resp = await HttpRetryPolicy.ExecuteAsync(() =>
         {
-            using var req = new HttpRequestMessage(HttpMethod.Post, url);
+            using var req = new HttpRequestMessage(HttpMethod.Post, requestUrl);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
             req.Content = new StringContent(json);
             req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
@@ -224,7 +253,7 @@ public class ProviderFactory : IProviderFactory
             .GetProperty("content")
             .GetString();
 
-        return content ?? throw new InvalidOperationException("OpenAI response content was null");
+        return content ?? throw new InvalidOperationException("OpenAI-compatible response content was null");
     }
 
     private async Task<string> ExecuteAzureOpenAiAsync(string endpoint, string apiKey, string deployment, string systemPrompt, string userPrompt, CancellationToken ct)
@@ -265,13 +294,16 @@ public class ProviderFactory : IProviderFactory
         return content ?? throw new InvalidOperationException("Azure OpenAI response content was null");
     }
 
-    private async Task<string> ExecuteOpenAiVisionAsync(string apiKey, string systemPrompt, string userPrompt, byte[]? imageBytes, object? config, CancellationToken ct)
+    private async Task<string> ExecuteOpenAiVisionAsync(
+        string apiKey,
+        string openAiBaseUrl,
+        string model,
+        string systemPrompt,
+        string userPrompt,
+        byte[]? imageBytes,
+        CancellationToken ct)
     {
-        var model = Environment.GetEnvironmentVariable("OPENAI_VISION_MODEL") ?? Environment.GetEnvironmentVariable("OPENAI_MODEL") ?? NexoDefaults.OpenAiDefaultVisionModel;
-        var baseUrl = Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? "https://api.openai.com";
-        var url = baseUrl.EndsWith("/v1/chat/completions", StringComparison.OrdinalIgnoreCase)
-            ? baseUrl
-            : baseUrl.TrimEnd('/') + "/v1/chat/completions";
+        var url = OpenAiCompatibleEndpoint.NormalizeChatCompletionsUrl(openAiBaseUrl).ToString();
 
         object[] contentParts;
         if (imageBytes is { Length: > 0 })
@@ -423,7 +455,7 @@ public class ProviderFactory : IProviderFactory
         if (provider is "mock" or "offline" or "mock-json" or "echo")
         {
             if (!AllowMock)
-                throw new ModelUnavailableException("Mock providers are disabled. Set NEXO_ALLOW_MOCK=1 or use ollama, openai, azure.");
+                throw new ModelUnavailableException("Mock providers are disabled. Set NEXO_ALLOW_MOCK=1 or use ollama, openai, openai_compat, azure.");
             return GenerateMockJsonResponse(systemPrompt, userPrompt);
         }
 
@@ -435,7 +467,29 @@ public class ProviderFactory : IProviderFactory
             var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new InvalidOperationException("OPENAI_API_KEY is not set. Set it or use provider ollama.");
-            return await ExecuteOpenAiVisionAsync(apiKey, systemPrompt, userPrompt, imageBytes, config, cancellationToken);
+            var baseUrl = Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? "https://api.openai.com";
+            var model = GetModelFromConfig(config)
+                ?? Environment.GetEnvironmentVariable("OPENAI_VISION_MODEL")
+                ?? Environment.GetEnvironmentVariable("OPENAI_MODEL")
+                ?? NexoDefaults.OpenAiDefaultVisionModel;
+            return await ExecuteOpenAiVisionAsync(apiKey, baseUrl, model, systemPrompt, userPrompt, imageBytes, cancellationToken);
+        }
+
+        if (provider is "openai_compat")
+        {
+            var apiKey = Environment.GetEnvironmentVariable("OPENAI_COMPAT_API_KEY");
+            var baseUrl = Environment.GetEnvironmentVariable("OPENAI_COMPAT_BASE_URL");
+            if (string.IsNullOrWhiteSpace(apiKey) || string.IsNullOrWhiteSpace(baseUrl))
+            {
+                throw new InvalidOperationException(
+                    "OPENAI_COMPAT_API_KEY and OPENAI_COMPAT_BASE_URL must be set for provider openai_compat.");
+            }
+
+            var model = GetModelFromConfig(config)
+                ?? Environment.GetEnvironmentVariable("OPENAI_COMPAT_VISION_MODEL")
+                ?? Environment.GetEnvironmentVariable("OPENAI_COMPAT_MODEL")
+                ?? NexoDefaults.OpenAiCompatDefaultVisionModel;
+            return await ExecuteOpenAiVisionAsync(apiKey, baseUrl, model, systemPrompt, userPrompt, imageBytes, cancellationToken);
         }
 
         if (provider is "azure")
@@ -448,7 +502,7 @@ public class ProviderFactory : IProviderFactory
             return await ExecuteAzureOpenAiVisionAsync(endpoint, apiKey, deployment, systemPrompt, userPrompt, imageBytes, config, cancellationToken);
         }
 
-        throw new InvalidOperationException($"Unknown or unsupported vision provider: {provider}. Use ollama, openai, azure, auto, or local.");
+        throw new InvalidOperationException($"Unknown or unsupported vision provider: {provider}. Use ollama, openai, openai_compat, azure, auto, or local.");
     }
 
     /// <inheritdoc />
@@ -476,7 +530,7 @@ public class ProviderFactory : IProviderFactory
         if (provider is "mock" or "offline" or "mock-json" or "echo")
         {
             if (!AllowMock)
-                throw new ModelUnavailableException("Mock providers are disabled. Set NEXO_ALLOW_MOCK=1 or use ollama, openai, azure.");
+                throw new ModelUnavailableException("Mock providers are disabled. Set NEXO_ALLOW_MOCK=1 or use ollama, openai, openai_compat, azure.");
             return await ExecuteVisionAsync(provider, systemPrompt, userPrompt + $"\n[Note: {frames.Count} frames provided, analyzing most recent.]", frames[^1], config, cancellationToken);
         }
 
@@ -491,7 +545,29 @@ public class ProviderFactory : IProviderFactory
             var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new InvalidOperationException("OPENAI_API_KEY is not set. Set it or use provider ollama.");
-            return await ExecuteOpenAiVisionAsync(apiKey, systemPrompt, userPrompt, frames[^1], config, cancellationToken);
+            var baseUrl = Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? "https://api.openai.com";
+            var model = GetModelFromConfig(config)
+                ?? Environment.GetEnvironmentVariable("OPENAI_VISION_MODEL")
+                ?? Environment.GetEnvironmentVariable("OPENAI_MODEL")
+                ?? NexoDefaults.OpenAiDefaultVisionModel;
+            return await ExecuteOpenAiVisionAsync(apiKey, baseUrl, model, systemPrompt, userPrompt, frames[^1], cancellationToken);
+        }
+
+        if (provider is "openai_compat")
+        {
+            var apiKey = Environment.GetEnvironmentVariable("OPENAI_COMPAT_API_KEY");
+            var baseUrl = Environment.GetEnvironmentVariable("OPENAI_COMPAT_BASE_URL");
+            if (string.IsNullOrWhiteSpace(apiKey) || string.IsNullOrWhiteSpace(baseUrl))
+            {
+                throw new InvalidOperationException(
+                    "OPENAI_COMPAT_API_KEY and OPENAI_COMPAT_BASE_URL must be set for provider openai_compat.");
+            }
+
+            var model = GetModelFromConfig(config)
+                ?? Environment.GetEnvironmentVariable("OPENAI_COMPAT_VISION_MODEL")
+                ?? Environment.GetEnvironmentVariable("OPENAI_COMPAT_MODEL")
+                ?? NexoDefaults.OpenAiCompatDefaultVisionModel;
+            return await ExecuteOpenAiVisionAsync(apiKey, baseUrl, model, systemPrompt, userPrompt, frames[^1], cancellationToken);
         }
 
         if (provider is "azure")

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/OpenAiCompatibleEndpointTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/OpenAiCompatibleEndpointTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using Nexo.Infrastructure.Execution;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Execution;
+
+public sealed class OpenAiCompatibleEndpointTests
+{
+    [Theory]
+    [InlineData("http://localhost:8000", "http://localhost:8000/v1/chat/completions")]
+    [InlineData("http://localhost:8000/v1", "http://localhost:8000/v1/chat/completions")]
+    [InlineData("http://localhost:8000/v1/", "http://localhost:8000/v1/chat/completions")]
+    [InlineData("http://host/v1/chat/completions", "http://host/v1/chat/completions")]
+    public void NormalizeChatCompletionsUrl_AppendsOrPreservesV1Path(string input, string expected)
+    {
+        var uri = OpenAiCompatibleEndpoint.NormalizeChatCompletionsUrl(input);
+        uri.ToString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void NormalizeChatCompletionsUrl_AddsHttpSchemeWhenMissing()
+    {
+        var uri = OpenAiCompatibleEndpoint.NormalizeChatCompletionsUrl("127.0.0.1:11435");
+        uri.Scheme.Should().Be("http");
+        uri.ToString().Should().Be("http://127.0.0.1:11435/v1/chat/completions");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Execution/ProviderFactoryTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Execution/ProviderFactoryTests.cs
@@ -95,6 +95,30 @@ public class ProviderFactoryTests : UnitTestBase
             AssertFalse(factory.IsProviderAvailable("openai"));
         });
 
+        WithEnv("OPENAI_COMPAT_API_KEY", null, () =>
+        {
+            WithEnv("OPENAI_COMPAT_BASE_URL", null, () =>
+            {
+                AssertFalse(factory.IsProviderAvailable("openai_compat"));
+            });
+        });
+
+        WithEnv("OPENAI_COMPAT_API_KEY", "k", () =>
+        {
+            WithEnv("OPENAI_COMPAT_BASE_URL", null, () =>
+            {
+                AssertFalse(factory.IsProviderAvailable("openai_compat"));
+            });
+        });
+
+        WithEnv("OPENAI_COMPAT_API_KEY", "k", () =>
+        {
+            WithEnv("OPENAI_COMPAT_BASE_URL", "http://localhost:8000", () =>
+            {
+                AssertTrue(factory.IsProviderAvailable("openai_compat"));
+            });
+        });
+
         WithEnv("AZURE_OPENAI_ENDPOINT", null, () =>
         {
             WithEnv("AZURE_OPENAI_API_KEY", null, () =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds provider **`openai_compat`** for any server that implements OpenAI-style **`POST /v1/chat/completions`** (Bearer auth, JSON body with `model` + `messages`), e.g. **vLLM**, **LiteLLM**, **llama.cpp** server, many gateways.

## Environment

| Variable | Role |
|----------|------|
| `OPENAI_COMPAT_API_KEY` | Bearer token (required) |
| `OPENAI_COMPAT_BASE_URL` | Origin, `.../v1`, or full `.../v1/chat/completions` URL (required) |
| `OPENAI_COMPAT_MODEL` | Text model id (default `default` from `NexoDefaults.OpenAiCompatDefaultModel`) |
| `OPENAI_COMPAT_VISION_MODEL` | Vision model when using `ExecuteVision*` with `openai_compat` |

Optional: **`config.model`** still overrides model for vision calls.

## Other changes

- **`OpenAiCompatibleEndpoint.NormalizeChatCompletionsUrl`** — shared URL normalization.
- **`openai`** path now normalizes `OPENAI_BASE_URL` the same way (origin-only and `/v1` roots resolve to `/v1/chat/completions`).
- **`ExecuteOpenAiChatCompletionAsync`** — shared POST + response parse for text chat.

## Documentation

- **`docs/Configuration.md`** — new **OpenAI-compatible (`openai_compat` provider)** section and clarified **`OPENAI_BASE_URL`** description.

## Tests

- `OpenAiCompatibleEndpointTests` — URL normalization cases.
- `ProviderFactoryTests.TestIsProviderAvailable` — `openai_compat` availability when key + base URL set.

Branch: `cursor/openai-compatible-provider-e0c8`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c74db3be-5f99-44c9-9fe0-1006cebee0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c74db3be-5f99-44c9-9fe0-1006cebee0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

