### PR TITLE
test: optional Mapbox raster + vector tile black-box HTTP checks

### DIFF
--- a/src/Nexo.Tests.Infrastructure/External/MapboxTileResponseValidators.cs
+++ b/src/Nexo.Tests.Infrastructure/External/MapboxTileResponseValidators.cs
@@ -1,0 +1,36 @@
+using System.Net;
+
+namespace Nexo.Tests.Infrastructure.External;
+
+/// <summary>
+/// Shared assertions for Mapbox tile HTTP responses (used by live black-box tests).
+/// </summary>
+public static class MapboxTileResponseValidators
+{
+    public static void AssertRasterTileSuccess(HttpStatusCode status, string? contentType, ReadOnlySpan<byte> body)
+    {
+        if (status != HttpStatusCode.OK)
+            throw new InvalidOperationException($"Expected OK, got {status}.");
+
+        if (string.IsNullOrEmpty(contentType) || !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Expected image/* content type, got '{contentType}'.");
+
+        if (body.Length < 100)
+            throw new InvalidOperationException($"Expected non-trivial JPEG body, got {body.Length} bytes.");
+
+        if (!MapboxTileUrls.IsJpegImage(body))
+            throw new InvalidOperationException("Body does not start with JPEG SOI (FF D8).");
+    }
+
+    public static void AssertVectorTileSuccess(HttpStatusCode status, string? contentType, ReadOnlySpan<byte> body)
+    {
+        if (status != HttpStatusCode.OK)
+            throw new InvalidOperationException($"Expected OK, got {status}.");
+
+        if (!string.IsNullOrEmpty(contentType) && !MapboxTileUrls.IsLikelyVectorTileContentType(contentType))
+            throw new InvalidOperationException($"Unexpected Content-Type for vector tile: '{contentType}'.");
+
+        if (body.Length < 20)
+            throw new InvalidOperationException($"Expected non-trivial tile body, got {body.Length} bytes.");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/External/MapboxTileUrls.cs
+++ b/src/Nexo.Tests.Infrastructure/External/MapboxTileUrls.cs
@@ -1,0 +1,81 @@
+namespace Nexo.Tests.Infrastructure.External;
+
+/// <summary>
+/// Builds Mapbox Raster / Vector Tile API v4 URLs and validates Web Mercator tile indices.
+/// Used by integration tests; keep token out of logs and source control (pass via env only).
+/// </summary>
+public static class MapboxTileUrls
+{
+    public const string DefaultRasterTilesetId = "mapbox.satellite";
+    public const string DefaultVectorTilesetId = "mapbox.mapbox-streets-v8";
+    public const string RasterHost = "https://api.mapbox.com";
+
+    /// <summary>Throws if tile indices are invalid for standard XYZ Web Mercator tiling at zoom <paramref name="z"/>.</summary>
+    public static void ValidateWebMercatorTile(int z, int x, int y)
+    {
+        if (z < 0 || z > 30)
+            throw new ArgumentOutOfRangeException(nameof(z), z, "Zoom must be in [0, 30].");
+
+        var extent = 1 << z;
+        if (x < 0 || x >= extent)
+            throw new ArgumentOutOfRangeException(nameof(x), x, $"Tile X must be in [0, {extent - 1}] for z={z}.");
+        if (y < 0 || y >= extent)
+            throw new ArgumentOutOfRangeException(nameof(y), y, $"Tile Y must be in [0, {extent - 1}] for z={z}.");
+    }
+
+    /// <summary>
+    /// Raster tile URL, e.g. <c>.../v4/mapbox.satellite/0/0/0.jpg?access_token=...</c>.
+    /// </summary>
+    /// <param name="rasterSuffix">File suffix including dot, e.g. <c>.jpg</c> or <c>@2x.jpg</c>.</param>
+    public static string BuildRasterTileUrl(
+        string tilesetId,
+        int z,
+        int x,
+        int y,
+        string accessToken,
+        string rasterSuffix = ".jpg")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tilesetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+        ValidateWebMercatorTile(z, x, y);
+
+        var suffix = string.IsNullOrWhiteSpace(rasterSuffix) ? ".jpg" : rasterSuffix.Trim();
+        if (!suffix.StartsWith("@", StringComparison.Ordinal) && !suffix.StartsWith(".", StringComparison.Ordinal))
+            suffix = "." + suffix.TrimStart('.');
+
+        return $"{RasterHost}/v4/{Uri.EscapeDataString(tilesetId.Trim())}/{z}/{x}/{y}{suffix}?access_token={Uri.EscapeDataString(accessToken.Trim())}";
+    }
+
+    /// <summary>
+    /// Vector tile URL (MVT), e.g. <c>.../v4/mapbox.mapbox-streets-v8/0/0/0.vector.pbf?access_token=...</c>.
+    /// </summary>
+    public static string BuildVectorTileUrl(string tilesetId, int z, int x, int y, string accessToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tilesetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+        ValidateWebMercatorTile(z, x, y);
+
+        return $"{RasterHost}/v4/{Uri.EscapeDataString(tilesetId.Trim())}/{z}/{x}/{y}.vector.pbf?access_token={Uri.EscapeDataString(accessToken.Trim())}";
+    }
+
+    /// <summary>True if <paramref name="bytes"/> looks like JPEG (SOI marker).</summary>
+    public static bool IsJpegImage(ReadOnlySpan<byte> bytes) =>
+        bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8;
+
+    /// <summary>True if payload is gzip-compressed (common for vector tiles).</summary>
+    public static bool IsGzipPayload(ReadOnlySpan<byte> bytes) =>
+        bytes.Length >= 2 && bytes[0] == 0x1F && bytes[1] == 0x8B;
+
+    /// <summary>Heuristic: Mapbox vector tile responses often use these content types.</summary>
+    public static bool IsLikelyVectorTileContentType(string? mediaType)
+    {
+        if (string.IsNullOrEmpty(mediaType))
+            return true;
+
+        return mediaType.Contains("protobuf", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("octet-stream", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("mapbox-vector-tile", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("gzip", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("application/x-protobuf", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/External/MapboxWebMercatorTileMath.cs
+++ b/src/Nexo.Tests.Infrastructure/External/MapboxWebMercatorTileMath.cs
@@ -1,0 +1,35 @@
+namespace Nexo.Tests.Infrastructure.External;
+
+/// <summary>
+/// Web Mercator (EPSG:3857) tile index math for standard XYZ tiling used by Mapbox raster/vector APIs.
+/// </summary>
+public static class MapboxWebMercatorTileMath
+{
+    /// <summary>Validates zoom only; tile count at zoom z is a power of two.</summary>
+    public static void ValidateZoom(int z)
+    {
+        if (z < 0 || z > 30)
+            throw new ArgumentOutOfRangeException(nameof(z), z, "Zoom must be in [0, 30].");
+    }
+
+    /// <summary>
+    /// Converts WGS84 latitude/longitude in degrees to tile X/Y at zoom <paramref name="z"/> (XYZ scheme, y down).
+    /// Results are clamped to valid tile bounds for the zoom level.
+    /// </summary>
+    public static (int X, int Y) TileIndexFromLatLon(double latitudeDegrees, double longitudeDegrees, int z)
+    {
+        ValidateZoom(z);
+
+        var n = 1 << z;
+        var x = (int)Math.Floor((longitudeDegrees + 180.0) / 360.0 * n);
+        var latRad = latitudeDegrees * (Math.PI / 180.0);
+        var y = (int)Math.Floor(
+            (1.0 - Math.Log(Math.Tan(latRad) + 1.0 / Math.Cos(latRad)) / Math.PI) / 2.0 * n);
+
+        x = Math.Clamp(x, 0, n - 1);
+        y = Math.Clamp(y, 0, n - 1);
+
+        MapboxTileUrls.ValidateWebMercatorTile(z, x, y);
+        return (x, y);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTileResponseValidatorsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTileResponseValidatorsTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using FluentAssertions;
+using Nexo.Tests.Infrastructure.External;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.External;
+
+public sealed class MapboxTileResponseValidatorsTests
+{
+    [Fact]
+    public void AssertRasterTileSuccess_AcceptsValidJpeg()
+    {
+        var jpeg = new byte[120];
+        jpeg[0] = 0xFF;
+        jpeg[1] = 0xD8;
+
+        var act = () => MapboxTileResponseValidators.AssertRasterTileSuccess(
+            HttpStatusCode.OK,
+            "image/jpeg",
+            jpeg);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AssertRasterTileSuccess_RejectsWrongStatus()
+    {
+        var jpeg = new byte[120];
+        jpeg[0] = 0xFF;
+        jpeg[1] = 0xD8;
+
+        var act = () => MapboxTileResponseValidators.AssertRasterTileSuccess(
+            HttpStatusCode.NotFound,
+            "image/jpeg",
+            jpeg);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*NotFound*");
+    }
+
+    [Fact]
+    public void AssertRasterTileSuccess_RejectsNonImageContentType()
+    {
+        var jpeg = new byte[120];
+        jpeg[0] = 0xFF;
+        jpeg[1] = 0xD8;
+
+        var act = () => MapboxTileResponseValidators.AssertRasterTileSuccess(
+            HttpStatusCode.OK,
+            "text/html",
+            jpeg);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*image*");
+    }
+
+    [Fact]
+    public void AssertRasterTileSuccess_RejectsTooSmallBody()
+    {
+        var jpeg = new byte[10];
+        jpeg[0] = 0xFF;
+        jpeg[1] = 0xD8;
+
+        var act = () => MapboxTileResponseValidators.AssertRasterTileSuccess(
+            HttpStatusCode.OK,
+            "image/jpeg",
+            jpeg);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*10 bytes*");
+    }
+
+    [Fact]
+    public void AssertVectorTileSuccess_AcceptsGzipPayload()
+    {
+        var gzip = new byte[30];
+        gzip[0] = 0x1F;
+        gzip[1] = 0x8B;
+
+        var act = () => MapboxTileResponseValidators.AssertVectorTileSuccess(
+            HttpStatusCode.OK,
+            "application/gzip",
+            gzip);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AssertVectorTileSuccess_RejectsBadContentTypeWhenPresent()
+    {
+        var body = new byte[50];
+
+        var act = () => MapboxTileResponseValidators.AssertVectorTileSuccess(
+            HttpStatusCode.OK,
+            "text/html",
+            body);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*text/html*");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTileUrlsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTileUrlsTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Nexo.Tests.Infrastructure.External;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.External;
+
+/// <summary>
+/// White-box tests for <see cref="MapboxTileUrls"/> — URL shape, escaping, Web Mercator bounds, and byte heuristics.
+/// </summary>
+public sealed class MapboxTileUrlsTests
+{
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(1, 0, 0)]
+    [InlineData(1, 1, 1)]
+    [InlineData(10, 512, 300)]
+    public void ValidateWebMercatorTile_AcceptsInRange(int z, int x, int y)
+    {
+        var act = () => MapboxTileUrls.ValidateWebMercatorTile(z, x, y);
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData(0, 1, 0)]
+    [InlineData(0, 0, 1)]
+    [InlineData(1, 2, 0)]
+    [InlineData(1, 0, 2)]
+    [InlineData(-1, 0, 0)]
+    [InlineData(31, 0, 0)]
+    public void ValidateWebMercatorTile_RejectsOutOfRange(int z, int x, int y)
+    {
+        var act = () => MapboxTileUrls.ValidateWebMercatorTile(z, x, y);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void BuildRasterTileUrl_EncodesTilesetAndToken()
+    {
+        var url = MapboxTileUrls.BuildRasterTileUrl("mapbox.satellite", 0, 0, 0, "pk.abc+def/");
+
+        url.Should().StartWith("https://api.mapbox.com/v4/");
+        url.Should().Contain("mapbox.satellite/0/0/0.jpg?");
+        url.Should().Contain("access_token=");
+        url.Should().Contain(Uri.EscapeDataString("pk.abc+def/"));
+        url.Should().NotContain(" ");
+    }
+
+    [Fact]
+    public void BuildRasterTileUrl_WithAt2xSuffix()
+    {
+        var url = MapboxTileUrls.BuildRasterTileUrl("mapbox.satellite", 2, 1, 1, "pk.x", "@2x.jpg");
+
+        url.Should().Contain("/2/1/1@2x.jpg?");
+        url.Should().NotContain(".@2x");
+    }
+
+    [Fact]
+    public void BuildRasterTileUrl_NormalizesSuffixWithoutLeadingDot()
+    {
+        var url = MapboxTileUrls.BuildRasterTileUrl("mapbox.satellite", 0, 0, 0, "pk.x", "jpg");
+
+        url.Should().Contain("/0/0/0.jpg?");
+    }
+
+    [Fact]
+    public void BuildVectorTileUrl_EncodesTilesetWithSlash()
+    {
+        var url = MapboxTileUrls.BuildVectorTileUrl("user.custom-v1", 3, 2, 4, "pk.token");
+
+        url.Should().Contain("/v4/user.custom-v1/3/2/4.vector.pbf?");
+        url.Should().Contain("access_token=pk.token");
+    }
+
+    [Fact]
+    public void BuildRasterTileUrl_EncodesSlashInTilesetId()
+    {
+        var url = MapboxTileUrls.BuildRasterTileUrl("user.foo/bar", 0, 0, 0, "pk.x");
+
+        url.Should().Contain(Uri.EscapeDataString("user.foo/bar"));
+    }
+
+    [Fact]
+    public void BuildRasterTileUrl_EmptyTileset_Throws()
+    {
+        var act = () => MapboxTileUrls.BuildRasterTileUrl("  ", 0, 0, 0, "pk.x");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BuildRasterTileUrl_EmptyToken_Throws()
+    {
+        var act = () => MapboxTileUrls.BuildRasterTileUrl("mapbox.satellite", 0, 0, 0, "  ");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void IsJpegImage_DetectsSoi()
+    {
+        MapboxTileUrls.IsJpegImage(new byte[] { 0xFF, 0xD8, 0xFF }).Should().BeTrue();
+        MapboxTileUrls.IsJpegImage(new byte[] { 0x1F, 0x8B }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsGzipPayload_DetectsMagic()
+    {
+        MapboxTileUrls.IsGzipPayload(new byte[] { 0x1F, 0x8B, 0x08 }).Should().BeTrue();
+        MapboxTileUrls.IsGzipPayload(new byte[] { 0xFF, 0xD8 }).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("application/x-protobuf")]
+    [InlineData("application/vnd.mapbox-vector-tile")]
+    [InlineData("application/octet-stream")]
+    [InlineData("application/gzip")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsLikelyVectorTileContentType_AcceptsExpected(string? media)
+    {
+        MapboxTileUrls.IsLikelyVectorTileContentType(media).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsLikelyVectorTileContentType_RejectsHtml()
+    {
+        MapboxTileUrls.IsLikelyVectorTileContentType("text/html").Should().BeFalse();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
@@ -5,10 +5,11 @@ using Xunit;
 namespace Nexo.Tests.Infrastructure.Tests.External;
 
 /// <summary>
-/// Optional black-box checks against Mapbox’s Raster Tiles API (HTTPS, no SDK).
+/// Optional black-box checks against Mapbox’s Raster and Vector Tiles APIs (HTTPS, no SDK).
 /// <para>
 /// Enable with <c>NEXO_TEST_MAPBOX_TILES=1</c> and <c>MAPBOX_ACCESS_TOKEN</c> set (never commit tokens).
-/// Default tileset is <c>mapbox.satellite</c>; override with <c>MAPBOX_TILESET_ID</c> if you use a custom style-backed tileset id.
+/// Raster: default tileset <c>mapbox.satellite</c> (<c>MAPBOX_TILESET_ID</c>).
+/// Vector: default tileset <c>mapbox.mapbox-streets-v8</c> (<c>MAPBOX_VECTOR_TILESET_ID</c>), extension <c>.vector.pbf</c>.
 /// </para>
 /// When disabled or token missing, tests return immediately so CI and offline runs stay green.
 /// </summary>
@@ -17,7 +18,8 @@ public sealed class MapboxTilesBlackBoxTests
 {
     private const string EnableEnv = "NEXO_TEST_MAPBOX_TILES";
     private const string TokenEnv = "MAPBOX_ACCESS_TOKEN";
-    private const string TilesetEnv = "MAPBOX_TILESET_ID";
+    private const string RasterTilesetEnv = "MAPBOX_TILESET_ID";
+    private const string VectorTilesetEnv = "MAPBOX_VECTOR_TILESET_ID";
 
     private static bool IsExplicitlyEnabled() =>
         string.Equals(Environment.GetEnvironmentVariable(EnableEnv), "1", StringComparison.OrdinalIgnoreCase);
@@ -32,7 +34,7 @@ public sealed class MapboxTilesBlackBoxTests
         if (string.IsNullOrWhiteSpace(token))
             return;
 
-        var tileset = Environment.GetEnvironmentVariable(TilesetEnv)?.Trim();
+        var tileset = Environment.GetEnvironmentVariable(RasterTilesetEnv)?.Trim();
         if (string.IsNullOrEmpty(tileset))
             tileset = "mapbox.satellite";
 
@@ -52,6 +54,60 @@ public sealed class MapboxTilesBlackBoxTests
         bytes.Length.Should().BeGreaterThan(100);
         bytes[0].Should().Be(0xFF);
         bytes[1].Should().Be(0xD8);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task VectorTile_ValidToken_ReturnsTileBytes()
+    {
+        if (!IsExplicitlyEnabled())
+            return;
+
+        var token = Environment.GetEnvironmentVariable(TokenEnv);
+        if (string.IsNullOrWhiteSpace(token))
+            return;
+
+        var tileset = Environment.GetEnvironmentVariable(VectorTilesetEnv)?.Trim();
+        if (string.IsNullOrEmpty(tileset))
+            tileset = "mapbox.mapbox-streets-v8";
+
+        // Vector Tiles API — MVT protobuf (.vector.pbf). Zoom 0 world tile.
+        var url =
+            $"https://api.mapbox.com/v4/{Uri.EscapeDataString(tileset)}/0/0/0.vector.pbf?access_token={Uri.EscapeDataString(token.Trim())}";
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
+        using var response = await client.GetAsync(url, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"GET {tileset}/0/0/0.vector.pbf should succeed with a valid token");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+        bytes.Should().NotBeEmpty();
+        bytes.Length.Should().BeGreaterThan(20);
+
+        var media = response.Content.Headers.ContentType?.MediaType ?? "";
+        if (!string.IsNullOrEmpty(media))
+        {
+            var ok =
+                media.Contains("protobuf", StringComparison.OrdinalIgnoreCase) ||
+                media.Contains("octet-stream", StringComparison.OrdinalIgnoreCase) ||
+                media.Contains("mapbox-vector-tile", StringComparison.OrdinalIgnoreCase) ||
+                media.Contains("gzip", StringComparison.OrdinalIgnoreCase) ||
+                media.Contains("application/x-protobuf", StringComparison.OrdinalIgnoreCase);
+            ok.Should().BeTrue($"unexpected Content-Type for vector tile: {media}");
+        }
+
+        // Payload is often gzip (starts with 1F 8B); otherwise raw MVT protobuf.
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task VectorTile_InvalidToken_IsUnauthorized()
+    {
+        var url =
+            "https://api.mapbox.com/v4/mapbox.mapbox-streets-v8/0/0/0.vector.pbf?access_token=pk.THIS_IS_NOT_A_REAL_MAPBOX_TOKEN";
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+        using var response = await client.GetAsync(url, CancellationToken.None);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
     }
 
     [Fact(Timeout = 30000)]

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.External;
+
+/// <summary>
+/// Optional black-box checks against Mapbox’s Raster Tiles API (HTTPS, no SDK).
+/// <para>
+/// Enable with <c>NEXO_TEST_MAPBOX_TILES=1</c> and <c>MAPBOX_ACCESS_TOKEN</c> set (never commit tokens).
+/// Default tileset is <c>mapbox.satellite</c>; override with <c>MAPBOX_TILESET_ID</c> if you use a custom style-backed tileset id.
+/// </para>
+/// When disabled or token missing, tests return immediately so CI and offline runs stay green.
+/// </summary>
+[Trait("Category", "External")]
+public sealed class MapboxTilesBlackBoxTests
+{
+    private const string EnableEnv = "NEXO_TEST_MAPBOX_TILES";
+    private const string TokenEnv = "MAPBOX_ACCESS_TOKEN";
+    private const string TilesetEnv = "MAPBOX_TILESET_ID";
+
+    private static bool IsExplicitlyEnabled() =>
+        string.Equals(Environment.GetEnvironmentVariable(EnableEnv), "1", StringComparison.OrdinalIgnoreCase);
+
+    [Fact(Timeout = 60000)]
+    public async Task RasterTile_ValidToken_ReturnsRasterBytes()
+    {
+        if (!IsExplicitlyEnabled())
+            return;
+
+        var token = Environment.GetEnvironmentVariable(TokenEnv);
+        if (string.IsNullOrWhiteSpace(token))
+            return;
+
+        var tileset = Environment.GetEnvironmentVariable(TilesetEnv)?.Trim();
+        if (string.IsNullOrEmpty(tileset))
+            tileset = "mapbox.satellite";
+
+        // Zoom 0 single world tile — minimal black-box probe (Mapbox Raster Tiles API v4).
+        var url =
+            $"https://api.mapbox.com/v4/{Uri.EscapeDataString(tileset)}/0/0/0.jpg?access_token={Uri.EscapeDataString(token.Trim())}";
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
+        using var response = await client.GetAsync(url, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"GET {tileset}/0/0/0.jpg should succeed with a valid token");
+        response.Content.Headers.ContentType?.MediaType.Should().StartWith("image/", "raster tiles return an image content type");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+        bytes.Should().NotBeEmpty();
+        // JPEG SOI
+        bytes.Length.Should().BeGreaterThan(100);
+        bytes[0].Should().Be(0xFF);
+        bytes[1].Should().Be(0xD8);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task RasterTile_InvalidToken_IsUnauthorized()
+    {
+        var url = "https://api.mapbox.com/v4/mapbox.satellite/0/0/0.jpg?access_token=pk.THIS_IS_NOT_A_REAL_MAPBOX_TOKEN";
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+        using var response = await client.GetAsync(url, CancellationToken.None);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
@@ -14,7 +14,8 @@ namespace Nexo.Tests.Infrastructure.Tests.External;
 /// </para>
 /// When disabled or token missing, tests return immediately so CI and offline runs stay green.
 /// URL construction and response rules are white-box tested in <see cref="MapboxTileUrlsTests"/> and
-/// <see cref="MapboxTileResponseValidatorsTests"/>.
+/// <see cref="MapboxTileResponseValidatorsTests"/>. Geography-driven URLs with real Mapbox responses are in
+/// <see cref="MapboxTilesWhiteBoxRealDataTests"/> (same env gate).
 /// </summary>
 [Trait("Category", "External")]
 public sealed class MapboxTilesBlackBoxTests

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesBlackBoxTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using Nexo.Tests.Infrastructure.External;
 using Xunit;
 
 namespace Nexo.Tests.Infrastructure.Tests.External;
@@ -12,6 +13,8 @@ namespace Nexo.Tests.Infrastructure.Tests.External;
 /// Vector: default tileset <c>mapbox.mapbox-streets-v8</c> (<c>MAPBOX_VECTOR_TILESET_ID</c>), extension <c>.vector.pbf</c>.
 /// </para>
 /// When disabled or token missing, tests return immediately so CI and offline runs stay green.
+/// URL construction and response rules are white-box tested in <see cref="MapboxTileUrlsTests"/> and
+/// <see cref="MapboxTileResponseValidatorsTests"/>.
 /// </summary>
 [Trait("Category", "External")]
 public sealed class MapboxTilesBlackBoxTests
@@ -36,24 +39,18 @@ public sealed class MapboxTilesBlackBoxTests
 
         var tileset = Environment.GetEnvironmentVariable(RasterTilesetEnv)?.Trim();
         if (string.IsNullOrEmpty(tileset))
-            tileset = "mapbox.satellite";
+            tileset = MapboxTileUrls.DefaultRasterTilesetId;
 
-        // Zoom 0 single world tile — minimal black-box probe (Mapbox Raster Tiles API v4).
-        var url =
-            $"https://api.mapbox.com/v4/{Uri.EscapeDataString(tileset)}/0/0/0.jpg?access_token={Uri.EscapeDataString(token.Trim())}";
+        var url = MapboxTileUrls.BuildRasterTileUrl(tileset, 0, 0, 0, token);
 
         using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
         using var response = await client.GetAsync(url, CancellationToken.None);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK, $"GET {tileset}/0/0/0.jpg should succeed with a valid token");
-        response.Content.Headers.ContentType?.MediaType.Should().StartWith("image/", "raster tiles return an image content type");
-
         var bytes = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
-        bytes.Should().NotBeEmpty();
-        // JPEG SOI
-        bytes.Length.Should().BeGreaterThan(100);
-        bytes[0].Should().Be(0xFF);
-        bytes[1].Should().Be(0xD8);
+        MapboxTileResponseValidators.AssertRasterTileSuccess(
+            response.StatusCode,
+            response.Content.Headers.ContentType?.MediaType,
+            bytes);
     }
 
     [Fact(Timeout = 60000)]
@@ -68,41 +65,29 @@ public sealed class MapboxTilesBlackBoxTests
 
         var tileset = Environment.GetEnvironmentVariable(VectorTilesetEnv)?.Trim();
         if (string.IsNullOrEmpty(tileset))
-            tileset = "mapbox.mapbox-streets-v8";
+            tileset = MapboxTileUrls.DefaultVectorTilesetId;
 
-        // Vector Tiles API — MVT protobuf (.vector.pbf). Zoom 0 world tile.
-        var url =
-            $"https://api.mapbox.com/v4/{Uri.EscapeDataString(tileset)}/0/0/0.vector.pbf?access_token={Uri.EscapeDataString(token.Trim())}";
+        var url = MapboxTileUrls.BuildVectorTileUrl(tileset, 0, 0, 0, token);
 
         using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
         using var response = await client.GetAsync(url, CancellationToken.None);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK, $"GET {tileset}/0/0/0.vector.pbf should succeed with a valid token");
-
         var bytes = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
-        bytes.Should().NotBeEmpty();
-        bytes.Length.Should().BeGreaterThan(20);
-
-        var media = response.Content.Headers.ContentType?.MediaType ?? "";
-        if (!string.IsNullOrEmpty(media))
-        {
-            var ok =
-                media.Contains("protobuf", StringComparison.OrdinalIgnoreCase) ||
-                media.Contains("octet-stream", StringComparison.OrdinalIgnoreCase) ||
-                media.Contains("mapbox-vector-tile", StringComparison.OrdinalIgnoreCase) ||
-                media.Contains("gzip", StringComparison.OrdinalIgnoreCase) ||
-                media.Contains("application/x-protobuf", StringComparison.OrdinalIgnoreCase);
-            ok.Should().BeTrue($"unexpected Content-Type for vector tile: {media}");
-        }
-
-        // Payload is often gzip (starts with 1F 8B); otherwise raw MVT protobuf.
+        MapboxTileResponseValidators.AssertVectorTileSuccess(
+            response.StatusCode,
+            response.Content.Headers.ContentType?.MediaType,
+            bytes);
     }
 
     [Fact(Timeout = 30000)]
     public async Task VectorTile_InvalidToken_IsUnauthorized()
     {
-        var url =
-            "https://api.mapbox.com/v4/mapbox.mapbox-streets-v8/0/0/0.vector.pbf?access_token=pk.THIS_IS_NOT_A_REAL_MAPBOX_TOKEN";
+        var url = MapboxTileUrls.BuildVectorTileUrl(
+            MapboxTileUrls.DefaultVectorTilesetId,
+            0,
+            0,
+            0,
+            "pk.THIS_IS_NOT_A_REAL_MAPBOX_TOKEN");
 
         using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
         using var response = await client.GetAsync(url, CancellationToken.None);
@@ -113,7 +98,12 @@ public sealed class MapboxTilesBlackBoxTests
     [Fact(Timeout = 30000)]
     public async Task RasterTile_InvalidToken_IsUnauthorized()
     {
-        var url = "https://api.mapbox.com/v4/mapbox.satellite/0/0/0.jpg?access_token=pk.THIS_IS_NOT_A_REAL_MAPBOX_TOKEN";
+        var url = MapboxTileUrls.BuildRasterTileUrl(
+            MapboxTileUrls.DefaultRasterTilesetId,
+            0,
+            0,
+            0,
+            "pk.THIS_IS_NOT_A_REAL_MAPBOX_TOKEN");
 
         using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
         using var response = await client.GetAsync(url, CancellationToken.None);

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesWhiteBoxRealDataTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxTilesWhiteBoxRealDataTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using FluentAssertions;
+using Nexo.Tests.Infrastructure.External;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.External;
+
+/// <summary>
+/// White-box integration: tile indices from <see cref="MapboxWebMercatorTileMath"/>, URLs from
+/// <see cref="MapboxTileUrls"/>, response checks from <see cref="MapboxTileResponseValidators"/>,
+/// against the live Mapbox API when <c>NEXO_TEST_MAPBOX_TILES=1</c> and <c>MAPBOX_ACCESS_TOKEN</c> are set.
+/// </summary>
+[Trait("Category", "External")]
+[Trait("Category", "MapboxRealData")]
+public sealed class MapboxTilesWhiteBoxRealDataTests
+{
+    private const string EnableEnv = "NEXO_TEST_MAPBOX_TILES";
+    private const string TokenEnv = "MAPBOX_ACCESS_TOKEN";
+    private const string RasterTilesetEnv = "MAPBOX_TILESET_ID";
+    private const string VectorTilesetEnv = "MAPBOX_VECTOR_TILESET_ID";
+
+    private static bool IsEnabled() =>
+        string.Equals(Environment.GetEnvironmentVariable(EnableEnv), "1", StringComparison.OrdinalIgnoreCase);
+
+    [Fact(Timeout = 90000)]
+    public async Task RasterTile_ComputedTileIndexFromGeography_MatchesValidators()
+    {
+        if (!IsEnabled())
+            return;
+
+        var token = Environment.GetEnvironmentVariable(TokenEnv);
+        if (string.IsNullOrWhiteSpace(token))
+            return;
+
+        var tileset = Environment.GetEnvironmentVariable(RasterTilesetEnv)?.Trim();
+        if (string.IsNullOrEmpty(tileset))
+            tileset = MapboxTileUrls.DefaultRasterTilesetId;
+
+        var (x, y) = MapboxWebMercatorTileMath.TileIndexFromLatLon(37.7749, -122.4194, 10);
+        x.Should().Be(163);
+        y.Should().Be(395);
+
+        var url = MapboxTileUrls.BuildRasterTileUrl(tileset, 10, x, y, token);
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
+        using var response = await client.GetAsync(url, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var bytes = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+        MapboxTileResponseValidators.AssertRasterTileSuccess(
+            response.StatusCode,
+            response.Content.Headers.ContentType?.MediaType,
+            bytes);
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task VectorTile_ComputedTileIndexFromGeography_MatchesValidators()
+    {
+        if (!IsEnabled())
+            return;
+
+        var token = Environment.GetEnvironmentVariable(TokenEnv);
+        if (string.IsNullOrWhiteSpace(token))
+            return;
+
+        var tileset = Environment.GetEnvironmentVariable(VectorTilesetEnv)?.Trim();
+        if (string.IsNullOrEmpty(tileset))
+            tileset = MapboxTileUrls.DefaultVectorTilesetId;
+
+        var (x, y) = MapboxWebMercatorTileMath.TileIndexFromLatLon(37.7749, -122.4194, 10);
+
+        var url = MapboxTileUrls.BuildVectorTileUrl(tileset, 10, x, y, token);
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(45) };
+        using var response = await client.GetAsync(url, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var bytes = await response.Content.ReadAsByteArrayAsync(CancellationToken.None);
+        MapboxTileResponseValidators.AssertVectorTileSuccess(
+            response.StatusCode,
+            response.Content.Headers.ContentType?.MediaType,
+            bytes);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/External/MapboxWebMercatorTileMathTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/External/MapboxWebMercatorTileMathTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Nexo.Tests.Infrastructure.External;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.External;
+
+public sealed class MapboxWebMercatorTileMathTests
+{
+    [Theory]
+    [InlineData(0, 0, 0, 0, 0)]
+    [InlineData(0, 0, 1, 1, 1)]
+    public void TileIndexFromLatLon_OriginAndZ1(double lat, double lon, int z, int expectX, int expectY)
+    {
+        var (x, y) = MapboxWebMercatorTileMath.TileIndexFromLatLon(lat, lon, z);
+        x.Should().Be(expectX);
+        y.Should().Be(expectY);
+    }
+
+    [Fact]
+    public void TileIndexFromLatLon_SanFranciscoZoom10_MatchesReferenceTile()
+    {
+        // Reference: Web Mercator XYZ at z=10 for approx downtown SF.
+        var (x, y) = MapboxWebMercatorTileMath.TileIndexFromLatLon(37.7749, -122.4194, 10);
+        x.Should().Be(163);
+        y.Should().Be(395);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(31)]
+    public void TileIndexFromLatLon_InvalidZoom_Throws(int z)
+    {
+        var act = () => MapboxWebMercatorTileMath.TileIndexFromLatLon(0, 0, z);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void TileIndexFromLatLon_DateLine_Clamped()
+    {
+        var (x, _) = MapboxWebMercatorTileMath.TileIndexFromLatLon(0, 180, 2);
+        x.Should().Be(3);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Optional **black-box** Mapbox HTTP tests plus **white-box** URL/tile math and response validators. New: **white-box + real Mapbox data** integration when env is enabled.

## White-box (CI, no network)

- **`MapboxTileUrls`** — Web Mercator bounds, raster/vector URL builders, escaping.
- **`MapboxTileResponseValidators`** — shared raster/vector success rules.
- **`MapboxWebMercatorTileMath`** — lat/lon → tile X/Y (XYZ), clamped to zoom extent.
- Unit tests: `MapboxTileUrlsTests`, `MapboxTileResponseValidatorsTests`, `MapboxWebMercatorTileMathTests`.

## White-box + real Mapbox (opt-in)

**`MapboxTilesWhiteBoxRealDataTests`** (`Trait: MapboxRealData`): uses our tile math for San Francisco at **z=10** → **(163, 395)**, builds URLs with **`MapboxTileUrls`**, `GET`s Mapbox, validates with **`MapboxTileResponseValidators`**. Same gate as black-box: **`NEXO_TEST_MAPBOX_TILES=1`** + **`MAPBOX_ACCESS_TOKEN`**.

## Black-box (opt-in)

`MapboxTilesBlackBoxTests` — z0/0/0 raster + vector with invalid-token negatives.

## Run

```bash
# All Mapbox-related (white-box always; live tests no-op without env):
dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --filter "FullyQualifiedName~Mapbox"

# Live white-box + real data + black-box:
export NEXO_TEST_MAPBOX_TILES=1
export MAPBOX_ACCESS_TOKEN='pk....'
dotnet test ... --filter "FullyQualifiedName~Mapbox"
```

## Security

Never commit tokens; rotate if exposed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

