### PR TITLE
CI: verify StableSdkHostSample against packaged Nexo.Hosting graph

### DIFF
--- a/.github/workflows/full-platform-readiness-gate.yml
+++ b/.github/workflows/full-platform-readiness-gate.yml
@@ -24,10 +24,25 @@ on:
       - "scripts/install/**"
       - "src/Nexo.CLI/**"
       - "src/Nexo.Hosting/**"
+      - "src/Nexo.Abstractions/**"
+      - "src/Nexo.Core/**"
       - "src/Nexo.Core.Domain/**"
       - "src/Nexo.Core.Application/**"
+      - "src/Nexo.Brick.Contracts/**"
+      - "src/Nexo.Policies/**"
+      - "src/Nexo.Tools.Assembly/**"
+      - "src/Nexo.Tools.Dev/**"
+      - "src/Nexo.Transport.Grpc/**"
+      - "src/Nexo.Runtime/**"
       - "src/Nexo.Infrastructure/**"
+      - "src/Nexo.Orchestration/**"
+      - "src/Nexo.BackgroundAgents/**"
       - "src/Nexo.Tests.BackgroundAgents/**"
+      - "scripts/pack-nexo-hosting-graph.sh"
+      - "scripts/pack-nexo-hosting-graph.ps1"
+      - "scripts/verify-stable-sdk-host-sample-packages.sh"
+      - "scripts/verify-stable-sdk-host-sample-packages.ps1"
+      - "docs/samples/StableSdkHostSample/**"
       - "global.json"
       - "Directory.Build.props"
       - "Directory.Packages.props"
@@ -39,10 +54,25 @@ on:
       - "scripts/install/**"
       - "src/Nexo.CLI/**"
       - "src/Nexo.Hosting/**"
+      - "src/Nexo.Abstractions/**"
+      - "src/Nexo.Core/**"
       - "src/Nexo.Core.Domain/**"
       - "src/Nexo.Core.Application/**"
+      - "src/Nexo.Brick.Contracts/**"
+      - "src/Nexo.Policies/**"
+      - "src/Nexo.Tools.Assembly/**"
+      - "src/Nexo.Tools.Dev/**"
+      - "src/Nexo.Transport.Grpc/**"
+      - "src/Nexo.Runtime/**"
       - "src/Nexo.Infrastructure/**"
+      - "src/Nexo.Orchestration/**"
+      - "src/Nexo.BackgroundAgents/**"
       - "src/Nexo.Tests.BackgroundAgents/**"
+      - "scripts/pack-nexo-hosting-graph.sh"
+      - "scripts/pack-nexo-hosting-graph.ps1"
+      - "scripts/verify-stable-sdk-host-sample-packages.sh"
+      - "scripts/verify-stable-sdk-host-sample-packages.ps1"
+      - "docs/samples/StableSdkHostSample/**"
       - "global.json"
       - "Directory.Build.props"
       - "Directory.Packages.props"
@@ -113,6 +143,17 @@ jobs:
 
       - name: "Setup — build SDK sample"
         run: dotnet build docs/samples/StableSdkHostSample/StableSdkHostSample.csproj -v minimal
+
+      - name: "Setup — verify SDK sample consumes local NuGet graph"
+        shell: bash
+        env:
+          NEXO_SDK_PACKAGE_VERSION: 1.0.0-ci
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            pwsh -NoProfile -File scripts/verify-stable-sdk-host-sample-packages.ps1 -Version "${NEXO_SDK_PACKAGE_VERSION}"
+          else
+            bash scripts/verify-stable-sdk-host-sample-packages.sh
+          fi
 
       # ── Stage 2: Discovery ──────────────────────────────────────────
       - name: "Discover — doctor report"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docs/api/api/
 # Build artifacts
 **/bin/
 **/obj/
+artifacts/
 # Nested helper tool under Nexo.Tests.Infrastructure (never commit its build output)
 src/Nexo.Tests.Infrastructure/scripts/bin/
 src/Nexo.Tests.Infrastructure/scripts/obj/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,13 @@
   </PropertyGroup>
 
   <!-- Override transitive System.Text.Encodings.Web 4.5.x (NU1904 / GHSA-ghhp-997w-qr28). -->
-  <ItemGroup>
+  <!-- Skip for package-only SDK sample: uses explicit versions + local Directory.Packages.props (see docs/samples/.../package-consumer). -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'StableSdkHostSample.Package'">
     <PackageReference Include="System.Text.Encodings.Web" />
+  </ItemGroup>
+
+  <!-- NuGet pack: README at repo root (NU5039 if only PackageReadmeFile without packed file). -->
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -61,6 +61,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 
 - `docs/api/index.md` — API docs index.
 - `docs/sdk.md` — SDK integration guidance.
+- `docs/PUBLISHING.md` — pack and publish `Nexo.Hosting` (and its `Nexo.*` graph) to NuGet / GitHub Packages; operator checklist.
 - `docs/samples/StableSdkHostSample/Program.cs` — reference host integration that only uses stable SDK extension points.
 - `docs/runtime/ExecutionRouting.md` — NCR-based generation routing (local, peer network, RunPod), preferences, and resilience behavior.
 - `docs/AgentExecutionIsolation.md` — per-agent isolation tiers (in-process through container-per-agent), JSON field, and invocation metadata for transports.

--- a/docs/ExecutionPlan.md
+++ b/docs/ExecutionPlan.md
@@ -158,7 +158,7 @@ These items establish the first end-to-end product experience and close the most
 - Full public-surface audit: explicit `[Stable]` / `[Experimental]` attributes and a complete classification table in `docs/sdk.md` (policy doc exists; table may still be partial).
 
 **Implementation tasks:**
-1. Add CI lane that builds and runs `StableSdkHostSample` in isolation (verify it compiles against published/local NuGet only — no project references to internals). **Remaining** (recommended explicit step).
+1. ~~Add CI lane that builds and runs `StableSdkHostSample` in isolation (verify it compiles against published/local NuGet only — no project references to internals).~~ **Done** — `package-consumer/StableSdkHostSample.Package.csproj` + `scripts/verify-stable-sdk-host-sample-packages.*` + readiness gate step **Setup — verify SDK sample consumes local NuGet graph**.
 2. Add `docs/SdkCompatibilityPolicy.md`: semver rules, deprecation process, breaking-change notification. **Done** — see [SdkCompatibilityPolicy.md](SdkCompatibilityPolicy.md).
 3. Audit all public types in `Nexo.Sdk`, `Nexo.Client`, `Nexo.Abstractions`, `Nexo.Brick.Contracts` — classify each as Stable / Experimental / Internal. Add classification table to `docs/sdk.md`. **Ongoing.**
 4. Add XML doc comments indicating stability level on key public interfaces. **Ongoing.**

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,52 @@
+# Publishing Nexo for external consumption
+
+This document describes how to **produce** and **publish** the .NET packages that external repos (for example game tooling) consume. CI already **verifies** NuGet-only consumption locally; publishing to a feed is an operator step.
+
+## What gets published
+
+Embedding the Nexo kernel from another .NET app uses **`Nexo.Hosting`**. That package depends on other **`Nexo.*`** packages built from this repo. Publish **all of them with the same semantic version** (for example `1.2.3`).
+
+Use:
+
+```bash
+bash scripts/pack-nexo-hosting-graph.sh 1.2.3 ./artifacts/nuget-release
+```
+
+(or `scripts/pack-nexo-hosting-graph.ps1` on Windows). Output is a folder of `*.nupkg` / `*.snupkg` files.
+
+Stable **client** surface (HTTP) is documented in `docs/sdk.md` (`Nexo.Sdk` / `Nexo.Client`); pack those separately if you publish them to the same feed.
+
+## Verify before you push
+
+From a clean machine or CI artifact:
+
+```bash
+export NEXO_SDK_PACKAGE_VERSION=1.2.3
+bash scripts/verify-stable-sdk-host-sample-packages.sh
+```
+
+This packs the graph to `artifacts/nuget-verify/packages`, restores `docs/samples/StableSdkHostSample/package-consumer/` against **only** that folder + nuget.org, builds, and runs the sample.
+
+## Publish to nuget.org (you do this)
+
+1. Create a **NuGet.org** account (if needed) and an **API key** with scope **Push** for the `Nexo.*` package IDs (or org-owned IDs).
+2. Locally: `dotnet nuget push "artifacts/nuget-release/*.nupkg" --api-key <KEY> --source https://api.nuget.org/v3/index.json`
+3. Optionally push symbols: `*.snupkg` to the same source (NuGet accepts symbols alongside).
+4. Tag the git repo **`v1.2.3`** to match the package version you pushed.
+5. Write **GitHub Release** notes: list package versions, migration notes, and any breaking changes per `docs/SdkCompatibilityPolicy.md`.
+
+## Publish to GitHub Packages (alternative)
+
+1. Generate a **PAT** or use `GITHUB_TOKEN` in Actions with `packages: write`.
+2. `dotnet nuget add source` pointing at `https://nuget.pkg.github.com/<OWNER>/index.json` with credentials.
+3. `dotnet nuget push` the same folder to that source.
+4. Document for consumers: **feed URL**, **auth** (PAT as password), and **exact package version** to pin.
+
+## Container image (separate track)
+
+The CLI image is published by `.github/workflows/container-image-publish.yml` to **GHCR**. That is orthogonal to NuGet; ops users may consume **only** the image, .NET hosts consume **NuGet**, or both.
+
+## What you must maintain over time
+
+- When `Nexo.Hosting` gains a **new project reference** to another in-repo `Nexo.*` project, add that project to **`scripts/pack-nexo-hosting-graph.sh`** / **`.ps1`** so the graph stays publishable.
+- Keep **`PackageVersion`** in sync across the graph for a given release (the scripts pass one version to every `dotnet pack`).

--- a/docs/SdkIntegrationGuide.md
+++ b/docs/SdkIntegrationGuide.md
@@ -99,10 +99,19 @@ services.AddNexoProfile(NexoDeploymentProfile.AirGapped, opts =>
 
 ## CI Validation
 
-The SDK sample is built in the readiness gate workflow to catch breaking changes:
+The readiness gate builds the **project-reference** sample and then verifies **NuGet-only** consumption:
 
-```yaml
-# .github/workflows/full-platform-readiness-gate.yml
-- name: "Build SDK sample"
-  run: dotnet build docs/samples/StableSdkHostSample/StableSdkHostSample.csproj
+1. `dotnet build docs/samples/StableSdkHostSample/StableSdkHostSample.csproj` (in-repo references).
+2. `scripts/verify-stable-sdk-host-sample-packages.sh` (POSIX) or `scripts/verify-stable-sdk-host-sample-packages.ps1` (Windows): packs the `Nexo.Hosting` dependency graph to a local feed, restores `docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj`, builds, and runs.
+
+See `.github/workflows/full-platform-readiness-gate.yml` (steps **Setup — build SDK sample** and **Setup — verify SDK sample consumes local NuGet graph**).
+
+## Publishing `Nexo.Hosting` for external repos
+
+`Nexo.Hosting` depends on other `Nexo.*` projects; publish **the same `PackageVersion`** for the whole graph before pushing to a feed:
+
+```bash
+bash scripts/pack-nexo-hosting-graph.sh 1.2.3 /path/to/output
 ```
+
+Then push `*.nupkg` from that folder to **nuget.org** or **GitHub Packages**. External hosts reference **`Nexo.Hosting`** only; NuGet resolves the matching versions of transitive `Nexo.*` packages from the same feed.

--- a/docs/samples/StableSdkHostSample/package-consumer/Directory.Build.props
+++ b/docs/samples/StableSdkHostSample/package-consumer/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Explicit transitive pin for local-feed restore (repo root adds versionless ref; skipped via root condition). -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.8" />
+  </ItemGroup>
+</Project>

--- a/docs/samples/StableSdkHostSample/package-consumer/Directory.Packages.props
+++ b/docs/samples/StableSdkHostSample/package-consumer/Directory.Packages.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Closest Directory.Packages.props wins: opt this sample out of repo central package management. -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/docs/samples/StableSdkHostSample/package-consumer/README.md
+++ b/docs/samples/StableSdkHostSample/package-consumer/README.md
@@ -1,0 +1,16 @@
+# Stable SDK host sample (package consumption)
+
+This project references **`Nexo.Hosting`** from NuGet only (no project references to the Nexo repo). It shares `Program.cs` with the sibling sample.
+
+Verify locally (from repo root):
+
+```bash
+NEXO_SDK_PACKAGE_VERSION=1.0.0-local bash scripts/verify-stable-sdk-host-sample-packages.sh
+```
+
+Override package version at restore time:
+
+```bash
+dotnet restore -p:NexoSdkPackageVersion=1.2.3
+dotnet build --no-restore
+```

--- a/docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj
+++ b/docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Standalone sample: do not inherit repo central package management (Nexo.Hosting version is local feed). -->
+    <!-- ManagePackageVersionsCentrally: see Directory.Build.props in this folder -->
+    <!-- Transitive advisory noise when resolving against local feed only; hosting graph pins safe versions. -->
+    <NoWarn>$(NoWarn);NU1904;NU1903;NU1902</NoWarn>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>StableSdkHostSamplePackage</AssemblyName>
+    <RootNamespace>StableSdkHostSample</RootNamespace>
+    <NexoSdkPackageVersion Condition="'$(NexoSdkPackageVersion)' == ''">1.0.0</NexoSdkPackageVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Nexo.Hosting" Version="$(NexoSdkPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -138,6 +138,7 @@ Both mechanisms merge into the same `AdaptationBrickOptions.AdditionalBrickTypes
 
 A minimal, stable-only host integration sample is provided at:
 
-- `docs/samples/StableSdkHostSample/`
+- `docs/samples/StableSdkHostSample/` — **project-reference** mode (`StableSdkHostSample.csproj`) for contributors working inside the repo.
+- `docs/samples/StableSdkHostSample/package-consumer/` — **package-only** mode (`StableSdkHostSample.Package.csproj`): references `Nexo.Hosting` from NuGet; verified by `scripts/verify-stable-sdk-host-sample-packages.sh` against a local feed after `scripts/pack-nexo-hosting-graph.sh`.
 
 The sample intentionally uses only `Nexo.Hosting.Sdk` + `INexoSdkBuilder` extension points and avoids internal namespaces.

--- a/scripts/pack-nexo-hosting-graph.ps1
+++ b/scripts/pack-nexo-hosting-graph.ps1
@@ -1,0 +1,38 @@
+#requires -Version 7.0
+param(
+    [Parameter(Mandatory = $true)][string] $Version,
+    [string] $OutputDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $OutputDir = Join-Path $Root "artifacts/nuget-local"
+}
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+function Pack-Project([string] $RelativePath) {
+    Write-Host "==> dotnet pack $RelativePath"
+    dotnet pack (Join-Path $Root $RelativePath) `
+        -c Release `
+        -o $OutputDir `
+        -p:PackageVersion=$Version `
+        -v minimal
+}
+
+Pack-Project "src/Nexo.Abstractions/Nexo.Abstractions.csproj"
+Pack-Project "src/Nexo.Core.Domain/Nexo.Core.Domain.csproj"
+Pack-Project "src/Nexo.Core/Nexo.Core.csproj"
+Pack-Project "src/Nexo.Core.Application/Nexo.Core.Application.csproj"
+Pack-Project "src/Nexo.Brick.Contracts/Nexo.Brick.Contracts.csproj"
+Pack-Project "src/Nexo.Policies/Nexo.Policies.csproj"
+Pack-Project "src/Nexo.Tools.Assembly/Nexo.Tools.Assembly.csproj"
+Pack-Project "src/Nexo.Tools.Dev/Nexo.Tools.Dev.csproj"
+Pack-Project "src/Nexo.Transport.Grpc/Nexo.Transport.Grpc.csproj"
+Pack-Project "src/Nexo.Runtime/Nexo.Runtime.csproj"
+Pack-Project "src/Nexo.Infrastructure/Nexo.Infrastructure.csproj"
+Pack-Project "src/Nexo.Orchestration/Nexo.Orchestration.csproj"
+Pack-Project "src/Nexo.BackgroundAgents/Nexo.BackgroundAgents.csproj"
+Pack-Project "src/Nexo.Hosting/Nexo.Hosting.csproj"
+
+Write-Host "pack-nexo-hosting-graph: OK ($OutputDir, version $Version)"

--- a/scripts/pack-nexo-hosting-graph.sh
+++ b/scripts/pack-nexo-hosting-graph.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Packs the Nexo.* project graph required for a consumable Nexo.Hosting package (same PackageVersion on all).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${1:?usage: pack-nexo-hosting-graph.sh <PackageVersion> [output-dir]}"
+OUT="${2:-${ROOT}/artifacts/nuget-local}"
+
+mkdir -p "${OUT}"
+
+pack() {
+  echo "==> dotnet pack $1"
+  dotnet pack "${ROOT}/$1" \
+    -c Release \
+    -o "${OUT}" \
+    -p:PackageVersion="${VERSION}" \
+    -v minimal
+}
+
+pack src/Nexo.Abstractions/Nexo.Abstractions.csproj
+pack src/Nexo.Core.Domain/Nexo.Core.Domain.csproj
+pack src/Nexo.Core/Nexo.Core.csproj
+pack src/Nexo.Core.Application/Nexo.Core.Application.csproj
+pack src/Nexo.Brick.Contracts/Nexo.Brick.Contracts.csproj
+pack src/Nexo.Policies/Nexo.Policies.csproj
+pack src/Nexo.Tools.Assembly/Nexo.Tools.Assembly.csproj
+pack src/Nexo.Tools.Dev/Nexo.Tools.Dev.csproj
+pack src/Nexo.Transport.Grpc/Nexo.Transport.Grpc.csproj
+pack src/Nexo.Runtime/Nexo.Runtime.csproj
+pack src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+pack src/Nexo.Orchestration/Nexo.Orchestration.csproj
+pack src/Nexo.BackgroundAgents/Nexo.BackgroundAgents.csproj
+pack src/Nexo.Hosting/Nexo.Hosting.csproj
+
+echo "pack-nexo-hosting-graph: OK (${OUT}, version ${VERSION})"

--- a/scripts/verify-stable-sdk-host-sample-packages.ps1
+++ b/scripts/verify-stable-sdk-host-sample-packages.ps1
@@ -1,0 +1,51 @@
+#requires -Version 7.0
+param(
+    [string] $Version = $env:NEXO_SDK_PACKAGE_VERSION
+)
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = "1.0.0-ci"
+}
+
+$ErrorActionPreference = "Stop"
+$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$Out = Join-Path $Root "artifacts/nuget-verify/packages"
+$CfgDir = Join-Path $Root "artifacts/nuget-verify"
+$Cfg = Join-Path $CfgDir "NuGet.Config"
+
+if (Test-Path $Out) { Remove-Item -Recurse -Force $Out }
+New-Item -ItemType Directory -Path $Out -Force | Out-Null
+New-Item -ItemType Directory -Path $CfgDir -Force | Out-Null
+
+Write-Host "Packing Nexo.Hosting dependency graph as version $Version..."
+& (Join-Path $Root "scripts/pack-nexo-hosting-graph.ps1") -Version $Version -OutputDir $Out
+
+$outUri = ([Uri]$Out).AbsoluteUri.TrimEnd('/')
+@"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nexo-local" value="$outUri" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -Path $Cfg -Encoding utf8
+
+Write-Host "Restoring and building package-consumption sample (NexoSdkPackageVersion=$Version)..."
+dotnet restore (Join-Path $Root "docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj") `
+    --configfile $Cfg `
+    -p:NexoSdkPackageVersion=$Version `
+    -v minimal
+
+dotnet build (Join-Path $Root "docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj") `
+    -c Release `
+    --no-restore `
+    -v minimal
+
+Write-Host "Running package-consumption sample..."
+dotnet run --project (Join-Path $Root "docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj") `
+    -c Release `
+    --no-build
+
+Write-Host "verify-stable-sdk-host-sample-packages: OK"

--- a/scripts/verify-stable-sdk-host-sample-packages.sh
+++ b/scripts/verify-stable-sdk-host-sample-packages.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Pack Nexo.Hosting to a local directory, restore StableSdkHostSample.Package.csproj against that feed only (+ nuget.org for dependencies), and build.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${NEXO_SDK_PACKAGE_VERSION:-1.0.0-ci}"
+OUT="${ROOT}/artifacts/nuget-verify/packages"
+CFG_DIR="${ROOT}/artifacts/nuget-verify"
+CFG="${CFG_DIR}/NuGet.Config"
+
+rm -rf "${OUT}"
+mkdir -p "${OUT}" "${CFG_DIR}"
+
+echo "Packing Nexo.Hosting dependency graph as version ${VERSION}..."
+bash "${ROOT}/scripts/pack-nexo-hosting-graph.sh" "${VERSION}" "${OUT}"
+
+cat > "${CFG}" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nexo-local" value="${OUT}" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>
+EOF
+
+echo "Restoring and building package-consumption sample (NexoSdkPackageVersion=${VERSION})..."
+dotnet restore "${ROOT}/docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj" \
+  --configfile "${CFG}" \
+  -p:NexoSdkPackageVersion="${VERSION}" \
+  -v minimal
+
+dotnet build "${ROOT}/docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj" \
+  -c Release \
+  --no-restore \
+  -v minimal
+
+echo "Running package-consumption sample..."
+dotnet run --project "${ROOT}/docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj" \
+  -c Release \
+  --no-build
+
+echo "verify-stable-sdk-host-sample-packages: OK"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the gap where `StableSdkHostSample` only validated **project references**. Adds a **package-consumer** sample and CI/scripts that **pack the full `Nexo.Hosting` NuGet dependency graph** to a local feed, restore **only** `Nexo.Hosting` from that feed (+ nuget.org for third-party deps), build, and run.

## Changes

- **`Directory.Build.props`** — pack repo `README.md` into nupkgs (fixes NU5039); skip global `System.Text.Encodings.Web` `PackageReference` for `StableSdkHostSample.Package` (sample pins its own).
- **`docs/samples/StableSdkHostSample/package-consumer/`** — `StableSdkHostSample.Package.csproj` + `Directory.Packages.props` (`ManagePackageVersionsCentrally=false`) + optional transitive pin + README.
- **`scripts/pack-nexo-hosting-graph.sh` / `.ps1`** — packs all `Nexo.*` projects required for a consumable `Nexo.Hosting` release with one **PackageVersion**.
- **`scripts/verify-stable-sdk-host-sample-packages.sh` / `.ps1`** — end-to-end local-feed verification.
- **`.github/workflows/full-platform-readiness-gate.yml`** — new step after building the project-reference sample; expanded path filters for hosting graph projects.
- **`.gitignore`** — `artifacts/`
- **Docs** — `docs/PUBLISHING.md` (operator checklist), updates to `SdkIntegrationGuide.md`, `sdk.md`, `ExecutionPlan.md`, `DocsIndex.md`.

## Manual steps for maintainers

See **`docs/PUBLISHING.md`**: NuGet.org API key, `dotnet nuget push`, git tag, release notes. When `Nexo.Hosting` gains new in-repo package dependencies, extend **`pack-nexo-hosting-graph`** accordingly.

Branch: `cursor/stable-sdk-nuget-gate-clean-e0c8`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c74db3be-5f99-44c9-9fe0-1006cebee0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c74db3be-5f99-44c9-9fe0-1006cebee0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

