### PR TITLE
Dev ergonomics: shared UnitTest bridge, coverage gate, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      xunit:
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/core-domain-coverage.yml
+++ b/.github/workflows/core-domain-coverage.yml
@@ -1,0 +1,46 @@
+# Line coverage for Nexo.Core.Domain exercised by Nexo.Tests.Domain (xUnit bridge + UnitTestBase).
+name: Core domain coverage
+
+on:
+  push:
+    branches: [master, main, "cursor/**"]
+    paths:
+      - ".github/workflows/core-domain-coverage.yml"
+      - "src/Nexo.Core.Domain/**"
+      - "src/Nexo.Core.Application/Testing/**"
+      - "src/Nexo.Infrastructure/Testing/**"
+      - "src/Nexo.Tests.Domain/**"
+      - "Directory.Packages.props"
+      - "Directory.Build.props"
+  pull_request:
+    paths:
+      - ".github/workflows/core-domain-coverage.yml"
+      - "src/Nexo.Core.Domain/**"
+      - "src/Nexo.Core.Application/Testing/**"
+      - "src/Nexo.Infrastructure/Testing/**"
+      - "src/Nexo.Tests.Domain/**"
+      - "Directory.Packages.props"
+      - "Directory.Build.props"
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Test with line coverage (Nexo.Core.Domain)
+        run: |
+          mkdir -p CoverageReports
+          dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj \
+            /p:CollectCoverage=true \
+            /p:CoverletOutput="$(pwd)/CoverageReports/domain.opencover.xml" \
+            /p:CoverletOutputFormat=opencover \
+            /p:Include="[Nexo.Core.Domain]*" \
+            /p:Threshold=55 \
+            /p:ThresholdType=line

--- a/.github/workflows/core-domain-coverage.yml
+++ b/.github/workflows/core-domain-coverage.yml
@@ -8,8 +8,11 @@ on:
       - ".github/workflows/core-domain-coverage.yml"
       - "src/Nexo.Core.Domain/**"
       - "src/Nexo.Core.Application/Testing/**"
-      - "src/Nexo.Infrastructure/Testing/**"
+      - "src/Nexo.Infrastructure/**"
       - "src/Nexo.Tests.Domain/**"
+      - "src/Nexo.Tests.Application/**"
+      - "src/Nexo.Tests.Infrastructure/**"
+      - "src/Nexo.Tests.CLI/**"
       - "Directory.Packages.props"
       - "Directory.Build.props"
   pull_request:
@@ -17,13 +20,17 @@ on:
       - ".github/workflows/core-domain-coverage.yml"
       - "src/Nexo.Core.Domain/**"
       - "src/Nexo.Core.Application/Testing/**"
-      - "src/Nexo.Infrastructure/Testing/**"
+      - "src/Nexo.Infrastructure/**"
       - "src/Nexo.Tests.Domain/**"
+      - "src/Nexo.Tests.Application/**"
+      - "src/Nexo.Tests.Infrastructure/**"
+      - "src/Nexo.Tests.CLI/**"
       - "Directory.Packages.props"
       - "Directory.Build.props"
 
 jobs:
-  coverage:
+  domain-coverage:
+    name: domain-coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,5 +49,5 @@ jobs:
             /p:CoverletOutput="$(pwd)/CoverageReports/domain.opencover.xml" \
             /p:CoverletOutputFormat=opencover \
             /p:Include="[Nexo.Core.Domain]*" \
-            /p:Threshold=55 \
+            /p:Threshold=60 \
             /p:ThresholdType=line

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -31,6 +31,7 @@ on:
       - 'src/Nexo.Infrastructure/**'
       - 'src/Nexo.BackgroundAgents/**'
       - 'src/Nexo.CLI/**'
+      - 'src/Nexo.Tests.Domain/**'
 
 jobs:
   cross-platform:

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -32,6 +32,8 @@ on:
       - 'src/Nexo.BackgroundAgents/**'
       - 'src/Nexo.CLI/**'
       - 'src/Nexo.Tests.Domain/**'
+      - 'src/Nexo.Tests.Application/**'
+      - 'src/Nexo.Tests.CLI/**'
 
 jobs:
   cross-platform:

--- a/.github/workflows/devcontainer-gate.yml
+++ b/.github/workflows/devcontainer-gate.yml
@@ -17,6 +17,7 @@ on:
       - "src/Nexo.Core.Application/**"
       - "src/Nexo.Infrastructure/**"
       - "src/Nexo.Tests.Infrastructure/**"
+      - "Nexo.LocalDevCore.slnf"
   pull_request:
     paths:
       - ".github/workflows/devcontainer-gate.yml"
@@ -29,6 +30,7 @@ on:
       - "src/Nexo.Core.Application/**"
       - "src/Nexo.Infrastructure/**"
       - "src/Nexo.Tests.Infrastructure/**"
+      - "Nexo.LocalDevCore.slnf"
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,13 @@ Thumbs.db
 
 # Test results
 TestResults/
+CoverageReports/
 test-results/
 test-reports/
 *.trx
 *.coverage
+coverage.opencover.xml
+*.opencover.xml
 *.dmp
 
 # Package files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ dotnet build Nexo.LocalDevCore.slnf -v minimal
 ## Testing: xUnit vs. `UnitTestBase`
 
 - **xUnit** suites (for example `Nexo.Tests.Infrastructure`) run with normal `dotnet test` filters.
-- **`UnitTestBase`** tests are executed by **`ITestRunner`** / **`TestRunnerAdapter`** (same path as the CLI). In **`Nexo.Tests.Domain`**, an xUnit **theory** bridges each `UnitTestBase` type so **`dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj`** always runs those tests.
+- **`UnitTestBase`** tests are executed by **`ITestRunner`** / **`TestRunnerAdapter`** (same path as the CLI). **`UnitTestFrameworkBridge`** (in `Nexo.Infrastructure`) exposes **`UnitTestBridgeTests`** in **`Nexo.Tests.Domain`**, **`Nexo.Tests.Application`**, **`Nexo.Tests.Infrastructure`**, and **`Nexo.Tests.CLI`** so `dotnet test` on those projects runs most framework suites. A few types are skipped when they need a special layout or host (see `docs/architecture/TestingModel.md`).
 
 High-level architecture notes: `docs/architecture/README.md`. SDK vs. `net8.0` / `net9.0`: `docs/architecture/DotnetVersions.md`.
 
@@ -63,6 +63,9 @@ Run the minimal local quality bar:
 ```bash
 make test
 dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj
+dotnet test src/Nexo.Tests.Application/Nexo.Tests.Application.csproj
+dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0
+dotnet test src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
 dotnet run --project src/Nexo.CLI -- --help
 dotnet run --project src/Nexo.CLI -- pipeline validate --template <template.json>
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,22 @@ dotnet run --project src/Nexo.CLI -- --help
 
 **Remote:** connect over **Remote SSH**, open the repo on the remote machine, then **Reopen in Container** there so the toolchain comes from the image, not from manual packages on the host.
 
+## Faster local restore (subset solution)
+
+Full `Nexo.sln` can require optional workloads (for example MAUI). For CLI plus core tests without opening every project, use the solution filter **`Nexo.LocalDevCore.slnf`**:
+
+```bash
+dotnet restore Nexo.LocalDevCore.slnf
+dotnet build Nexo.LocalDevCore.slnf -v minimal
+```
+
+## Testing: xUnit vs. `UnitTestBase`
+
+- **xUnit** suites (for example `Nexo.Tests.Infrastructure`) run with normal `dotnet test` filters.
+- **`UnitTestBase`** tests are executed by **`ITestRunner`** / **`TestRunnerAdapter`** (same path as the CLI). In **`Nexo.Tests.Domain`**, an xUnit **theory** bridges each `UnitTestBase` type so **`dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj`** always runs those tests.
+
+High-level architecture notes: `docs/architecture/README.md`. SDK vs. `net8.0` / `net9.0`: `docs/architecture/DotnetVersions.md`.
+
 ## Prerequisites (native escape hatch)
 
 Use this only when you cannot use the dev container or other Docker workflows:
@@ -46,6 +62,7 @@ Run the minimal local quality bar:
 
 ```bash
 make test
+dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj
 dotnet run --project src/Nexo.CLI -- --help
 dotnet run --project src/Nexo.CLI -- pipeline validate --template <template.json>
 ```

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -140,6 +140,7 @@
     <PackageVersion Include="xunit" Version="2.6.6" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
-.PHONY: build test test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary clean-test-artifacts test-readiness-gate
+.PHONY: build build-core restore-core test test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary clean-test-artifacts test-readiness-gate
 
 # Build the solution
 build:
 	dotnet build
+
+# Restore/build a small slice (CLI + domain tests + infra tests) — avoids full Nexo.sln workload requirements
+restore-core:
+	dotnet restore Nexo.LocalDevCore.slnf
+
+build-core:
+	dotnet build Nexo.LocalDevCore.slnf -v minimal
 
 # Run tests locally (blame-hang-timeout prevents indefinite freeze from hung tests)
 # --blame-hang-dump-type none avoids 6GB+ hang dumps that accumulate in TestResults/

--- a/Nexo.LocalDevCore.slnf
+++ b/Nexo.LocalDevCore.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "Nexo.sln",
+    "projects": [
+      "src/Nexo.CLI/Nexo.CLI.csproj",
+      "src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj",
+      "src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Nexo operates entirely on infrastructure you control. Cloud providers are opt-in
 
 Repository: <https://github.com/IanFrelinger/Nexo>
 
+Architecture notes for contributors and reviewers: **`docs/architecture/`** (trust boundaries, testing model, .NET SDK vs. target frameworks).
+
 ## Default workflow
 
 1. **Develop** — [Quick Start (5 minutes)](#quick-start-5-minutes) → **Lane A** → **Dev Container** (first subsection).

--- a/docs/architecture/DotnetVersions.md
+++ b/docs/architecture/DotnetVersions.md
@@ -1,0 +1,13 @@
+# .NET SDK and target frameworks
+
+## SDK version (`global.json`)
+
+The repository pins the **.NET SDK** to **9.x** (see `global.json` with `rollForward: latestMinor`). Developer images and CI often use **`mcr.microsoft.com/dotnet/sdk:9.0`** so everyone builds with the same MSBuild and C# language version.
+
+## Target frameworks
+
+Many libraries and executables target **`net8.0`** (current LTS for shipped artifacts). That is intentional: runtime and deployment baselines stay on LTS while the **toolchain** stays current.
+
+Some test projects multi-target **`net8.0` and `net9.0`** (for example `Nexo.Tests.Infrastructure`) so CI can exercise both runtimes where workflows pass `-f net9.0`.
+
+**Rule of thumb:** use the SDK from `global.json` to build; ship or run on `net8.0` unless a specific project or workflow documents a different TFM.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,9 @@
+# Architecture overview
+
+High-level maps of how Nexo is structured. For day-to-day commands, see the repository root `README.md` and `CONTRIBUTING.md`.
+
+| Document | Contents |
+| -------- | -------- |
+| [Trust and execution boundaries](TrustAndExecutionBoundaries.md) | Where trust is decided, how requests cross layers, and what runs locally vs. on peers. |
+| [Testing model](TestingModel.md) | Relationship between xUnit tests, `UnitTestBase` / `ITestRunner`, and CI. |
+| [.NET SDK and target frameworks](DotnetVersions.md) | Why `global.json` pins SDK 9.x while many libraries target `net8.0`. |

--- a/docs/architecture/TestingModel.md
+++ b/docs/architecture/TestingModel.md
@@ -1,0 +1,19 @@
+# Testing model
+
+Nexo uses **two complementary styles** of automated tests.
+
+## xUnit (VSTest)
+
+Projects such as `Nexo.Tests.Application` and `Nexo.Tests.Infrastructure` use **xUnit** directly. They are the primary targets for `dotnet test` in CI matrices (`FullyQualifiedName` filters, TRX loggers, etc.).
+
+## Framework tests (`UnitTestBase` + `ITestRunner`)
+
+Some suites inherit **`UnitTestBase`** (which extends **`TestBase`**) and implement **`ExecuteAsync`**. The infrastructure **`TestRunnerAdapter`** discovers those types by reflection and runs them; the **CLI** uses **`ITestRunner`** for the same pipeline.
+
+**`Nexo.Tests.Domain`** now also exposes an **xUnit bridge** (`UnitTestBridgeTests`) so `dotnet test src/Nexo.Tests.Domain` runs each concrete `UnitTestBase` through `ITestRunner`, matching CLI behavior while appearing as normal VSTest cases.
+
+## Local commands
+
+- **Domain framework tests via xUnit:** `dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj`
+- **Broader local bar:** `make test` (see `Makefile`; uses blame-hang options)
+- **CI-style verification:** `make ci-verify` or `dotnet run --project src/Nexo.CLI -- ci verify`

--- a/docs/architecture/TestingModel.md
+++ b/docs/architecture/TestingModel.md
@@ -10,10 +10,18 @@ Projects such as `Nexo.Tests.Application` and `Nexo.Tests.Infrastructure` use **
 
 Some suites inherit **`UnitTestBase`** (which extends **`TestBase`**) and implement **`ExecuteAsync`**. The infrastructure **`TestRunnerAdapter`** discovers those types by reflection and runs them; the **CLI** uses **`ITestRunner`** for the same pipeline.
 
-**`Nexo.Tests.Domain`** now also exposes an **xUnit bridge** (`UnitTestBridgeTests`) so `dotnet test src/Nexo.Tests.Domain` runs each concrete `UnitTestBase` through `ITestRunner`, matching CLI behavior while appearing as normal VSTest cases.
+**`UnitTestFrameworkBridge`** (in `Nexo.Infrastructure`) runs each concrete `UnitTestBase` through that runner. Test assemblies **`Nexo.Tests.Domain`**, **`Nexo.Tests.Application`**, **`Nexo.Tests.Infrastructure`**, and **`Nexo.Tests.CLI`** each expose **`UnitTestBridgeTests`** (xUnit theory) so `dotnet test` on those projects executes the same framework suites as the CLI. Infrastructure discovery skips **`SimpleTestForRunner`** (helper for **`TestRunnerAdapterTests`**), **`DependencyWrappingArchitectureTests`** (requires the **`copy-assemblies`** layout; run it via the full **`Nexo.Tests.Infrastructure`** test flow or filtered `dotnet test` after that target), and **`DoctorCommandTests`** (expects repo layout / host health; run via **`dotnet test`** with filter **`FullyQualifiedName~DoctorCommandTests`** or the CLI integration lane).
+
+## Merge policy (GitHub)
+
+To block merges when domain line coverage regresses, in GitHub go to **Settings → Branches → Branch protection rule**, enable **Require status checks to pass**, and add **`domain-coverage`** (the job id from **Core domain coverage**). If the UI only shows the workflow name, pick the check that corresponds to that workflow’s latest green run.
 
 ## Local commands
 
-- **Domain framework tests via xUnit:** `dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj`
+- **Framework suites via xUnit:**  
+  `dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj`  
+  `dotnet test src/Nexo.Tests.Application/Nexo.Tests.Application.csproj`  
+  `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj`  
+  `dotnet test src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj`
 - **Broader local bar:** `make test` (see `Makefile`; uses blame-hang options)
 - **CI-style verification:** `make ci-verify` or `dotnet run --project src/Nexo.CLI -- ci verify`

--- a/docs/architecture/TrustAndExecutionBoundaries.md
+++ b/docs/architecture/TrustAndExecutionBoundaries.md
@@ -1,0 +1,18 @@
+# Trust and execution boundaries
+
+Nexo separates **policy and trust** from **transport and UI**. The following boundaries are the usual mental model when reading the codebase.
+
+## Layers
+
+1. **Domain (`Nexo.Core.Domain`)** — Entities, value objects, and domain rules. No knowledge of HTTP, gRPC, or hosting.
+2. **Application (`Nexo.Core.Application`)** — Use cases, ports (interfaces), and orchestration contracts. Mediates between domain and the outside world without binding to a specific host.
+3. **Infrastructure (`Nexo.Infrastructure`)** — Adapters: persistence, `ITestRunner` (reflection-based test discovery), external tools, and similar implementations of application ports.
+4. **Hosting (`Nexo.Hosting`, `Nexo.API`)** — Composition root for processes: dependency injection, HTTP APIs, and service registration (including `ITestRunner` → `TestRunnerAdapter`).
+
+## Trust and data flow
+
+- **Portal and API** surface operator and developer actions; they should not bypass application use cases for privileged operations.
+- **Background agents** and **mesh** features route work according to configured trust tiers and policies (see product docs under `docs/` for operator-facing detail).
+- **Air-gapped and no-network CI** workflows validate that selected paths do not assume outbound network access; they complement but do not replace a full threat model review for your deployment.
+
+For concrete configuration keys and environment variables, use `docs/Configuration.md` (repository root `docs/`).

--- a/src/Nexo.Core.Application/Testing/Abstractions/UnitTestBase.cs
+++ b/src/Nexo.Core.Application/Testing/Abstractions/UnitTestBase.cs
@@ -56,6 +56,12 @@ public abstract class UnitTestBase : TestBase
         {
             // Expected
         }
+        catch (Exception ex) when (ex is not AssertionException)
+        {
+            throw new AssertionException(
+                message ?? $"Assertion failed: expected {typeof(TException).Name}, but {ex.GetType().Name} was thrown: {ex.Message}",
+                ex);
+        }
     }
 
     protected async Task AssertThrowsAsync<TException>(Func<Task> action, string? message = null) where TException : Exception
@@ -68,6 +74,12 @@ public abstract class UnitTestBase : TestBase
         catch (TException)
         {
             // Expected
+        }
+        catch (Exception ex) when (ex is not AssertionException)
+        {
+            throw new AssertionException(
+                message ?? $"Assertion failed: expected {typeof(TException).Name}, but {ex.GetType().Name} was thrown: {ex.Message}",
+                ex);
         }
     }
 }

--- a/src/Nexo.Core.Application/Testing/Abstractions/UnitTestBase.cs
+++ b/src/Nexo.Core.Application/Testing/Abstractions/UnitTestBase.cs
@@ -56,12 +56,6 @@ public abstract class UnitTestBase : TestBase
         {
             // Expected
         }
-        catch (Exception ex) when (ex is not AssertionException)
-        {
-            throw new AssertionException(
-                message ?? $"Assertion failed: expected {typeof(TException).Name}, but {ex.GetType().Name} was thrown: {ex.Message}",
-                ex);
-        }
     }
 
     protected async Task AssertThrowsAsync<TException>(Func<Task> action, string? message = null) where TException : Exception
@@ -74,12 +68,6 @@ public abstract class UnitTestBase : TestBase
         catch (TException)
         {
             // Expected
-        }
-        catch (Exception ex) when (ex is not AssertionException)
-        {
-            throw new AssertionException(
-                message ?? $"Assertion failed: expected {typeof(TException).Name}, but {ex.GetType().Name} was thrown: {ex.Message}",
-                ex);
         }
     }
 }

--- a/src/Nexo.Infrastructure/Agent/Adapters/AgentRegistryAdapter.cs
+++ b/src/Nexo.Infrastructure/Agent/Adapters/AgentRegistryAdapter.cs
@@ -112,8 +112,21 @@ public class AgentRegistryAdapter : IAgentRegistry
             .OrderByDescending(c => c.GetParameters().Length)
             .FirstOrDefault();
         if (ctor == null) return new Dictionary<string, string>();
-        return ctor.GetParameters()
-            .ToDictionary(p => p.Name ?? "param", p => p.ParameterType.Name, StringComparer.OrdinalIgnoreCase);
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in ctor.GetParameters())
+        {
+            var baseName = string.IsNullOrEmpty(p.Name) ? "param" : p.Name;
+            var key = baseName;
+            var n = 0;
+            while (dict.ContainsKey(key))
+            {
+                key = $"{baseName}_{++n}";
+            }
+
+            dict[key] = p.ParameterType.Name;
+        }
+
+        return dict;
     }
 }
 

--- a/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+++ b/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
@@ -47,6 +47,10 @@
     <PackageReference Include="Polly" />
     <PackageReference Include="LlamaSharp" />
     <PackageReference Include="LLamaSharp.Backend.Cpu" />
+    <PackageReference Include="xunit">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Nexo.Infrastructure/Testing/UnitTestFrameworkBridge.cs
+++ b/src/Nexo.Infrastructure/Testing/UnitTestFrameworkBridge.cs
@@ -1,36 +1,51 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nexo.Core.Application.Testing.Abstractions;
 using Nexo.Core.Application.Testing.Ports;
-using Nexo.Infrastructure.Testing;
 using Xunit;
 
-namespace Nexo.Tests.Domain.Framework;
+namespace Nexo.Infrastructure.Testing;
 
 /// <summary>
-/// Runs <see cref="UnitTestBase"/> tests through <see cref="ITestRunner"/> so they participate in VSTest/xUnit.
+/// Runs concrete <see cref="UnitTestBase"/> types through <see cref="ITestRunner"/> so they appear in VSTest/xUnit.
 /// </summary>
-public static class FrameworkTestExecutor
+public static class UnitTestFrameworkBridge
 {
     /// <summary>
-    /// Discovers concrete <see cref="UnitTestBase"/> types in this assembly (excludes nested helper types).
+    /// Discovers concrete <see cref="UnitTestBase"/> types in <paramref name="assembly"/> (public only; skips nested private types).
     /// </summary>
-    public static IReadOnlyList<Type> DiscoverUnitTestTypes()
+    public static IReadOnlyList<Type> DiscoverUnitTestTypesFromAssembly(Assembly assembly)
     {
-        return typeof(FrameworkTestExecutor).Assembly
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var types = assembly
             .GetTypes()
             .Where(t =>
                 t is { IsClass: true, IsAbstract: false } &&
                 t.IsSubclassOf(typeof(UnitTestBase)) &&
                 (!t.IsNested || t.IsNestedPublic))
-            .OrderBy(t => t.FullName, StringComparer.Ordinal)
-            .ToList();
+            .AsEnumerable();
+
+        if (string.Equals(assembly.GetName().Name, "Nexo.Tests.Infrastructure", StringComparison.Ordinal))
+        {
+            types = types.Where(t =>
+                !string.Equals(t.Name, "SimpleTestForRunner", StringComparison.Ordinal) &&
+                !string.Equals(t.Name, "DependencyWrappingArchitectureTests", StringComparison.Ordinal));
+        }
+
+        if (string.Equals(assembly.GetName().Name, "Nexo.Tests.CLI", StringComparison.Ordinal))
+        {
+            types = types.Where(t => !string.Equals(t.Name, "DoctorCommandTests", StringComparison.Ordinal));
+        }
+
+        return types.OrderBy(t => t.FullName, StringComparer.Ordinal).ToList();
     }
 
     /// <summary>
-    /// Executes a single framework test type using the same discovery path as the CLI <c>ITestRunner</c>.
+    /// Executes one <see cref="UnitTestBase"/> type using the same path as the CLI-hosted <see cref="ITestRunner"/>.
     /// </summary>
-    public static async Task ExecuteAsync(Type testType, CancellationToken cancellationToken = default)
+    public static async Task ExecuteUnitTestAsync(Type testType, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(testType);
         if (!testType.IsSubclassOf(typeof(UnitTestBase)) || testType.IsAbstract)

--- a/src/Nexo.Tests.Application/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.Application/Framework/UnitTestBridgeTests.cs
@@ -2,11 +2,10 @@ using System.Reflection;
 using Nexo.Infrastructure.Testing;
 using Xunit;
 
-namespace Nexo.Tests.Domain.Framework;
+namespace Nexo.Tests.Application.Framework;
 
 /// <summary>
-/// Bridges Nexo <c>UnitTestBase</c> tests to xUnit so <c>dotnet test src/Nexo.Tests.Domain</c> runs the same
-/// logic as the infrastructure <c>ITestRunner</c> used by the CLI.
+/// Bridges <c>UnitTestBase</c> suites in this assembly to xUnit / VSTest via <see cref="UnitTestFrameworkBridge"/>.
 /// </summary>
 public sealed class UnitTestBridgeTests
 {

--- a/src/Nexo.Tests.Application/Nexo.Tests.Application.csproj
+++ b/src/Nexo.Tests.Application/Nexo.Tests.Application.csproj
@@ -8,15 +8,21 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nexo.Tests.CLI/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.CLI/Framework/UnitTestBridgeTests.cs
@@ -2,11 +2,10 @@ using System.Reflection;
 using Nexo.Infrastructure.Testing;
 using Xunit;
 
-namespace Nexo.Tests.Domain.Framework;
+namespace Nexo.Tests.CLI.Framework;
 
 /// <summary>
-/// Bridges Nexo <c>UnitTestBase</c> tests to xUnit so <c>dotnet test src/Nexo.Tests.Domain</c> runs the same
-/// logic as the infrastructure <c>ITestRunner</c> used by the CLI.
+/// Bridges <c>UnitTestBase</c> suites in this assembly to xUnit / VSTest via <see cref="UnitTestFrameworkBridge"/>.
 /// </summary>
 public sealed class UnitTestBridgeTests
 {

--- a/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
+++ b/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
@@ -5,13 +5,19 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nexo.Tests.Domain/Framework/FrameworkTestExecutor.cs
+++ b/src/Nexo.Tests.Domain/Framework/FrameworkTestExecutor.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Ports;
+using Nexo.Infrastructure.Testing;
+using Xunit;
+
+namespace Nexo.Tests.Domain.Framework;
+
+/// <summary>
+/// Runs <see cref="UnitTestBase"/> tests through <see cref="ITestRunner"/> so they participate in VSTest/xUnit.
+/// </summary>
+public static class FrameworkTestExecutor
+{
+    /// <summary>
+    /// Discovers concrete <see cref="UnitTestBase"/> types in this assembly (excludes nested helper types).
+    /// </summary>
+    public static IReadOnlyList<Type> DiscoverUnitTestTypes()
+    {
+        return typeof(FrameworkTestExecutor).Assembly
+            .GetTypes()
+            .Where(t =>
+                t is { IsClass: true, IsAbstract: false } &&
+                t.IsSubclassOf(typeof(UnitTestBase)) &&
+                (!t.IsNested || t.IsNestedPublic))
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Executes a single framework test type using the same discovery path as the CLI <c>ITestRunner</c>.
+    /// </summary>
+    public static async Task ExecuteAsync(Type testType, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(testType);
+        if (!testType.IsSubclassOf(typeof(UnitTestBase)) || testType.IsAbstract)
+        {
+            throw new ArgumentException($"Type must be a concrete subclass of {nameof(UnitTestBase)}.", nameof(testType));
+        }
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton<ITestRunner, TestRunnerAdapter>();
+        await using var provider = services.BuildServiceProvider();
+        var runner = provider.GetRequiredService<ITestRunner>();
+
+        var filter = testType.Name;
+        var execution = await runner.RunTestsAsync(filter, cancellationToken: cancellationToken);
+
+        var match = execution.Results.FirstOrDefault(r =>
+            string.Equals(r.Name, testType.Name, StringComparison.Ordinal));
+
+        if (match is null)
+        {
+            var ran = string.Join(", ", execution.Results.Select(r => r.Name));
+            Assert.Fail(
+                $"No result for '{testType.Name}'. TotalTests={execution.TotalTests}. Ran: [{ran}]");
+        }
+
+        AssertPassed(match);
+    }
+
+    private static void AssertPassed(Nexo.Core.Application.Common.Models.TestResult match)
+    {
+        if (match.Passed)
+        {
+            return;
+        }
+
+        var detail = string.IsNullOrEmpty(match.ErrorMessage)
+            ? match.Message
+            : match.ErrorMessage;
+        var trace = string.IsNullOrEmpty(match.StackTrace) ? "" : Environment.NewLine + match.StackTrace;
+        Assert.Fail($"Framework test '{match.Name}' failed: {detail}{trace}");
+    }
+}

--- a/src/Nexo.Tests.Domain/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.Domain/Framework/UnitTestBridgeTests.cs
@@ -1,0 +1,30 @@
+using Xunit;
+
+namespace Nexo.Tests.Domain.Framework;
+
+/// <summary>
+/// Bridges Nexo <c>UnitTestBase</c> tests to xUnit so <c>dotnet test src/Nexo.Tests.Domain</c> runs the same
+/// logic as the infrastructure <c>ITestRunner</c> used by the CLI.
+/// </summary>
+public sealed class UnitTestBridgeTests
+{
+    public static TheoryData<Type> UnitTestTypes { get; } = BuildTheoryData();
+
+    private static TheoryData<Type> BuildTheoryData()
+    {
+        var data = new TheoryData<Type>();
+        foreach (var t in FrameworkTestExecutor.DiscoverUnitTestTypes())
+        {
+            data.Add(t);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(UnitTestTypes))]
+    public async Task Framework_unit_test_passes(Type testType)
+    {
+        await FrameworkTestExecutor.ExecuteAsync(testType);
+    }
+}

--- a/src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj
+++ b/src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +15,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Nexo.Tests.Infrastructure/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Framework/UnitTestBridgeTests.cs
@@ -2,11 +2,11 @@ using System.Reflection;
 using Nexo.Infrastructure.Testing;
 using Xunit;
 
-namespace Nexo.Tests.Domain.Framework;
+namespace Nexo.Tests.Infrastructure.Framework;
 
 /// <summary>
-/// Bridges Nexo <c>UnitTestBase</c> tests to xUnit so <c>dotnet test src/Nexo.Tests.Domain</c> runs the same
-/// logic as the infrastructure <c>ITestRunner</c> used by the CLI.
+/// Bridges <c>UnitTestBase</c> suites in this assembly to xUnit / VSTest via <see cref="UnitTestFrameworkBridge"/>.
+/// Excludes <c>SimpleTestForRunner</c> (helper exercised only from <c>TestRunnerAdapterTests</c>).
 /// </summary>
 public sealed class UnitTestBridgeTests
 {

--- a/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
+++ b/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -40,6 +41,10 @@
     <PackageReference Include="CsCheck" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Docker.DotNet" />
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the **`UnitTestBase` → xUnit** bridge across **`Nexo.Tests.Application`**, **`Nexo.Tests.Infrastructure`**, and **`Nexo.Tests.CLI`**, centralizes logic in **`Nexo.Infrastructure.UnitTestFrameworkBridge`**, raises the domain line coverage floor to **60%**, and names the coverage CI job **`domain-coverage`** so it is easy to require in branch protection.

## Changes

- **`UnitTestFrameworkBridge`** (`Nexo.Infrastructure`): discovers concrete `UnitTestBase` types per assembly; skips **`SimpleTestForRunner`**, **`DependencyWrappingArchitectureTests`** (needs `copy-assemblies` layout), and **`DoctorCommandTests`** (host/repo-dependent).
- **`UnitTestBridgeTests`** added to Application, Infrastructure, and CLI test projects; Domain project delegates to the shared bridge.
- **`AgentRegistryAdapter.GetAgentParameters`**: avoid duplicate dictionary keys when Moq proxy constructors expose duplicate parameter names.
- **Coverage workflow**: threshold **60%**; job id **`domain-coverage`**; path filters include `src/Nexo.Infrastructure/**` and related test projects.
- **`UnitTestBase.AssertThrows`**: reverted the “wrap wrong exception” change (it broke **`AnalyzeCodeHandlerComprehensiveTests`** cancellation handling).
- **Cross-platform workflow**: also triggers on **`Nexo.Tests.Application`** / **`Nexo.Tests.CLI`** path changes.

## Branch protection (manual)

In GitHub branch protection, require status check **`domain-coverage`** (see `docs/architecture/TestingModel.md`).

## Verification

- `dotnet test src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj`
- `dotnet test src/Nexo.Tests.Application/Nexo.Tests.Application.csproj`
- `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter FullyQualifiedName~UnitTestBridgeTests`
- `dotnet test src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj`
- `dotnet build src/Nexo.Infrastructure/Nexo.Infrastructure.csproj`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8373a0af-b26e-452b-a29d-68d2a489261d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8373a0af-b26e-452b-a29d-68d2a489261d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

