### PR TITLE
feat(aesthetics): cross-engine pipeline hints and surface bindings on AestheticPack

### DIFF
--- a/src/Nexo.API/Endpoints/ForgeEndpoints.cs
+++ b/src/Nexo.API/Endpoints/ForgeEndpoints.cs
@@ -450,6 +450,7 @@ internal static class ForgeSessionStore
         new AestheticPack
         {
             Id = "low_poly", Name = "Low Poly", GeometryStrategy = "low_poly",
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardStylized,
             DefaultPaletteColors = ["#81C784", "#64B5F6", "#FFB74D", "#CE93D8"],
             LodLevels = [new LodLevel(0, 1.0), new LodLevel(1, 0.5)]
         },
@@ -462,6 +463,7 @@ internal static class ForgeSessionStore
         new AestheticPack
         {
             Id = "pbr", Name = "PBR", GeometryStrategy = "pbr",
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardPbr,
             DefaultPaletteColors = ["#E0E0E0", "#BDBDBD", "#9E9E9E"],
             LodLevels = [new LodLevel(0, 1.0), new LodLevel(1, 0.75), new LodLevel(2, 0.5), new LodLevel(3, 0.25)],
             PostProcessEffects = ["bloom", "ambient_occlusion", "tone_mapping"]

--- a/src/Nexo.GameDomain/Aesthetics/AestheticPack.cs
+++ b/src/Nexo.GameDomain/Aesthetics/AestheticPack.cs
@@ -4,8 +4,10 @@ namespace Nexo.GameDomain.Aesthetics;
 /// Describes the visual style applied to a session, controlling geometry strategy, colour
 /// palette, LOD configuration, and post-processing effects.
 /// <para>
-/// The Unity rendering pipeline reads the active <see cref="AestheticPack"/> to select
-/// mesh generators, material shaders, and camera post-process volumes at scene load time.
+/// Game engines (Unity, Unreal, Godot, or custom hosts) read the active <see cref="AestheticPack"/> to select
+/// mesh generators, materials, shaders, and camera post-process volumes at scene load time.
+/// Use <see cref="AestheticPack.EngineSurfaceBindings"/> to map logical roles to engine-specific surfaces while keeping
+/// <see cref="GeometryStrategy"/> and palettes engine-neutral.
 /// </para>
 /// </summary>
 public sealed record AestheticPack
@@ -39,6 +41,18 @@ public sealed record AestheticPack
     /// <c>"chromatic_aberration"</c>, <c>"vignette"</c>).
     /// </summary>
     public IReadOnlyList<string> PostProcessEffects { get; init; } = [];
+
+    /// <summary>
+    /// Semantic render pipeline hint (e.g. <see cref="RenderingPipelineKinds.ForwardStylized"/>).
+    /// Hosts translate this to engine-specific renderer features (URP Forward+, Unreal Forward Shading, etc.).
+    /// </summary>
+    public string RenderingPipelineKind { get; init; } = RenderingPipelineKinds.Auto;
+
+    /// <summary>
+    /// Optional per-engine bindings from logical surface roles to concrete shader/material hints.
+    /// Empty means hosts infer surfaces from <see cref="GeometryStrategy"/> alone.
+    /// </summary>
+    public IReadOnlyList<EngineRenderingSurfaceBinding> EngineSurfaceBindings { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Nexo.GameDomain/Aesthetics/EngineRenderingSurfaceBinding.cs
+++ b/src/Nexo.GameDomain/Aesthetics/EngineRenderingSurfaceBinding.cs
@@ -1,0 +1,24 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Binds a logical rendering role in an <see cref="AestheticPack"/> to an engine-specific material or shader surface.
+/// Multiple bindings for the same <see cref="Role"/> and different <see cref="EngineId"/> allow one pack to adapt
+/// across Unity, Unreal, Godot, or custom runtimes without changing Nexo core types.
+/// </summary>
+public sealed record EngineRenderingSurfaceBinding
+{
+    /// <summary>Target engine; use <see cref="GameEngines"/> constants when possible.</summary>
+    public required string EngineId { get; init; }
+
+    /// <summary>Logical surface role, e.g. <c>world_primary</c>, <c>character_skin</c>, <c>ui_default</c>.</summary>
+    public required string Role { get; init; }
+
+    /// <summary>Engine-neutral material intent, e.g. <c>stylized_lit</c>, <c>unlit_vertex_color</c>.</summary>
+    public required string MaterialSurfaceId { get; init; }
+
+    /// <summary>Optional engine-specific shader or material asset path / registry id.</summary>
+    public string? AssetOrShaderHint { get; init; }
+
+    /// <summary>Optional key/value hints (render queue, feature flags, texture slot ids).</summary>
+    public IReadOnlyDictionary<string, string>? Parameters { get; init; }
+}

--- a/src/Nexo.GameDomain/Aesthetics/EngineSurfaceBindingResolver.cs
+++ b/src/Nexo.GameDomain/Aesthetics/EngineSurfaceBindingResolver.cs
@@ -1,0 +1,31 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Helpers for hosts resolving <see cref="EngineRenderingSurfaceBinding"/> entries on an <see cref="AestheticPack"/>.
+/// </summary>
+public static class EngineSurfaceBindingResolver
+{
+    /// <summary>
+    /// Returns the first binding matching <paramref name="engineId"/> and <paramref name="role"/>,
+    /// using ordinal case-insensitive comparison for ids.
+    /// </summary>
+    public static EngineRenderingSurfaceBinding? TryGetBinding(
+        AestheticPack pack,
+        string engineId,
+        string role)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+
+        if (string.IsNullOrWhiteSpace(engineId) || string.IsNullOrWhiteSpace(role))
+            return null;
+
+        foreach (var b in pack.EngineSurfaceBindings)
+        {
+            if (string.Equals(b.EngineId, engineId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(b.Role, role, StringComparison.OrdinalIgnoreCase))
+                return b;
+        }
+
+        return null;
+    }
+}

--- a/src/Nexo.GameDomain/Aesthetics/GameEngines.cs
+++ b/src/Nexo.GameDomain/Aesthetics/GameEngines.cs
@@ -1,0 +1,13 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Known host identifiers for <see cref="EngineRenderingSurfaceBinding.EngineId"/>.
+/// Hosts may use additional custom ids; these are interoperable defaults.
+/// </summary>
+public static class GameEngines
+{
+    public const string Unity = "unity";
+    public const string Unreal = "unreal";
+    public const string Godot = "godot";
+    public const string Custom = "custom";
+}

--- a/src/Nexo.GameDomain/Aesthetics/RenderingPipelineKinds.cs
+++ b/src/Nexo.GameDomain/Aesthetics/RenderingPipelineKinds.cs
@@ -1,0 +1,14 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Optional semantic pipeline hint for <see cref="AestheticPack.RenderingPipelineKind"/>.
+/// Hosts map these to engine-specific render paths (URP/HDRP, Forward+, Godot Forward+, etc.).
+/// </summary>
+public static class RenderingPipelineKinds
+{
+    public const string ForwardStylized = "forward_stylized";
+    public const string ForwardPbr = "forward_pbr";
+    public const string DeferredPbr = "deferred_pbr";
+    public const string UnlitFlat = "unlit_flat";
+    public const string Auto = "auto";
+}

--- a/src/Nexo.GameDomain/Contracts/IForgeClient.cs
+++ b/src/Nexo.GameDomain/Contracts/IForgeClient.cs
@@ -5,7 +5,7 @@ using Nexo.GameDomain.Session;
 namespace Nexo.GameDomain.Contracts;
 
 /// <summary>
-/// Contract for a Unity client communicating with the Nexo Forge backend.
+/// Contract for a game-engine client (Unity, Unreal, Godot, or custom) communicating with the Nexo Forge backend.
 /// Implementations handle transport (HTTP, gRPC, WebSocket) without exposing
 /// framework-specific dependencies.
 /// </summary>

--- a/src/Nexo.Tests.GameDomain/AestheticPackTests.cs
+++ b/src/Nexo.Tests.GameDomain/AestheticPackTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json;
 using FluentAssertions;
 using Nexo.GameDomain.Aesthetics;
@@ -14,6 +15,8 @@ public class AestheticPackTests
         pack.Id.Should().BeEmpty();
         pack.Name.Should().BeEmpty();
         pack.GeometryStrategy.Should().Be("low_poly");
+        pack.RenderingPipelineKind.Should().Be(RenderingPipelineKinds.Auto);
+        pack.EngineSurfaceBindings.Should().BeEmpty();
         pack.DefaultPaletteColors.Should().BeEmpty();
         pack.LodLevels.Should().BeEmpty();
         pack.PostProcessEffects.Should().BeEmpty();
@@ -33,7 +36,26 @@ public class AestheticPackTests
                 new LodLevel(0, 1.0),
                 new LodLevel(1, 0.5),
             ],
-            PostProcessEffects = ["vignette"]
+            PostProcessEffects = ["vignette"],
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardStylized,
+            EngineSurfaceBindings =
+            [
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Unity,
+                    Role = "world_primary",
+                    MaterialSurfaceId = "stylized_lit",
+                    AssetOrShaderHint = "Universal Render Pipeline/Lit",
+                    Parameters = new Dictionary<string, string> { ["workflow"] = "Specular" },
+                },
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Unreal,
+                    Role = "world_primary",
+                    MaterialSurfaceId = "stylized_lit",
+                    AssetOrShaderHint = "/Game/Materials/M_StylizedWorld",
+                },
+            ]
         };
 
         var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
@@ -54,6 +76,32 @@ public class AestheticPackTests
         restored.LodLevels[0].DetailFactor.Should().Be(1.0);
         restored.LodLevels[1].DetailFactor.Should().Be(0.5);
         restored.PostProcessEffects.Should().ContainSingle().Which.Should().Be("vignette");
+        restored.RenderingPipelineKind.Should().Be(RenderingPipelineKinds.ForwardStylized);
+        restored.EngineSurfaceBindings.Should().HaveCount(2);
+        restored.EngineSurfaceBindings[0].EngineId.Should().Be(GameEngines.Unity);
+        restored.EngineSurfaceBindings[0].Parameters.Should().ContainKey("workflow");
+    }
+
+    [Fact]
+    public void EngineSurfaceBindingResolver_ReturnsMatchingBinding()
+    {
+        var pack = new AestheticPack
+        {
+            EngineSurfaceBindings =
+            [
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Godot,
+                    Role = "ui_default",
+                    MaterialSurfaceId = "unlit",
+                    AssetOrShaderHint = "res://ui.tres",
+                },
+            ]
+        };
+
+        var b = EngineSurfaceBindingResolver.TryGetBinding(pack, "GODOT", "ui_default");
+        b.Should().NotBeNull();
+        b!.MaterialSurfaceId.Should().Be("unlit");
     }
 
     [Fact]

--- a/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
@@ -203,6 +203,8 @@ public sealed class ForgeEndpointsTests : IDisposable
         var packs = ExtractOkValue<IReadOnlyList<AestheticPack>>(result);
         packs.Should().HaveCount(6);
         packs.Select(p => p.Id).Should().Contain(new[] { "voxel", "low_poly", "pixel_art", "pbr", "wireframe", "sketch" });
+        packs.Single(p => p.Id == "low_poly").RenderingPipelineKind.Should().Be(RenderingPipelineKinds.ForwardStylized);
+        packs.Single(p => p.Id == "pbr").RenderingPipelineKind.Should().Be(RenderingPipelineKinds.ForwardPbr);
     }
 
     [Fact(Timeout = 15000)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **engine-neutral** hooks on `AestheticPack` so the same session style can be **interpreted** by Unity, Unreal, Godot, or custom hosts without changing Nexo types.

## Model

- **`RenderingPipelineKind`** — semantic hint (`auto`, `forward_stylized`, `forward_pbr`, `deferred_pbr`, `unlit_flat` via `RenderingPipelineKinds`).
- **`EngineSurfaceBindings`** — list of **`EngineRenderingSurfaceBinding`**: `EngineId` (`GameEngines`), logical `Role`, engine-neutral `MaterialSurfaceId`, optional `AssetOrShaderHint`, optional `Parameters` dictionary.
- **`EngineSurfaceBindingResolver.TryGetBinding`** — resolve binding for `(pack, engineId, role)`.

## Forge

Built-in **`low_poly`** pack sets `RenderingPipelineKind = forward_stylized`; **`pbr`** uses `forward_pbr` (illustrative defaults).

## Tests

- `AestheticPackTests` — defaults, JSON round-trip with bindings + pipeline kind, resolver smoke.
- `ForgeEndpointsTests.ListAesthetics_Returns6Packs` — asserts pipeline hints on built-in packs.

## Host usage

Each engine adapter reads the same JSON: pick `RenderingPipelineKind` for renderer mode, then for each mesh role call `TryGetBinding` and map `MaterialSurfaceId` / hints to native materials/shaders.

## Note

Existing asset descriptors (`MaterialDescriptor`, etc.) are still Unity-oriented in comments; this PR focuses on **session aesthetics** as the cross-engine contract extension point.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

