### PR TITLE
Add Ghost devlog publisher and release workflow

### DIFF
--- a/.github/workflows/devlog-ghost-release.yml
+++ b/.github/workflows/devlog-ghost-release.yml
@@ -1,0 +1,76 @@
+# Pushes a Ghost draft when a GitHub Release is published (optional).
+# Automated runs: set repository variable DEVLOG_GHOST_ENABLED=true
+# Secrets: GHOST_URL, GHOST_ADMIN_API_KEY (see tools/devlog-ghost-publish/README.md)
+#
+# Manual test: Actions → Devlog Ghost publish → Run workflow (no variable required).
+
+name: Devlog Ghost publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      title:
+        description: "Post title"
+        required: true
+        default: "Devlog update"
+      body:
+        description: "Post body (HTML). Leave default for a short placeholder."
+        required: false
+        default: "<p>Milestone update (edit in Ghost).</p>"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || vars.DEVLOG_GHOST_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Write release notes (release event)
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${{ github.event.release.tag_name }}" --repo "${{ github.repository }}" \
+            --json body -q .body > "${{ runner.temp }}/release-notes.md"
+
+      - name: Write manual body (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          BODY: ${{ github.event.inputs.body }}
+        run: |
+          printf '%s\n' "$BODY" > "${{ runner.temp }}/release-notes.html"
+
+      - name: Publish draft to Ghost
+        env:
+          GHOST_URL: ${{ secrets.GHOST_URL }}
+          GHOST_ADMIN_API_KEY: ${{ secrets.GHOST_ADMIN_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TITLE="${{ github.event.inputs.title }}"
+          else
+            NAME="${{ github.event.release.name }}"
+            TAG="${{ github.event.release.tag_name }}"
+            if [ -n "$NAME" ] && [ "$NAME" != "$TAG" ]; then
+              TITLE="$NAME"
+            else
+              TITLE="Release: $TAG"
+            fi
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            node tools/devlog-ghost-publish/publish.mjs \
+              --title "$TITLE" \
+              --html-file "${{ runner.temp }}/release-notes.html" \
+              --status draft
+          else
+            node tools/devlog-ghost-publish/publish.mjs \
+              --title "$TITLE" \
+              --markdown-file "${{ runner.temp }}/release-notes.md" \
+              --status draft
+          fi

--- a/tools/devlog-ghost-publish/README.md
+++ b/tools/devlog-ghost-publish/README.md
@@ -1,0 +1,33 @@
+# Devlog → Ghost (draft publisher)
+
+Creates a **draft** (or published) post on your Ghost site using the [Admin API](https://ghost.org/docs/admin-api/).
+
+## One-time: Ghost
+
+1. Create a site on [Ghost(Pro)](https://ghost.org/pricing/) or self-host Ghost.
+2. Admin → **Settings → Integrations → Add custom integration** → copy the **Admin API Key** (`id:secret`).
+
+## GitHub Actions
+
+Add repository **secrets**:
+
+| Secret | Value |
+|--------|--------|
+| `GHOST_URL` | `https://your-ghost-host.com` (no trailing slash) |
+| `GHOST_ADMIN_API_KEY` | Admin API key from Ghost |
+
+Releases: publishing a [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) runs `.github/workflows/devlog-ghost-release.yml` and opens a Ghost **draft** titled `Release: <tag>`.
+
+Manual run: **Actions → Devlog Ghost publish → Run workflow** (optional title/body; body defaults to a placeholder).
+
+## Local test
+
+```bash
+export GHOST_URL="https://your-ghost-host.com"
+export GHOST_ADMIN_API_KEY="paste:id:here"
+echo "<p>Hello from Nexo tooling.</p>" | node publish.mjs --title "Test draft"
+```
+
+## Video / interactive posts
+
+Edit the draft in Ghost: add video blocks (YouTube/Vimeo/upload) or embed HTML (CodePen, demos). This tool only seeds the draft from release notes.

--- a/tools/devlog-ghost-publish/package.json
+++ b/tools/devlog-ghost-publish/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "devlog-ghost-publish",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "publish": "node publish.mjs"
+  }
+}

--- a/tools/devlog-ghost-publish/publish.mjs
+++ b/tools/devlog-ghost-publish/publish.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Creates a draft post on a Ghost blog via the Admin API.
+ * Env: GHOST_URL, GHOST_ADMIN_API_KEY (format id:secret from Ghost Admin → Integrations).
+ */
+import crypto from "node:crypto";
+import process from "node:process";
+
+function usage() {
+  console.error(`Usage:
+  publish.mjs --title "..." [--html-file path] [--html-string "..."] [--markdown-file path] [--status draft|published]
+
+Or pipe HTML on stdin (title still required):
+  cat body.html | publish.mjs --title "..."
+
+Environment:
+  GHOST_URL              e.g. https://blog.example.com (no trailing slash)
+  GHOST_ADMIN_API_KEY    Admin API key from Ghost (id:secret)`);
+}
+
+function parseArgs(argv) {
+  const out = {
+    title: null,
+    htmlFile: null,
+    htmlString: null,
+    markdownFile: null,
+    status: "draft",
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--title" && argv[i + 1]) {
+      out.title = argv[++i];
+    } else if (a === "--html-file" && argv[i + 1]) {
+      out.htmlFile = argv[++i];
+    } else if (a === "--html-string" && argv[i + 1]) {
+      out.htmlString = argv[++i];
+    } else if (a === "--markdown-file" && argv[i + 1]) {
+      out.markdownFile = argv[++i];
+    } else if (a === "--status" && argv[i + 1]) {
+      out.status = argv[++i];
+    } else if (a === "--help" || a === "-h") {
+      usage();
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function base64UrlEncode(data) {
+  return Buffer.from(data)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function ghostAdminToken(adminApiKey) {
+  const parts = adminApiKey.split(":");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error("GHOST_ADMIN_API_KEY must be id:secret from Ghost Admin → Integrations");
+  }
+  const [keyId, secretHex] = parts;
+  const header = { alg: "HS256", typ: "JWT", kid: keyId };
+  const iat = Math.floor(Date.now() / 1000);
+  const payload = { iat, exp: iat + 300, aud: "/admin/" };
+  const headerSeg = base64UrlEncode(JSON.stringify(header));
+  const payloadSeg = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${headerSeg}.${payloadSeg}`;
+  const secret = Buffer.from(secretHex, "hex");
+  const sig = crypto.createHmac("sha256", secret).update(signingInput).digest("base64");
+  const sigSeg = sig.replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+  return `${signingInput}.${sigSeg}`;
+}
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Turn plain GitHub release notes into simple HTML (paragraphs + line breaks). Escapes HTML. */
+function releaseMarkdownToHtml(markdown) {
+  if (!markdown || !markdown.trim()) {
+    return "<p><em>(No release notes provided.)</em></p>";
+  }
+  return markdown
+    .split(/\n\n+/)
+    .map((block) => `<p>${escapeHtml(block).replace(/\n/g, "<br/>")}</p>`)
+    .join("\n");
+}
+
+function normalizeGhostUrl(url) {
+  const u = (url || "").trim().replace(/\/+$/, "");
+  if (!u.startsWith("http://") && !u.startsWith("https://")) {
+    throw new Error("GHOST_URL must start with https:// or http://");
+  }
+  return u;
+}
+
+async function readHtml(args, stdinHtml) {
+  if (stdinHtml) {
+    return stdinHtml;
+  }
+  if (args.htmlString) {
+    return args.htmlString;
+  }
+  if (args.htmlFile) {
+    const fs = await import("node:fs/promises");
+    return fs.readFile(args.htmlFile, "utf8");
+  }
+  if (args.markdownFile) {
+    const fs = await import("node:fs/promises");
+    const md = await fs.readFile(args.markdownFile, "utf8");
+    return releaseMarkdownToHtml(md);
+  }
+  throw new Error("Provide --html-file, --html-string, --markdown-file, or pipe HTML on stdin");
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!args.title) {
+    usage();
+    process.exit(1);
+  }
+  if (args.status !== "draft" && args.status !== "published") {
+    console.error('status must be "draft" or "published"');
+    process.exit(1);
+  }
+
+  const ghostUrl = normalizeGhostUrl(process.env.GHOST_URL || "");
+  const adminKey = process.env.GHOST_ADMIN_API_KEY || "";
+  if (!ghostUrl || !adminKey) {
+    console.error("Missing GHOST_URL or GHOST_ADMIN_API_KEY");
+    process.exit(1);
+  }
+
+  let stdinHtml = "";
+  if (!args.htmlFile && !args.htmlString && !args.markdownFile) {
+    stdinHtml = await new Promise((resolve, reject) => {
+      const chunks = [];
+      process.stdin.on("data", (c) => chunks.push(c));
+      process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+      process.stdin.on("error", reject);
+    });
+  }
+
+  const html = await readHtml(args, stdinHtml.trim() || null);
+  if (!html || !html.trim()) {
+    console.error("HTML body is empty");
+    process.exit(1);
+  }
+
+  const token = ghostAdminToken(adminKey);
+  const endpoint = `${ghostUrl}/ghost/api/admin/posts/?source=html`;
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Ghost ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      posts: [
+        {
+          title: args.title,
+          html,
+          status: args.status,
+        },
+      ],
+    }),
+  });
+
+  const text = await res.text();
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = null;
+  }
+
+  if (!res.ok) {
+    console.error("Ghost API error:", res.status, text);
+    process.exit(1);
+  }
+
+  const post = json?.posts?.[0];
+  if (!post) {
+    console.error("Unexpected response:", text);
+    process.exit(1);
+  }
+
+  console.log(JSON.stringify({ id: post.id, url: post.url, uuid: post.uuid, status: post.status }, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds in-repo tooling to create **Ghost** draft posts from GitHub Releases (or manual workflow runs), matching the recommended devlog flow: Squarespace stays the portfolio; Ghost hosts the engineering log on a subdomain you configure separately.

## What was added

- `tools/devlog-ghost-publish/publish.mjs` — Node 20+ script using the Ghost Admin API (JWT from `id:secret` key). Supports HTML file/string, markdown file (escaped paragraphs for release notes), or stdin HTML.
- `tools/devlog-ghost-publish/README.md` — setup: Ghost integration key, GitHub secrets, local test.
- `.github/workflows/devlog-ghost-release.yml` — on **published** releases, writes release body to a temp file and creates a **draft** in Ghost. **workflow_dispatch** works without the repo variable for smoke tests. Release automation is gated by repository variable `DEVLOG_GHOST_ENABLED=true`.

## Operator setup (after merge)

1. Create a Ghost site (Ghost(Pro) or self-hosted).
2. Ghost Admin → Settings → Integrations → custom integration → copy **Admin API Key**.
3. GitHub repo → **Secrets**: `GHOST_URL`, `GHOST_ADMIN_API_KEY`.
4. GitHub repo → **Variables**: `DEVLOG_GHOST_ENABLED` = `true` (optional; manual dispatch works without it).
5. Link `blog.yourdomain.com` from Squarespace.

## Notes

- This does not create the Ghost account or DNS; those remain manual one-time steps.
- Release notes are converted to simple HTML with HTML escaping (safe default). Rich markdown is not fully rendered; refine drafts in Ghost and add video/embeds there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd4ea23e-177c-4bcb-b359-f02373b459fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd4ea23e-177c-4bcb-b359-f02373b459fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

