### PR TITLE
feat: aesthetic validation, custom Forge aesthetic pack, Mapbox helpers in GameDomain

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -6,4 +6,4 @@ High-level maps of how Nexo is structured. For day-to-day commands, see the repo
 | -------- | -------- |
 | [Trust and execution boundaries](TrustAndExecutionBoundaries.md) | Where trust is decided, how requests cross layers, and what runs locally vs. on peers. |
 | [Testing model](TestingModel.md) | Relationship between xUnit tests, `UnitTestBase` / `ITestRunner`, and CI. |
-| [.NET SDK and target frameworks](DotnetVersions.md) | Why `global.json` pins SDK 9.x while many libraries target `net8.0`. |
+| [Aesthetic and engine adaptation](aesthetic-engine-adaptation.md) | Cross-engine `AestheticPack` fields, validation, Forge `apply-pack`, and shared Mapbox tile helpers. |

--- a/docs/architecture/aesthetic-engine-adaptation.md
+++ b/docs/architecture/aesthetic-engine-adaptation.md
@@ -1,0 +1,38 @@
+# Aesthetic and engine adaptation glossary
+
+Nexo carries **portable visual intent** in `AestheticPack`. Game engines (Unity, Unreal, Godot, custom) **interpret** these fields and map them to native shaders, materials, and render features.
+
+## Fields (engine-neutral)
+
+| Field | Purpose |
+| ----- | ------- |
+| `GeometryStrategy` | How authored geometry is produced (voxel, low_poly, pbr, …). Use `GeometryStrategies` constants. |
+| `RenderingPipelineKind` | Semantic render path (forward stylized, deferred PBR, …). Use `RenderingPipelineKinds`. Host maps to URP/HDRP, Unreal, Godot renderer settings. |
+| `DefaultPaletteColors` | Hex colours for procedural assignment when textures are absent. |
+| `LodLevels` | Ordered LOD tiers; `DetailFactor` meaning depends on `GeometryStrategy` (see `LodLevel` XML docs). |
+| `PostProcessEffects` | Logical post names (bloom, vignette, …); host maps to engine post stack. |
+| `EngineSurfaceBindings` | Per-engine optional rows: logical `Role` + `MaterialSurfaceId` + optional `AssetOrShaderHint` and `Parameters`. |
+
+## Catalogs and validation
+
+- **`AestheticAdaptationCatalog`** — known `RenderingPipelineKind` and `EngineId` values for strict checks.
+- **`GeometryStrategies`**, **`RenderingSurfaceRoles`**, **`MaterialSurfaceIds`** — recommended strings; roles/surfaces outside documented sets get **informational** validation codes, not hard failures.
+- **`AestheticPackValidation.Validate`** — returns `AestheticValidationIssue` list; **`AestheticPackValidation.IsValid`** treats `binding.undocumented_*` as non-blocking by default.
+
+## Forge API
+
+- **`POST /api/forge/aesthetic/apply`** — apply a **built-in** pack by id (unchanged).
+- **`POST /api/forge/aesthetic/apply-pack`** — body: `ForgeApplyCustomAestheticPackRequest` (`Pack`, optional `Scope`, optional `RequireKnownEngineIds`). Validates then stores the full pack on the session.
+
+## Mapbox tiles (shared kernel)
+
+`Nexo.GameDomain.Maps` provides **`MapboxTileUrls`**, **`MapboxWebMercatorTileMath`**, and **`MapboxTileResponseValidators`** for host-agnostic URL construction and HTTP response checks. **Never** embed access tokens in source; use environment variables or secret stores.
+
+## Precedence (recommended)
+
+1. If `EngineSurfaceBindingResolver.TryGetBinding(pack, currentEngine, role)` returns a row, use its `MaterialSurfaceId` and hints.
+2. Else derive from `GeometryStrategy` + `RenderingPipelineKind` + palette defaults.
+
+## Unity-specific descriptors
+
+Types under `Nexo.GameDomain.Assets` and many `Descriptors` still mention Unity in comments. Treat them as **legacy host projections**; new cross-engine work should prefer `AestheticPack` + neutral descriptors or parallel DTOs in a consuming repo.

--- a/src/Nexo.API/Endpoints/ForgeEndpoints.cs
+++ b/src/Nexo.API/Endpoints/ForgeEndpoints.cs
@@ -1,8 +1,10 @@
+using System.Linq;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Nexo.GameDomain.Aesthetics;
+using Nexo.GameDomain.Contracts;
 using Nexo.GameDomain.Descriptors;
 using Nexo.GameDomain.Macros;
 using Nexo.GameDomain.Scoping;
@@ -111,6 +113,12 @@ public static class ForgeEndpoints
         group.MapPost("/aesthetic/apply", ApplyAestheticAsync)
             .WithName("ApplyForgeAesthetic")
             .WithSummary("Apply an aesthetic pack at a given scope")
+            .Produces<SessionState>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        group.MapPost("/aesthetic/apply-pack", ApplyCustomAestheticPackAsync)
+            .WithName("ApplyForgeCustomAestheticPack")
+            .WithSummary("Apply a full AestheticPack JSON (custom id, bindings, pipeline kind) after validation")
             .Produces<SessionState>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
@@ -386,6 +394,16 @@ public static class ForgeEndpoints
         if (pack is null)
             return Results.BadRequest(new ProblemDetails { Title = $"Unknown aesthetic pack '{request.AestheticId}'" });
 
+        var builtInIssues = AestheticPackValidation.Validate(pack);
+        if (!AestheticPackValidation.IsValid(builtInIssues))
+        {
+            var detail = string.Join("; ", builtInIssues.Select(i => $"{i.Code}: {i.Message}"));
+            return Results.BadRequest(new ProblemDetails
+            {
+                Title = "Built-in aesthetic pack failed validation",
+                Detail = detail
+            });
+        }
         var setting = new ScopedSetting
         {
             SettingId = "aesthetic",
@@ -404,6 +422,56 @@ public static class ForgeEndpoints
 
         if (!session.AestheticPacks.Any(a => a.Id == pack.Id))
             session.AestheticPacks.Add(pack);
+
+        session.LastModifiedAtUtc = DateTimeOffset.UtcNow;
+        return Results.Ok(session);
+    }
+
+    private static async Task<IResult> ApplyCustomAestheticPackAsync(
+        [FromBody] ForgeApplyCustomAestheticPackRequest? request)
+    {
+        await Task.CompletedTask;
+
+        if (request?.Pack is null)
+            return Results.BadRequest(new ProblemDetails { Title = "Pack is required" });
+
+        var pack = request.Pack;
+        if (string.IsNullOrWhiteSpace(pack.Id))
+            return Results.BadRequest(new ProblemDetails { Title = "AestheticPack.Id is required" });
+
+        var validationOptions = new AestheticPackValidationOptions
+        {
+            RequireKnownEngineIds = request.RequireKnownEngineIds ?? false
+        };
+        var issues = AestheticPackValidation.Validate(pack, validationOptions);
+        if (!AestheticPackValidation.IsValid(issues, treatUndocumentedAsNonBlocking: true))
+        {
+            var detail = string.Join("; ", issues.Select(i => $"{i.Code}: {i.Message}"));
+            return Results.BadRequest(new ProblemDetails
+            {
+                Title = "Aesthetic pack validation failed",
+                Detail = detail
+            });
+        }
+
+        var setting = new ScopedSetting
+        {
+            SettingId = "aesthetic",
+            Value = pack.Id,
+            Scope = request.Scope ?? new SettingScope(),
+            CreatedBy = "forge",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        var session = ForgeSessionStore.Session;
+        session.ScopedSettings.RemoveAll(s =>
+            s.SettingId == "aesthetic" &&
+            s.Scope.Type == setting.Scope.Type &&
+            s.Scope.Target == setting.Scope.Target);
+        session.ScopedSettings.Add(setting);
+
+        session.AestheticPacks.RemoveAll(a => a.Id == pack.Id);
+        session.AestheticPacks.Add(pack);
 
         session.LastModifiedAtUtc = DateTimeOffset.UtcNow;
         return Results.Ok(session);

--- a/src/Nexo.API/Endpoints/ForgeEndpoints.cs
+++ b/src/Nexo.API/Endpoints/ForgeEndpoints.cs
@@ -450,6 +450,7 @@ internal static class ForgeSessionStore
         new AestheticPack
         {
             Id = "low_poly", Name = "Low Poly", GeometryStrategy = "low_poly",
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardStylized,
             DefaultPaletteColors = ["#81C784", "#64B5F6", "#FFB74D", "#CE93D8"],
             LodLevels = [new LodLevel(0, 1.0), new LodLevel(1, 0.5)]
         },
@@ -462,6 +463,7 @@ internal static class ForgeSessionStore
         new AestheticPack
         {
             Id = "pbr", Name = "PBR", GeometryStrategy = "pbr",
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardPbr,
             DefaultPaletteColors = ["#E0E0E0", "#BDBDBD", "#9E9E9E"],
             LodLevels = [new LodLevel(0, 1.0), new LodLevel(1, 0.75), new LodLevel(2, 0.5), new LodLevel(3, 0.25)],
             PostProcessEffects = ["bloom", "ambient_occlusion", "tone_mapping"]

--- a/src/Nexo.GameDomain/Aesthetics/AestheticAdaptationCatalog.cs
+++ b/src/Nexo.GameDomain/Aesthetics/AestheticAdaptationCatalog.cs
@@ -1,0 +1,35 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Central registry of known pipeline kinds and engine ids for <see cref="AestheticPackValidation"/>.
+/// </summary>
+public static class AestheticAdaptationCatalog
+{
+    public static IReadOnlySet<string> KnownRenderingPipelineKinds { get; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            RenderingPipelineKinds.Auto,
+            RenderingPipelineKinds.ForwardStylized,
+            RenderingPipelineKinds.ForwardPbr,
+            RenderingPipelineKinds.DeferredPbr,
+            RenderingPipelineKinds.UnlitFlat,
+        };
+
+    public static IReadOnlySet<string> KnownEngineIds { get; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            GameEngines.Unity,
+            GameEngines.Unreal,
+            GameEngines.Godot,
+            GameEngines.Custom,
+        };
+
+    public static bool IsKnownRenderingPipelineKind(string? value) =>
+        !string.IsNullOrWhiteSpace(value) && KnownRenderingPipelineKinds.Contains(value.Trim());
+
+    public static bool IsKnownEngineId(string? value) =>
+        !string.IsNullOrWhiteSpace(value) && KnownEngineIds.Contains(value.Trim());
+
+    public static bool IsKnownGeometryStrategy(string? value) =>
+        !string.IsNullOrWhiteSpace(value) && GeometryStrategies.All.Contains(value.Trim());
+}

--- a/src/Nexo.GameDomain/Aesthetics/AestheticPack.cs
+++ b/src/Nexo.GameDomain/Aesthetics/AestheticPack.cs
@@ -4,8 +4,10 @@ namespace Nexo.GameDomain.Aesthetics;
 /// Describes the visual style applied to a session, controlling geometry strategy, colour
 /// palette, LOD configuration, and post-processing effects.
 /// <para>
-/// The Unity rendering pipeline reads the active <see cref="AestheticPack"/> to select
-/// mesh generators, material shaders, and camera post-process volumes at scene load time.
+/// Game engines (Unity, Unreal, Godot, or custom hosts) read the active <see cref="AestheticPack"/> to select
+/// mesh generators, materials, shaders, and camera post-process volumes at scene load time.
+/// Use <see cref="AestheticPack.EngineSurfaceBindings"/> to map logical roles to engine-specific surfaces while keeping
+/// <see cref="GeometryStrategy"/> and palettes engine-neutral.
 /// </para>
 /// </summary>
 public sealed record AestheticPack
@@ -39,6 +41,18 @@ public sealed record AestheticPack
     /// <c>"chromatic_aberration"</c>, <c>"vignette"</c>).
     /// </summary>
     public IReadOnlyList<string> PostProcessEffects { get; init; } = [];
+
+    /// <summary>
+    /// Semantic render pipeline hint (e.g. <see cref="RenderingPipelineKinds.ForwardStylized"/>).
+    /// Hosts translate this to engine-specific renderer features (URP Forward+, Unreal Forward Shading, etc.).
+    /// </summary>
+    public string RenderingPipelineKind { get; init; } = RenderingPipelineKinds.Auto;
+
+    /// <summary>
+    /// Optional per-engine bindings from logical surface roles to concrete shader/material hints.
+    /// Empty means hosts infer surfaces from <see cref="GeometryStrategy"/> alone.
+    /// </summary>
+    public IReadOnlyList<EngineRenderingSurfaceBinding> EngineSurfaceBindings { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Nexo.GameDomain/Aesthetics/AestheticPackValidation.cs
+++ b/src/Nexo.GameDomain/Aesthetics/AestheticPackValidation.cs
@@ -1,0 +1,131 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// A single validation finding for an <see cref="AestheticPack"/> or binding.
+/// </summary>
+public readonly record struct AestheticValidationIssue(string Code, string Message);
+
+/// <summary>
+/// Options for <see cref="AestheticPackValidation"/>.
+/// </summary>
+public sealed class AestheticPackValidationOptions
+{
+    /// <summary>When true, <see cref="AestheticPack.RenderingPipelineKind"/> must be a <see cref="AestheticAdaptationCatalog.KnownRenderingPipelineKinds"/> member.</summary>
+    public bool RequireKnownRenderingPipelineKind { get; init; } = true;
+
+    /// <summary>When true, <see cref="AestheticPack.GeometryStrategy"/> must be a <see cref="GeometryStrategies.All"/> member.</summary>
+    public bool RequireKnownGeometryStrategy { get; init; } = true;
+
+    /// <summary>When true, each <see cref="EngineRenderingSurfaceBinding.EngineId"/> must be a <see cref="AestheticAdaptationCatalog.KnownEngineIds"/> member.</summary>
+    public bool RequireKnownEngineIds { get; init; }
+
+    /// <summary>When true, informational issues for undocumented <see cref="EngineRenderingSurfaceBinding.Role"/> or <see cref="EngineRenderingSurfaceBinding.MaterialSurfaceId"/>.</summary>
+    public bool WarnOnUndocumentedRolesAndSurfaces { get; init; } = true;
+}
+
+/// <summary>
+/// Validates <see cref="AestheticPack"/> adaptation fields for typos and structural mistakes.
+/// </summary>
+public static class AestheticPackValidation
+{
+    /// <summary>
+    /// Validates <paramref name="pack"/>; returns issues. Empty list means no findings.
+    /// </summary>
+    public static IReadOnlyList<AestheticValidationIssue> Validate(
+        AestheticPack pack,
+        AestheticPackValidationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+        options ??= new AestheticPackValidationOptions();
+
+        var issues = new List<AestheticValidationIssue>();
+
+        if (string.IsNullOrWhiteSpace(pack.Id))
+            issues.Add(new("aesthetic.empty_id", "AestheticPack.Id is required."));
+
+        if (options.RequireKnownGeometryStrategy &&
+            !AestheticAdaptationCatalog.IsKnownGeometryStrategy(pack.GeometryStrategy))
+        {
+            issues.Add(new(
+                "aesthetic.unknown_geometry_strategy",
+                $"GeometryStrategy '{pack.GeometryStrategy}' is not a known value. Expected one of: {string.Join(", ", GeometryStrategies.All)}."));
+        }
+
+        if (options.RequireKnownRenderingPipelineKind &&
+            !AestheticAdaptationCatalog.IsKnownRenderingPipelineKind(pack.RenderingPipelineKind))
+        {
+            issues.Add(new(
+                "aesthetic.unknown_rendering_pipeline_kind",
+                $"RenderingPipelineKind '{pack.RenderingPipelineKind}' is not known. Expected one of: {string.Join(", ", AestheticAdaptationCatalog.KnownRenderingPipelineKinds)}."));
+        }
+
+        var seenBindings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var b in pack.EngineSurfaceBindings)
+        {
+            if (string.IsNullOrWhiteSpace(b.EngineId))
+            {
+                issues.Add(new("binding.empty_engine_id", "EngineSurfaceBinding.EngineId must not be empty."));
+                continue;
+            }
+
+            if (options.RequireKnownEngineIds && !AestheticAdaptationCatalog.IsKnownEngineId(b.EngineId))
+            {
+                issues.Add(new(
+                    "binding.unknown_engine_id",
+                    $"EngineId '{b.EngineId}' is not in the known engine catalog. Use GameEngines constants or set RequireKnownEngineIds=false."));
+            }
+
+            if (string.IsNullOrWhiteSpace(b.Role))
+                issues.Add(new("binding.empty_role", "EngineSurfaceBinding.Role must not be empty."));
+
+            if (string.IsNullOrWhiteSpace(b.MaterialSurfaceId))
+                issues.Add(new("binding.empty_material_surface", "EngineSurfaceBinding.MaterialSurfaceId must not be empty."));
+
+            if (options.WarnOnUndocumentedRolesAndSurfaces &&
+                !string.IsNullOrWhiteSpace(b.Role) &&
+                !RenderingSurfaceRoles.Documented.Contains(b.Role.Trim()))
+            {
+                issues.Add(new(
+                    "binding.undocumented_role",
+                    $"Role '{b.Role}' is not in the documented interoperability set; hosts may still support it."));
+            }
+
+            if (options.WarnOnUndocumentedRolesAndSurfaces &&
+                !string.IsNullOrWhiteSpace(b.MaterialSurfaceId) &&
+                !MaterialSurfaceIds.Documented.Contains(b.MaterialSurfaceId.Trim()))
+            {
+                issues.Add(new(
+                    "binding.undocumented_material_surface",
+                    $"MaterialSurfaceId '{b.MaterialSurfaceId}' is not in the documented set; hosts may still map it."));
+            }
+
+            var key = $"{b.EngineId.Trim()}\0{b.Role.Trim()}";
+            if (!string.IsNullOrWhiteSpace(b.Role) && !seenBindings.Add(key))
+            {
+                issues.Add(new(
+                    "binding.duplicate_engine_role",
+                    $"Duplicate EngineSurfaceBinding for engine '{b.EngineId}' and role '{b.Role}'."));
+            }
+        }
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Returns true when there are no blocking issues (errors). Undocumented role/surface codes are treated as non-blocking when <paramref name="treatUndocumentedAsNonBlocking"/> is true.
+    /// </summary>
+    public static bool IsValid(
+        IReadOnlyList<AestheticValidationIssue> issues,
+        bool treatUndocumentedAsNonBlocking = true)
+    {
+        foreach (var i in issues)
+        {
+            if (treatUndocumentedAsNonBlocking && i.Code.StartsWith("binding.undocumented_", StringComparison.Ordinal))
+                continue;
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Nexo.GameDomain/Aesthetics/EngineRenderingSurfaceBinding.cs
+++ b/src/Nexo.GameDomain/Aesthetics/EngineRenderingSurfaceBinding.cs
@@ -1,0 +1,24 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Binds a logical rendering role in an <see cref="AestheticPack"/> to an engine-specific material or shader surface.
+/// Multiple bindings for the same <see cref="Role"/> and different <see cref="EngineId"/> allow one pack to adapt
+/// across Unity, Unreal, Godot, or custom runtimes without changing Nexo core types.
+/// </summary>
+public sealed record EngineRenderingSurfaceBinding
+{
+    /// <summary>Target engine; use <see cref="GameEngines"/> constants when possible.</summary>
+    public required string EngineId { get; init; }
+
+    /// <summary>Logical surface role, e.g. <c>world_primary</c>, <c>character_skin</c>, <c>ui_default</c>.</summary>
+    public required string Role { get; init; }
+
+    /// <summary>Engine-neutral material intent, e.g. <c>stylized_lit</c>, <c>unlit_vertex_color</c>.</summary>
+    public required string MaterialSurfaceId { get; init; }
+
+    /// <summary>Optional engine-specific shader or material asset path / registry id.</summary>
+    public string? AssetOrShaderHint { get; init; }
+
+    /// <summary>Optional key/value hints (render queue, feature flags, texture slot ids).</summary>
+    public IReadOnlyDictionary<string, string>? Parameters { get; init; }
+}

--- a/src/Nexo.GameDomain/Aesthetics/EngineSurfaceBindingResolver.cs
+++ b/src/Nexo.GameDomain/Aesthetics/EngineSurfaceBindingResolver.cs
@@ -1,0 +1,31 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Helpers for hosts resolving <see cref="EngineRenderingSurfaceBinding"/> entries on an <see cref="AestheticPack"/>.
+/// </summary>
+public static class EngineSurfaceBindingResolver
+{
+    /// <summary>
+    /// Returns the first binding matching <paramref name="engineId"/> and <paramref name="role"/>,
+    /// using ordinal case-insensitive comparison for ids.
+    /// </summary>
+    public static EngineRenderingSurfaceBinding? TryGetBinding(
+        AestheticPack pack,
+        string engineId,
+        string role)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+
+        if (string.IsNullOrWhiteSpace(engineId) || string.IsNullOrWhiteSpace(role))
+            return null;
+
+        foreach (var b in pack.EngineSurfaceBindings)
+        {
+            if (string.Equals(b.EngineId, engineId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(b.Role, role, StringComparison.OrdinalIgnoreCase))
+                return b;
+        }
+
+        return null;
+    }
+}

--- a/src/Nexo.GameDomain/Aesthetics/GameEngines.cs
+++ b/src/Nexo.GameDomain/Aesthetics/GameEngines.cs
@@ -1,0 +1,13 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Known host identifiers for <see cref="EngineRenderingSurfaceBinding.EngineId"/>.
+/// Hosts may use additional custom ids; these are interoperable defaults.
+/// </summary>
+public static class GameEngines
+{
+    public const string Unity = "unity";
+    public const string Unreal = "unreal";
+    public const string Godot = "godot";
+    public const string Custom = "custom";
+}

--- a/src/Nexo.GameDomain/Aesthetics/GeometryStrategies.cs
+++ b/src/Nexo.GameDomain/Aesthetics/GeometryStrategies.cs
@@ -1,0 +1,20 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Known <see cref="AestheticPack.GeometryStrategy"/> string identifiers for validation and tooling.
+/// </summary>
+public static class GeometryStrategies
+{
+    public const string Voxel = "voxel";
+    public const string LowPoly = "low_poly";
+    public const string PixelArt = "pixel_art";
+    public const string Pbr = "pbr";
+    public const string Wireframe = "wireframe";
+    public const string Sketch = "sketch";
+
+    /// <summary>Stable set used by <see cref="AestheticPackValidation"/>.</summary>
+    public static IReadOnlySet<string> All { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        Voxel, LowPoly, PixelArt, Pbr, Wireframe, Sketch
+    };
+}

--- a/src/Nexo.GameDomain/Aesthetics/MaterialSurfaceIds.cs
+++ b/src/Nexo.GameDomain/Aesthetics/MaterialSurfaceIds.cs
@@ -1,0 +1,17 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Recommended <see cref="EngineRenderingSurfaceBinding.MaterialSurfaceId"/> values (engine-neutral intent).
+/// </summary>
+public static class MaterialSurfaceIds
+{
+    public const string StylizedLit = "stylized_lit";
+    public const string ForwardPbr = "forward_pbr";
+    public const string UnlitVertexColor = "unlit_vertex_color";
+    public const string Unlit = "unlit";
+
+    public static IReadOnlySet<string> Documented { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        StylizedLit, ForwardPbr, UnlitVertexColor, Unlit
+    };
+}

--- a/src/Nexo.GameDomain/Aesthetics/RenderingPipelineKinds.cs
+++ b/src/Nexo.GameDomain/Aesthetics/RenderingPipelineKinds.cs
@@ -1,0 +1,14 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Optional semantic pipeline hint for <see cref="AestheticPack.RenderingPipelineKind"/>.
+/// Hosts map these to engine-specific render paths (URP/HDRP, Forward+, Godot Forward+, etc.).
+/// </summary>
+public static class RenderingPipelineKinds
+{
+    public const string ForwardStylized = "forward_stylized";
+    public const string ForwardPbr = "forward_pbr";
+    public const string DeferredPbr = "deferred_pbr";
+    public const string UnlitFlat = "unlit_flat";
+    public const string Auto = "auto";
+}

--- a/src/Nexo.GameDomain/Aesthetics/RenderingSurfaceRoles.cs
+++ b/src/Nexo.GameDomain/Aesthetics/RenderingSurfaceRoles.cs
@@ -1,0 +1,19 @@
+namespace Nexo.GameDomain.Aesthetics;
+
+/// <summary>
+/// Recommended logical <see cref="EngineRenderingSurfaceBinding.Role"/> values for cross-engine packs.
+/// Hosts may use additional custom roles; unknown roles are not rejected by validation.
+/// </summary>
+public static class RenderingSurfaceRoles
+{
+    public const string WorldPrimary = "world_primary";
+    public const string CharacterSkin = "character_skin";
+    public const string UiDefault = "ui_default";
+    public const string EffectsParticles = "effects_particles";
+
+    /// <summary>Roles documented for interoperability; not exhaustive.</summary>
+    public static IReadOnlySet<string> Documented { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        WorldPrimary, CharacterSkin, UiDefault, EffectsParticles
+    };
+}

--- a/src/Nexo.GameDomain/Contracts/ForgeApiContracts.cs
+++ b/src/Nexo.GameDomain/Contracts/ForgeApiContracts.cs
@@ -1,3 +1,4 @@
+using Nexo.GameDomain.Aesthetics;
 using Nexo.GameDomain.Scoping;
 
 namespace Nexo.GameDomain.Contracts;
@@ -61,3 +62,11 @@ public sealed record ForgeMacroRunRequest(
 /// <param name="AestheticId">Identifier of the aesthetic pack to apply.</param>
 /// <param name="Scope">Scope at which the aesthetic should take effect.</param>
 public sealed record ForgeAestheticApplyRequest(string AestheticId, SettingScope Scope);
+
+/// <summary>
+/// Request to apply a full custom <see cref="AestheticPack"/> (cross-engine bindings) at a scope.
+/// </summary>
+public sealed record ForgeApplyCustomAestheticPackRequest(
+    AestheticPack Pack,
+    SettingScope? Scope = null,
+    bool? RequireKnownEngineIds = null);

--- a/src/Nexo.GameDomain/Contracts/IForgeClient.cs
+++ b/src/Nexo.GameDomain/Contracts/IForgeClient.cs
@@ -5,7 +5,7 @@ using Nexo.GameDomain.Session;
 namespace Nexo.GameDomain.Contracts;
 
 /// <summary>
-/// Contract for a Unity client communicating with the Nexo Forge backend.
+/// Contract for a game-engine client (Unity, Unreal, Godot, or custom) communicating with the Nexo Forge backend.
 /// Implementations handle transport (HTTP, gRPC, WebSocket) without exposing
 /// framework-specific dependencies.
 /// </summary>

--- a/src/Nexo.GameDomain/Maps/MapboxTileResponseValidators.cs
+++ b/src/Nexo.GameDomain/Maps/MapboxTileResponseValidators.cs
@@ -1,0 +1,36 @@
+using System.Net;
+
+namespace Nexo.GameDomain.Maps;
+
+/// <summary>
+/// Shared assertions for Mapbox tile HTTP responses (hosts and tests).
+/// </summary>
+public static class MapboxTileResponseValidators
+{
+    public static void AssertRasterTileSuccess(HttpStatusCode status, string? contentType, ReadOnlySpan<byte> body)
+    {
+        if (status != HttpStatusCode.OK)
+            throw new InvalidOperationException($"Expected OK, got {status}.");
+
+        if (string.IsNullOrEmpty(contentType) || !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Expected image/* content type, got '{contentType}'.");
+
+        if (body.Length < 100)
+            throw new InvalidOperationException($"Expected non-trivial JPEG body, got {body.Length} bytes.");
+
+        if (!MapboxTileUrls.IsJpegImage(body))
+            throw new InvalidOperationException("Body does not start with JPEG SOI (FF D8).");
+    }
+
+    public static void AssertVectorTileSuccess(HttpStatusCode status, string? contentType, ReadOnlySpan<byte> body)
+    {
+        if (status != HttpStatusCode.OK)
+            throw new InvalidOperationException($"Expected OK, got {status}.");
+
+        if (!string.IsNullOrEmpty(contentType) && !MapboxTileUrls.IsLikelyVectorTileContentType(contentType))
+            throw new InvalidOperationException($"Unexpected Content-Type for vector tile: '{contentType}'.");
+
+        if (body.Length < 20)
+            throw new InvalidOperationException($"Expected non-trivial tile body, got {body.Length} bytes.");
+    }
+}

--- a/src/Nexo.GameDomain/Maps/MapboxTileUrls.cs
+++ b/src/Nexo.GameDomain/Maps/MapboxTileUrls.cs
@@ -1,0 +1,91 @@
+namespace Nexo.GameDomain.Maps;
+
+/// <summary>
+/// Builds Mapbox Raster / Vector Tile API v4 URLs and validates Web Mercator tile indices.
+/// Host-agnostic; keep access tokens in environment or secure storage, never in source control.
+/// </summary>
+public static class MapboxTileUrls
+{
+    public const string DefaultRasterTilesetId = "mapbox.satellite";
+    public const string DefaultVectorTilesetId = "mapbox.mapbox-streets-v8";
+    public const string RasterHost = "https://api.mapbox.com";
+
+    /// <summary>Throws if tile indices are invalid for standard XYZ Web Mercator tiling at zoom <paramref name="z"/>.</summary>
+    public static void ValidateWebMercatorTile(int z, int x, int y)
+    {
+        if (z < 0 || z > 30)
+            throw new ArgumentOutOfRangeException(nameof(z), z, "Zoom must be in [0, 30].");
+
+        var extent = 1 << z;
+        if (x < 0 || x >= extent)
+            throw new ArgumentOutOfRangeException(nameof(x), x, $"Tile X must be in [0, {extent - 1}] for z={z}.");
+        if (y < 0 || y >= extent)
+            throw new ArgumentOutOfRangeException(nameof(y), y, $"Tile Y must be in [0, {extent - 1}] for z={z}.");
+    }
+
+    /// <summary>
+    /// Raster tile URL, e.g. <c>.../v4/mapbox.satellite/0/0/0.jpg?access_token=...</c>.
+    /// </summary>
+    /// <param name="tilesetId">Mapbox tileset id.</param>
+    /// <param name="z">Zoom level.</param>
+    /// <param name="x">Tile X.</param>
+    /// <param name="y">Tile Y.</param>
+    /// <param name="accessToken">Mapbox access token (do not log).</param>
+    /// <param name="rasterSuffix">File suffix including dot, e.g. <c>.jpg</c> or <c>@2x.jpg</c>.</param>
+    public static string BuildRasterTileUrl(
+        string tilesetId,
+        int z,
+        int x,
+        int y,
+        string accessToken,
+        string rasterSuffix = ".jpg")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tilesetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+        ValidateWebMercatorTile(z, x, y);
+
+        var suffix = string.IsNullOrWhiteSpace(rasterSuffix) ? ".jpg" : rasterSuffix.Trim();
+        if (!suffix.StartsWith("@", StringComparison.Ordinal) && !suffix.StartsWith(".", StringComparison.Ordinal))
+            suffix = "." + suffix.TrimStart('.');
+
+        return $"{RasterHost}/v4/{Uri.EscapeDataString(tilesetId.Trim())}/{z}/{x}/{y}{suffix}?access_token={Uri.EscapeDataString(accessToken.Trim())}";
+    }
+
+    /// <summary>
+    /// Vector tile URL (MVT), e.g. <c>.../v4/mapbox.mapbox-streets-v8/0/0/0.vector.pbf?access_token=...</c>.
+    /// </summary>
+    /// <param name="tilesetId">Mapbox tileset id.</param>
+    /// <param name="z">Zoom level.</param>
+    /// <param name="x">Tile X.</param>
+    /// <param name="y">Tile Y.</param>
+    /// <param name="accessToken">Mapbox access token (do not log).</param>
+    public static string BuildVectorTileUrl(string tilesetId, int z, int x, int y, string accessToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tilesetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+        ValidateWebMercatorTile(z, x, y);
+
+        return $"{RasterHost}/v4/{Uri.EscapeDataString(tilesetId.Trim())}/{z}/{x}/{y}.vector.pbf?access_token={Uri.EscapeDataString(accessToken.Trim())}";
+    }
+
+    /// <summary>True if <paramref name="bytes"/> looks like JPEG (SOI marker).</summary>
+    public static bool IsJpegImage(ReadOnlySpan<byte> bytes) =>
+        bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8;
+
+    /// <summary>True if payload is gzip-compressed (common for vector tiles).</summary>
+    public static bool IsGzipPayload(ReadOnlySpan<byte> bytes) =>
+        bytes.Length >= 2 && bytes[0] == 0x1F && bytes[1] == 0x8B;
+
+    /// <summary>Heuristic: Mapbox vector tile responses often use these content types.</summary>
+    public static bool IsLikelyVectorTileContentType(string? mediaType)
+    {
+        if (string.IsNullOrEmpty(mediaType))
+            return true;
+
+        return mediaType.Contains("protobuf", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("octet-stream", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("mapbox-vector-tile", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("gzip", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("application/x-protobuf", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Nexo.GameDomain/Maps/MapboxWebMercatorTileMath.cs
+++ b/src/Nexo.GameDomain/Maps/MapboxWebMercatorTileMath.cs
@@ -1,0 +1,35 @@
+namespace Nexo.GameDomain.Maps;
+
+/// <summary>
+/// Web Mercator (EPSG:3857) tile index math for standard XYZ tiling used by Mapbox raster/vector APIs.
+/// </summary>
+public static class MapboxWebMercatorTileMath
+{
+    /// <summary>Validates zoom only; tile count at zoom z is a power of two.</summary>
+    public static void ValidateZoom(int z)
+    {
+        if (z < 0 || z > 30)
+            throw new ArgumentOutOfRangeException(nameof(z), z, "Zoom must be in [0, 30].");
+    }
+
+    /// <summary>
+    /// Converts WGS84 latitude/longitude in degrees to tile X/Y at zoom <paramref name="z"/> (XYZ scheme, y down).
+    /// Results are clamped to valid tile bounds for the zoom level.
+    /// </summary>
+    public static (int X, int Y) TileIndexFromLatLon(double latitudeDegrees, double longitudeDegrees, int z)
+    {
+        ValidateZoom(z);
+
+        var n = 1 << z;
+        var x = (int)Math.Floor((longitudeDegrees + 180.0) / 360.0 * n);
+        var latRad = latitudeDegrees * (Math.PI / 180.0);
+        var y = (int)Math.Floor(
+            (1.0 - Math.Log(Math.Tan(latRad) + 1.0 / Math.Cos(latRad)) / Math.PI) / 2.0 * n);
+
+        x = Math.Clamp(x, 0, n - 1);
+        y = Math.Clamp(y, 0, n - 1);
+
+        MapboxTileUrls.ValidateWebMercatorTile(z, x, y);
+        return (x, y);
+    }
+}

--- a/src/Nexo.Tests.GameDomain/AestheticPackTests.cs
+++ b/src/Nexo.Tests.GameDomain/AestheticPackTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json;
 using FluentAssertions;
 using Nexo.GameDomain.Aesthetics;
@@ -14,6 +15,8 @@ public class AestheticPackTests
         pack.Id.Should().BeEmpty();
         pack.Name.Should().BeEmpty();
         pack.GeometryStrategy.Should().Be("low_poly");
+        pack.RenderingPipelineKind.Should().Be(RenderingPipelineKinds.Auto);
+        pack.EngineSurfaceBindings.Should().BeEmpty();
         pack.DefaultPaletteColors.Should().BeEmpty();
         pack.LodLevels.Should().BeEmpty();
         pack.PostProcessEffects.Should().BeEmpty();
@@ -33,7 +36,26 @@ public class AestheticPackTests
                 new LodLevel(0, 1.0),
                 new LodLevel(1, 0.5),
             ],
-            PostProcessEffects = ["vignette"]
+            PostProcessEffects = ["vignette"],
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardStylized,
+            EngineSurfaceBindings =
+            [
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Unity,
+                    Role = "world_primary",
+                    MaterialSurfaceId = "stylized_lit",
+                    AssetOrShaderHint = "Universal Render Pipeline/Lit",
+                    Parameters = new Dictionary<string, string> { ["workflow"] = "Specular" },
+                },
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Unreal,
+                    Role = "world_primary",
+                    MaterialSurfaceId = "stylized_lit",
+                    AssetOrShaderHint = "/Game/Materials/M_StylizedWorld",
+                },
+            ]
         };
 
         var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
@@ -54,6 +76,32 @@ public class AestheticPackTests
         restored.LodLevels[0].DetailFactor.Should().Be(1.0);
         restored.LodLevels[1].DetailFactor.Should().Be(0.5);
         restored.PostProcessEffects.Should().ContainSingle().Which.Should().Be("vignette");
+        restored.RenderingPipelineKind.Should().Be(RenderingPipelineKinds.ForwardStylized);
+        restored.EngineSurfaceBindings.Should().HaveCount(2);
+        restored.EngineSurfaceBindings[0].EngineId.Should().Be(GameEngines.Unity);
+        restored.EngineSurfaceBindings[0].Parameters.Should().ContainKey("workflow");
+    }
+
+    [Fact]
+    public void EngineSurfaceBindingResolver_ReturnsMatchingBinding()
+    {
+        var pack = new AestheticPack
+        {
+            EngineSurfaceBindings =
+            [
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Godot,
+                    Role = "ui_default",
+                    MaterialSurfaceId = "unlit",
+                    AssetOrShaderHint = "res://ui.tres",
+                },
+            ]
+        };
+
+        var b = EngineSurfaceBindingResolver.TryGetBinding(pack, "GODOT", "ui_default");
+        b.Should().NotBeNull();
+        b!.MaterialSurfaceId.Should().Be("unlit");
     }
 
     [Fact]

--- a/src/Nexo.Tests.GameDomain/AestheticPackValidationTests.cs
+++ b/src/Nexo.Tests.GameDomain/AestheticPackValidationTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Nexo.GameDomain.Aesthetics;
+using Xunit;
+
+namespace Nexo.Tests.GameDomain;
+
+public class AestheticPackValidationTests
+{
+    [Fact]
+    public void Validate_BuiltInLikePack_HasNoBlockingIssues()
+    {
+        var pack = new AestheticPack
+        {
+            Id = "low_poly",
+            Name = "Low Poly",
+            GeometryStrategy = GeometryStrategies.LowPoly,
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardStylized,
+        };
+
+        var issues = AestheticPackValidation.Validate(pack);
+        AestheticPackValidation.IsValid(issues).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_UnknownGeometryStrategy_Fails()
+    {
+        var pack = new AestheticPack
+        {
+            Id = "x",
+            GeometryStrategy = "not_a_strategy",
+            RenderingPipelineKind = RenderingPipelineKinds.Auto,
+        };
+
+        var issues = AestheticPackValidation.Validate(pack);
+        issues.Should().Contain(i => i.Code == "aesthetic.unknown_geometry_strategy");
+        AestheticPackValidation.IsValid(issues).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_UnknownPipelineKind_Fails()
+    {
+        var pack = new AestheticPack
+        {
+            Id = "x",
+            GeometryStrategy = GeometryStrategies.Pbr,
+            RenderingPipelineKind = "weird_pipeline",
+        };
+
+        var issues = AestheticPackValidation.Validate(pack);
+        issues.Should().Contain(i => i.Code == "aesthetic.unknown_rendering_pipeline_kind");
+        AestheticPackValidation.IsValid(issues).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_DuplicateEngineRole_Fails()
+    {
+        var pack = new AestheticPack
+        {
+            Id = "dup",
+            GeometryStrategy = GeometryStrategies.LowPoly,
+            RenderingPipelineKind = RenderingPipelineKinds.Auto,
+            EngineSurfaceBindings =
+            [
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Unity,
+                    Role = RenderingSurfaceRoles.WorldPrimary,
+                    MaterialSurfaceId = MaterialSurfaceIds.StylizedLit,
+                },
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Unity,
+                    Role = RenderingSurfaceRoles.WorldPrimary,
+                    MaterialSurfaceId = MaterialSurfaceIds.ForwardPbr,
+                },
+            ]
+        };
+
+        var issues = AestheticPackValidation.Validate(pack);
+        issues.Should().Contain(i => i.Code == "binding.duplicate_engine_role");
+        AestheticPackValidation.IsValid(issues).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_UnknownEngineId_WhenRequired_Fails()
+    {
+        var pack = new AestheticPack
+        {
+            Id = "e",
+            GeometryStrategy = GeometryStrategies.LowPoly,
+            RenderingPipelineKind = RenderingPipelineKinds.Auto,
+            EngineSurfaceBindings =
+            [
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = "bevy",
+                    Role = RenderingSurfaceRoles.WorldPrimary,
+                    MaterialSurfaceId = MaterialSurfaceIds.Unlit,
+                },
+            ]
+        };
+
+        var strict = new AestheticPackValidationOptions { RequireKnownEngineIds = true };
+        var issues = AestheticPackValidation.Validate(pack, strict);
+        issues.Should().Contain(i => i.Code == "binding.unknown_engine_id");
+        AestheticPackValidation.IsValid(issues).Should().BeFalse();
+    }
+}

--- a/src/Nexo.Tests.GameDomain/ForgeContractsTests.cs
+++ b/src/Nexo.Tests.GameDomain/ForgeContractsTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FluentAssertions;
+using Nexo.GameDomain.Aesthetics;
 using Nexo.GameDomain.Contracts;
 using Nexo.GameDomain.Descriptors;
 using Nexo.GameDomain.Scoping;
@@ -100,5 +101,25 @@ public class ForgeContractsTests
         aesthetic.AestheticId.Should().Be("pack-1");
         aesthetic.Scope.Type.Should().Be(SettingScopeType.Server);
         aesthetic.Scope.Target.Should().BeNull();
+    }
+
+    [Fact]
+    public void ForgeApplyCustomAestheticPackRequest_Serialization()
+    {
+        var pack = new AestheticPack
+        {
+            Id = "custom",
+            Name = "Custom",
+            GeometryStrategy = GeometryStrategies.LowPoly,
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardStylized,
+        };
+        var request = new ForgeApplyCustomAestheticPackRequest(pack, new SettingScope(), RequireKnownEngineIds: true);
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        var restored = JsonSerializer.Deserialize<ForgeApplyCustomAestheticPackRequest>(json, JsonOptions);
+
+        restored.Should().NotBeNull();
+        restored!.Pack.Id.Should().Be("custom");
+        restored.RequireKnownEngineIds.Should().BeTrue();
     }
 }

--- a/src/Nexo.Tests.GameDomain/MapboxTileUrlsTests.cs
+++ b/src/Nexo.Tests.GameDomain/MapboxTileUrlsTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using Nexo.GameDomain.Maps;
+using Xunit;
+
+namespace Nexo.Tests.GameDomain;
+
+public class MapboxTileUrlsTests
+{
+    [Fact]
+    public void BuildRasterTileUrl_EncodesToken()
+    {
+        var url = MapboxTileUrls.BuildRasterTileUrl("mapbox.satellite", 0, 0, 0, "pk.a+b");
+        url.Should().Contain("access_token=");
+        url.Should().Contain(Uri.EscapeDataString("pk.a+b"));
+    }
+
+    [Fact]
+    public void BuildVectorTileUrl_UsesVectorSuffix()
+    {
+        var url = MapboxTileUrls.BuildVectorTileUrl("mapbox.mapbox-streets-v8", 1, 0, 0, "pk.x");
+        url.Should().Contain("/1/0/0.vector.pbf?");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Nexo.API.Endpoints;
 using Nexo.GameDomain.Aesthetics;
 using Nexo.GameDomain.Descriptors;
@@ -220,6 +221,61 @@ public sealed class ForgeEndpointsTests : IDisposable
         var session = ExtractOkValue<SessionState>(result);
         session.ScopedSettings.Should().Contain(s => s.SettingId == "aesthetic" && s.Value.ToString() == "voxel");
         session.AestheticPacks.Should().Contain(a => a.Id == "voxel");
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task ApplyCustomAestheticPack_ValidPack_ReplacesSessionPack()
+    {
+        await InvokeAsync(GetHandler("CreateSessionAsync"),
+            new ForgeCreateSessionRequest("CustomPackTest"));
+
+        var custom = new AestheticPack
+        {
+            Id = "studio_stylized",
+            Name = "Studio Stylized",
+            GeometryStrategy = GeometryStrategies.LowPoly,
+            RenderingPipelineKind = RenderingPipelineKinds.ForwardStylized,
+            EngineSurfaceBindings =
+            [
+                new EngineRenderingSurfaceBinding
+                {
+                    EngineId = GameEngines.Unity,
+                    Role = RenderingSurfaceRoles.WorldPrimary,
+                    MaterialSurfaceId = MaterialSurfaceIds.StylizedLit,
+                    AssetOrShaderHint = "Universal Render Pipeline/Lit",
+                },
+            ]
+        };
+
+        var req = new Nexo.GameDomain.Contracts.ForgeApplyCustomAestheticPackRequest(custom);
+        var result = await InvokeAsync(GetHandler("ApplyCustomAestheticPackAsync"), req);
+
+        var session = ExtractOkValue<SessionState>(result);
+        session.ScopedSettings.Should().Contain(s => s.SettingId == "aesthetic" && s.Value.ToString() == "studio_stylized");
+        session.AestheticPacks.Should().ContainSingle(a => a.Id == "studio_stylized");
+        session.AestheticPacks.Single(a => a.Id == "studio_stylized").EngineSurfaceBindings.Should().HaveCount(1);
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task ApplyCustomAestheticPack_InvalidGeometry_ReturnsBadRequest()
+    {
+        await InvokeAsync(GetHandler("CreateSessionAsync"),
+            new ForgeCreateSessionRequest("BadPack"));
+
+        var bad = new AestheticPack
+        {
+            Id = "bad",
+            Name = "Bad",
+            GeometryStrategy = "totally_unknown",
+            RenderingPipelineKind = RenderingPipelineKinds.Auto,
+        };
+
+        var result = await InvokeAsync(GetHandler("ApplyCustomAestheticPackAsync"),
+            new Nexo.GameDomain.Contracts.ForgeApplyCustomAestheticPackRequest(bad));
+
+        var status = result as IStatusCodeHttpResult;
+        status.Should().NotBeNull();
+        status!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact(Timeout = 15000)]

--- a/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
@@ -203,6 +203,8 @@ public sealed class ForgeEndpointsTests : IDisposable
         var packs = ExtractOkValue<IReadOnlyList<AestheticPack>>(result);
         packs.Should().HaveCount(6);
         packs.Select(p => p.Id).Should().Contain(new[] { "voxel", "low_poly", "pixel_art", "pbr", "wireframe", "sketch" });
+        packs.Single(p => p.Id == "low_poly").RenderingPipelineKind.Should().Be(RenderingPipelineKinds.ForwardStylized);
+        packs.Single(p => p.Id == "pbr").RenderingPipelineKind.Should().Be(RenderingPipelineKinds.ForwardPbr);
     }
 
     [Fact(Timeout = 15000)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delivers the **gap-closing** items discussed: validation/registry for cross-engine aesthetics, **Forge** support for **custom full packs**, **shared Mapbox tile helpers** in `Nexo.GameDomain`, and a **glossary** doc.

## Aesthetic validation & catalogs

- **`GeometryStrategies`**, **`AestheticAdaptationCatalog`** (known pipeline kinds + engine ids)
- **`RenderingSurfaceRoles`**, **`MaterialSurfaceIds`** (documented interoperability sets)
- **`AestheticPackValidation`** + **`AestheticPackValidationOptions`** (optional strict engine ids, undocumented role/surface as non-blocking warnings)
- **`AestheticPackValidationTests`**

## Forge

- **`POST /api/forge/aesthetic/apply-pack`** — body: `ForgeApplyCustomAestheticPackRequest` (`Pack`, optional `Scope`, optional `RequireKnownEngineIds`)
- Built-in **`POST /api/forge/aesthetic/apply`** now validates the resolved built-in pack (safety net)
- Contract: **`ForgeApplyCustomAestheticPackRequest`** in `ForgeApiContracts.cs`; serialization test in `ForgeContractsTests`
- **`ForgeEndpointsTests`**: happy path custom pack + invalid geometry → 400

## Mapbox (kernel)

- **`Nexo.GameDomain.Maps`**: `MapboxTileUrls`, `MapboxWebMercatorTileMath`, `MapboxTileResponseValidators`
- **`MapboxTileUrlsTests`** in GameDomain

## Docs

- **`docs/architecture/aesthetic-engine-adaptation.md`** + index row in `docs/architecture/README.md`

## Tests

- `dotnet test` GameDomain + ForgeEndpoints subset run clean locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

