### PR TITLE
ci: layer-boundary workflow for runtime vs application PRs

### DIFF
--- a/.github/workflows/layer-boundary.yml
+++ b/.github/workflows/layer-boundary.yml
@@ -1,0 +1,88 @@
+# Enforces separation between kernel/runtime (`src/`) and application (`application/`).
+#
+# Enable required check: Settings → Rules → require status check "layer-boundary / verify".
+# See docs/contributing/Branch-layer-rules.md
+name: layer-boundary
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: layer-boundary-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce layer rules
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "::error::Missing PR base or head SHA."
+            exit 1
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)
+          echo "Base: $BASE_REF  Head: $HEAD_REF"
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          # --- Runtime bases: no application/ ---
+          case "$BASE_REF" in
+            master|main|runtime/*)
+              if echo "$CHANGED" | grep -q '^application/'; then
+                echo "::error::Base branch '$BASE_REF' is runtime/kernel-first. This PR changes application/ — retarget or remove those paths."
+                exit 1
+              fi
+              ;;
+          esac
+
+          # --- Application bases: no kernel src/ ---
+          case "$BASE_REF" in
+            application/*)
+              if echo "$CHANGED" | grep -q '^src/'; then
+                echo "::error::Base branch '$BASE_REF' is application-only. This PR changes src/ — open kernel changes against master/main instead."
+                exit 1
+              fi
+              ;;
+          esac
+
+          # --- Branch naming: avoid application/* → runtime base ---
+          case "$BASE_REF" in
+            master|main|runtime/*)
+              case "$HEAD_REF" in
+                application/*)
+                  echo "::error::Head branch '$HEAD_REF' is application-scoped; do not PR directly into '$BASE_REF'."
+                  exit 1
+                  ;;
+              esac
+              ;;
+          esac
+
+          # --- Branch naming: avoid runtime/* → application base ---
+          case "$BASE_REF" in
+            application/*)
+              case "$HEAD_REF" in
+                runtime/*)
+                  echo "::error::Head branch '$HEAD_REF' is runtime-scoped; do not PR into application base '$BASE_REF'."
+                  exit 1
+                  ;;
+              esac
+              ;;
+          esac
+
+          echo "Layer boundary checks passed."

--- a/docs/contributing/Branch-layer-rules.md
+++ b/docs/contributing/Branch-layer-rules.md
@@ -1,0 +1,26 @@
+# Branch layer rules (runtime vs application)
+
+CI workflow **`.github/workflows/layer-boundary.yml`** enforces:
+
+| Base branch | Rule |
+|-------------|------|
+| `master`, `main`, or `runtime/*` | PR must **not** change files under **`application/`** |
+| `application/*` | PR must **not** change files under **`src/`** (kernel) |
+| `master` / `main` / `runtime/*` | Head branch must **not** be named `application/*` |
+| `application/*` | Head branch must **not** be named `runtime/*` |
+
+## Enable required check on GitHub
+
+1. Repository **Settings → Rules → Rulesets** (or **Branches → Branch protection**).
+2. Target branches: e.g. `master`, `main`, `application/**`, `runtime/**` as needed.
+3. Enable **Require status checks to pass**.
+4. Add the check named **`layer-boundary`** (job **`verify`** appears as **`layer-boundary / verify`** in the checks list — require that job).
+
+Until the workflow runs once on a PR, the check may not appear in the search box; merge any PR that touches `.github/workflows/` first or run workflow manually via **Actions**.
+
+## Branch naming convention
+
+- **`application/feature-xyz`** — work that only touches `application/`, docs, tooling outside `src/`.
+- **`runtime/feature-xyz`** or topic branches off `master` — kernel changes under `src/`.
+
+If you do not use long-lived `application/*` integration branches, only the **runtime-base** rules apply until you create one.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`.github/workflows/layer-boundary.yml`** so CI can block incompatible merges between runtime and application layers.

### Rules enforced

| Base | Rejects |
|------|---------|
| `master`, `main`, `runtime/*` | Any changed path under **`application/`** |
| `application/*` | Any changed path under **`src/`** |
| `master` / `main` / `runtime/*` | Head branch named **`application/*`** |
| `application/*` | Head branch named **`runtime/*`** |

### Docs

- **`docs/contributing/Branch-layer-rules.md`** — how to enable the required check in GitHub Settings.

### After merge

In **Settings → Rules → Rulesets** (or Branch protection), require status check **`layer-boundary / verify`** on protected branches.

---

Naming convention for branches: `application/feature-x` vs `runtime/feature-x` or plain topic branches off `master` for kernel work.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

