### PR TITLE
NCR simulation + prime-time ProdStyle gate (full test slice)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-core restore-core test test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary clean-test-artifacts test-readiness-gate
+.PHONY: build build-core restore-core test test-prod-style test-framework-prod-first test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary clean-test-artifacts test-readiness-gate
 
 # Build the solution
 build:
@@ -10,6 +10,19 @@ restore-core:
 
 build-core:
 	dotnet build Nexo.LocalDevCore.slnf -v minimal
+
+# Production-like integration (Category=ProdStyle): Nexo.Tests.Infrastructure only — real DI hosts / graphs.
+# Run this before the full suite when validating framework behaviour locally or in CI-style gates.
+test-prod-style: restore-core build-core
+	dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --no-build \
+	  --filter "Category=ProdStyle" \
+	  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+# Runs test-prod-style then the full LocalDevCore test slice (Domain + Infrastructure + CLI harness).
+# Note: ProdStyle tests execute twice (once filtered, once inside the full run).
+test-framework-prod-first: test-prod-style
+	dotnet test Nexo.LocalDevCore.slnf --no-build \
+	  --blame-hang-timeout 30s --blame-hang-dump-type none
 
 # Run tests locally (blame-hang-timeout prevents indefinite freeze from hung tests)
 # --blame-hang-dump-type none avoids 6GB+ hang dumps that accumulate in TestResults/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build build-core restore-core test test-prod-style test-framework-prod-first test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary clean-test-artifacts test-readiness-gate
+.PHONY: build build-core restore-core test test-prod-style test-framework-prod-first test-prime-time test-prime-time-full test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary clean-test-artifacts test-readiness-gate
+
+# All automated test projects (excludes MAUI/Android workloads required by full Nexo.sln).
+PRIME_TIME_SLNF := Nexo.PrimeTime.slnf
 
 # Build the solution
 build:
@@ -23,6 +26,18 @@ test-prod-style: restore-core build-core
 test-framework-prod-first: test-prod-style
 	dotnet test Nexo.LocalDevCore.slnf --no-build \
 	  --blame-hang-timeout 30s --blame-hang-dump-type none
+
+# Prime-time gate: Category=ProdStyle across Nexo.PrimeTime.slnf (all test assemblies; no MAUI workloads).
+test-prime-time:
+	dotnet build $(PRIME_TIME_SLNF) -v minimal
+	dotnet test $(PRIME_TIME_SLNF) --no-build \
+	  --filter "Category=ProdStyle" \
+	  --blame-hang-timeout 300s --blame-hang-dump-type none
+
+# Full PrimeTime matrix after ProdStyle gate (runs everything including ProdStyle twice).
+test-prime-time-full: test-prime-time
+	dotnet test $(PRIME_TIME_SLNF) --no-build \
+	  --blame-hang-timeout 300s --blame-hang-dump-type none
 
 # Run tests locally (blame-hang-timeout prevents indefinite freeze from hung tests)
 # --blame-hang-dump-type none avoids 6GB+ hang dumps that accumulate in TestResults/

--- a/Nexo.PrimeTime.slnf
+++ b/Nexo.PrimeTime.slnf
@@ -1,0 +1,15 @@
+{
+  "solution": {
+    "path": "Nexo.sln",
+    "projects": [
+      "src/Nexo.Tests.Application/Nexo.Tests.Application.csproj",
+      "src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj",
+      "src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj",
+      "src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj",
+      "src/Nexo.Tests.GameDomain/Nexo.Tests.GameDomain.csproj",
+      "src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj",
+      "src/Nexo.Tests.Orchestration/Nexo.Tests.Orchestration.csproj",
+      "src/Nexo.Tests.Transport/Nexo.Tests.Transport.csproj"
+    ]
+  }
+}

--- a/docs/NcrReleaseSLOs.md
+++ b/docs/NcrReleaseSLOs.md
@@ -11,6 +11,10 @@ Applies to:
 - Ollama backend integration (`ncr.ollama.*`)
 - Agentic escalation signals (`ncr.execution.escalated.*`)
 
+### Virtual production harness (routing stack)
+
+For CI and local soak without GPUs or real peers, **`VirtualProductionNcrRoutingHost`** (`Nexo.Tests.Infrastructure/Helpers/Ncr/VirtualProductionNcrRoutingHost.cs`) boots a generic **`IHost`** with the same **`AddRunPodCapabilityRouting`** registration as production (including **`NCRCapabilityPoller`** and **`PeerCapabilitySnapshotPoller`**), binding **`Nexo:RunPod`** / **`Nexo:NodeCapabilityRuntime`** options while substituting **`IHardwareProfiler`**, **`IInstanceDiscovery`**, **`ILocalQueueDepthProvider`**, **`IRunPodClient`**, and **`ILocalExecutor`**. Integration tests: **`VirtualProductionNcrRoutingTests`**.
+
 ## SLO targets (first release)
 
 Evaluate over 1h rolling windows in production-like environments.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -8,7 +8,8 @@ Nexo uses multiple mechanisms to prevent tests from hanging indefinitely and kee
 
 | Scope | blame-hang-timeout | Per-test timeout | Notes |
 |-------|--------------------|------------------|-------|
-| prod-style | 120s | varies | **Category=ProdStyle** — production-like DI / hosts (`make test-prod-style`) |
+| prime-time | 300s | varies | **`Nexo.PrimeTime.slnf`** — ProdStyle then full (`make test-prime-time` / `make test-prime-time-full`) |
+| prod-style | 120s | varies | **Category=ProdStyle** — Infrastructure-only (`make test-prod-style`) |
 | smoke | 30s | — | BaseFrameworkSmokeTests; local `make test` |
 | integration | 60s | 15s (Integration tests) | Category=Integration |
 | persistence | 60s | — | InMemoryPersistenceTests |
@@ -36,12 +37,14 @@ Nexo uses multiple mechanisms to prevent tests from hanging indefinitely and kee
 
 ## Running Tests
 
-**Production-like gate first** (when validating hosting, routing, adaptation, Forge — matches **`Category=ProdStyle`**):
+**Prime-time (whole automated framework slice):**  
 
 ```bash
-make test-prod-style
-make test-framework-prod-first   # ProdStyle + full Nexo.LocalDevCore.slnf slice (ProdStyle runs twice)
+make test-prime-time          # Category=ProdStyle across Nexo.PrimeTime.slnf (nine test projects; skips MAUI/Android workloads from full Nexo.sln)
+make test-prime-time-full    # ProdStyle gate then full test count on the same slice (ProdStyle runs twice)
 ```
+
+**Faster Infrastructure-only ProdStyle:** `make test-prod-style`
 
 `nexo` command note:
 - Commands shown as `nexo ...` assume the CLI tool is installed on your PATH.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -8,6 +8,7 @@ Nexo uses multiple mechanisms to prevent tests from hanging indefinitely and kee
 
 | Scope | blame-hang-timeout | Per-test timeout | Notes |
 |-------|--------------------|------------------|-------|
+| prod-style | 120s | varies | **Category=ProdStyle** — production-like DI / hosts (`make test-prod-style`) |
 | smoke | 30s | — | BaseFrameworkSmokeTests; local `make test` |
 | integration | 60s | 15s (Integration tests) | Category=Integration |
 | persistence | 60s | — | InMemoryPersistenceTests |
@@ -28,11 +29,19 @@ Nexo uses multiple mechanisms to prevent tests from hanging indefinitely and kee
 
 ### Adding New Integration Tests
 
-1. Add `[Collection("Integration")]` and `[Trait("Category", "Integration")]` to the test class
-2. Add `[Fact(Timeout = 15000)]` (or appropriate value) to async/I/O tests
-3. Integration tests run sequentially (DisableParallelization) to avoid file watcher and temp dir contention
+1. Add `[Collection("Integration")]` and `[Trait("Category", "Integration")]` to the test class when appropriate.
+2. For suites that exercise production DI graphs or **`Host`** wiring, also add **`[Trait("Category", "ProdStyle")]`** so they participate in **`make test-prod-style`** / **`nexo ci verify`** ordering.
+3. Add `[Fact(Timeout = 15000)]` (or appropriate value) to async/I/O tests
+4. Integration tests run sequentially (DisableParallelization) to avoid file watcher and temp dir contention
 
 ## Running Tests
+
+**Production-like gate first** (when validating hosting, routing, adaptation, Forge — matches **`Category=ProdStyle`**):
+
+```bash
+make test-prod-style
+make test-framework-prod-first   # ProdStyle + full Nexo.LocalDevCore.slnf slice (ProdStyle runs twice)
+```
 
 `nexo` command note:
 - Commands shown as `nexo ...` assume the CLI tool is installed on your PATH.

--- a/docs/architecture/TestingModel.md
+++ b/docs/architecture/TestingModel.md
@@ -12,6 +12,10 @@ Some suites inherit **`UnitTestBase`** (which extends **`TestBase`**) and implem
 
 **`UnitTestFrameworkBridge`** (in `Nexo.Infrastructure`) runs each concrete `UnitTestBase` through that runner. Test assemblies **`Nexo.Tests.Domain`**, **`Nexo.Tests.Application`**, **`Nexo.Tests.Infrastructure`**, and **`Nexo.Tests.CLI`** each expose **`UnitTestBridgeTests`** (xUnit theory) so `dotnet test` on those projects executes the same framework suites as the CLI. Infrastructure discovery skips **`SimpleTestForRunner`** (helper for **`TestRunnerAdapterTests`**), **`DependencyWrappingArchitectureTests`** (requires the **`copy-assemblies`** layout; run it via the full **`Nexo.Tests.Infrastructure`** test flow or filtered `dotnet test` after that target), and **`DoctorCommandTests`** (expects repo layout / host health; run via **`dotnet test`** with filter **`FullyQualifiedName~DoctorCommandTests`** or the CLI integration lane).
 
+## Production-like tests (`Category=ProdStyle`)
+
+Use **`[Trait("Category", "ProdStyle")]`** on xUnit classes that mirror production wiring: **`AddNexo`**, **`AddRunPodCapabilityRouting`**, adaptation/composition stacks, Forge HTTP surfaces, capability routing, barriers, etc. These are intended to run **before** lighter smoke (`BaseFrameworkSmokeTests`) and full matrices — see **`make test-prod-style`**, **`make test-framework-prod-first`**, and **`nexo ci verify`** (ProdStyle runs after Infrastructure build, before smoke).
+
 ## Merge policy (GitHub)
 
 To block merges when domain line coverage regresses, in GitHub go to **Settings → Branches → Branch protection rule**, enable **Require status checks to pass**, and add **`domain-coverage`** (the job id from **Core domain coverage**). If the UI only shows the workflow name, pick the check that corresponds to that workflow’s latest green run.
@@ -24,4 +28,5 @@ To block merges when domain line coverage regresses, in GitHub go to **Settings 
   `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj`  
   `dotnet test src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj`
 - **Broader local bar:** `make test` (see `Makefile`; uses blame-hang options)
+- **Production-like integration first:** `make test-prod-style` then optionally `make test-framework-prod-first`
 - **CI-style verification:** `make ci-verify` or `dotnet run --project src/Nexo.CLI -- ci verify`

--- a/docs/architecture/TestingModel.md
+++ b/docs/architecture/TestingModel.md
@@ -14,7 +14,9 @@ Some suites inherit **`UnitTestBase`** (which extends **`TestBase`**) and implem
 
 ## Production-like tests (`Category=ProdStyle`)
 
-Use **`[Trait("Category", "ProdStyle")]`** on xUnit classes that mirror production wiring: **`AddNexo`**, **`AddRunPodCapabilityRouting`**, adaptation/composition stacks, Forge HTTP surfaces, capability routing, barriers, etc. These are intended to run **before** lighter smoke (`BaseFrameworkSmokeTests`) and full matrices — see **`make test-prod-style`**, **`make test-framework-prod-first`**, and **`nexo ci verify`** (ProdStyle runs after Infrastructure build, before smoke).
+Use **`[Trait("Category", "ProdStyle")]`** on xUnit classes that mirror production wiring: **`AddNexo`**, **`AddRunPodCapabilityRouting`**, adaptation/composition stacks, Forge HTTP surfaces, capability routing, barriers, etc. **`UnitTestBridgeTests`** in Application / Domain / Infrastructure / CLI is tagged so every **`UnitTestBase`** suite participates. **`Nexo.Tests.GameDomain`** and **`Nexo.Tests.Transport`** use **`[assembly: AssemblyTrait("Category", "ProdStyle")]`** so the full assembly runs under **`Category=ProdStyle`**.
+
+Run **before** lighter smoke (`BaseFrameworkSmokeTests`) and full matrices — see **`make test-prod-style`**, **`make test-prime-time`** (**`Nexo.PrimeTime.slnf`**), **`make test-framework-prod-first`**, and **`nexo ci verify`** (ProdStyle runs after Infrastructure build, before smoke).
 
 ## Merge policy (GitHub)
 
@@ -28,5 +30,6 @@ To block merges when domain line coverage regresses, in GitHub go to **Settings 
   `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj`  
   `dotnet test src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj`
 - **Broader local bar:** `make test` (see `Makefile`; uses blame-hang options)
-- **Production-like integration first:** `make test-prod-style` then optionally `make test-framework-prod-first`
+- **Production-like integration first (Infrastructure only):** `make test-prod-style` then optionally `make test-framework-prod-first`
+- **Prime-time gate (all test projects in `Nexo.PrimeTime.slnf`):** `make test-prime-time` — **`Category=ProdStyle`** across Application, Domain, Infrastructure, CLI, Orchestration, BackgroundAgents, GameDomain, Transport; then **`make test-prime-time-full`** for the full slice.
 - **CI-style verification:** `make ci-verify` or `dotnet run --project src/Nexo.CLI -- ci verify`

--- a/src/Nexo.CLI/Commands/CiCommand.cs
+++ b/src/Nexo.CLI/Commands/CiCommand.cs
@@ -55,7 +55,7 @@ public sealed class CiCommand : Command
     }
 
     /// <summary>
-    /// Runs: dotnet build → dotnet test (smoke) → nexo validate.
+    /// Runs: dotnet build → dotnet test (ProdStyle) → dotnet test (smoke) → nexo validate.
     /// Exits 0 only if all succeed.
     /// </summary>
     public static async Task<int> ExecuteVerifyAsync()
@@ -86,7 +86,19 @@ public sealed class CiCommand : Command
             return buildInfraExit;
         }
 
-        // Step 2: Smoke tests (BaseFrameworkSmokeTests)
+        // Step 2: Production-like integration (real DI graphs / hosts; fail fast before lighter smoke)
+        Console.WriteLine("=== CI Verify: Production-like tests (Category=ProdStyle) ===");
+        var prodStyleExit = await RunProcessAsync(
+            "dotnet",
+            $"test \"{infraTestsProject}\" --no-build --blame-hang-timeout 120s --blame-hang-dump-type none --filter \"Category=ProdStyle\" --verbosity minimal",
+            repoRoot);
+        if (prodStyleExit != 0)
+        {
+            Console.Error.WriteLine($"ci verify: Production-like tests failed (exit {prodStyleExit})");
+            return prodStyleExit;
+        }
+
+        // Step 3: Smoke tests (BaseFrameworkSmokeTests)
         Console.WriteLine("=== CI Verify: Smoke Tests ===");
         var testExit = await RunProcessAsync(
             "dotnet",
@@ -98,7 +110,7 @@ public sealed class CiCommand : Command
             return testExit;
         }
 
-        // Step 3: Architecture validation (nexo validate)
+        // Step 4: Architecture validation (nexo validate)
         Console.WriteLine("=== CI Verify: Architecture Validation ===");
         var validateExit = await RunProcessAsync(
             "dotnet",

--- a/src/Nexo.Tests.Application/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.Application/Framework/UnitTestBridgeTests.cs
@@ -7,6 +7,7 @@ namespace Nexo.Tests.Application.Framework;
 /// <summary>
 /// Bridges <c>UnitTestBase</c> suites in this assembly to xUnit / VSTest via <see cref="UnitTestFrameworkBridge"/>.
 /// </summary>
+[Trait("Category", "ProdStyle")]
 public sealed class UnitTestBridgeTests
 {
     public static TheoryData<Type> UnitTestTypes { get; } = BuildTheoryData();

--- a/src/Nexo.Tests.BackgroundAgents/Forge/ForgeToolsTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Forge/ForgeToolsTests.cs
@@ -11,6 +11,7 @@ namespace Nexo.Tests.BackgroundAgents.Forge;
 
 /// <summary>Forge tool + policy integration (Streams C).</summary>
 [Trait("Category", "RuntimeStudio")]
+[Trait("Category", "ProdStyle")]
 public class ForgeToolsTests : IDisposable
 {
     private readonly string _tempDir;

--- a/src/Nexo.Tests.BackgroundAgents/Smoke/RuntimeStudioWhiteBoxSmokeTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Smoke/RuntimeStudioWhiteBoxSmokeTests.cs
@@ -15,6 +15,7 @@ namespace Nexo.Tests.BackgroundAgents.Smoke;
 /// </summary>
 [Trait("Category", "Smoke")]
 [Trait("Category", "RuntimeStudio")]
+[Trait("Category", "ProdStyle")]
 public sealed class RuntimeStudioWhiteBoxSmokeTests : IDisposable
 {
     private readonly string _root;

--- a/src/Nexo.Tests.CLI/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.CLI/Framework/UnitTestBridgeTests.cs
@@ -7,6 +7,7 @@ namespace Nexo.Tests.CLI.Framework;
 /// <summary>
 /// Bridges <c>UnitTestBase</c> suites in this assembly to xUnit / VSTest via <see cref="UnitTestFrameworkBridge"/>.
 /// </summary>
+[Trait("Category", "ProdStyle")]
 public sealed class UnitTestBridgeTests
 {
     public static TheoryData<Type> UnitTestTypes { get; } = BuildTheoryData();

--- a/src/Nexo.Tests.CLI/Tests/Commands/ForgeRelatedCommandTests.cs
+++ b/src/Nexo.Tests.CLI/Tests/Commands/ForgeRelatedCommandTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 namespace Nexo.Tests.CLI.Tests.Commands;
 
 [Trait("Category", "E2E")]
+[Trait("Category", "ProdStyle")]
 public sealed class ForgeRelatedCommandTests
 {
     [Fact(Timeout = 15000)]

--- a/src/Nexo.Tests.Domain/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.Domain/Framework/UnitTestBridgeTests.cs
@@ -8,6 +8,7 @@ namespace Nexo.Tests.Domain.Framework;
 /// Bridges Nexo <c>UnitTestBase</c> tests to xUnit so <c>dotnet test src/Nexo.Tests.Domain</c> runs the same
 /// logic as the infrastructure <c>ITestRunner</c> used by the CLI.
 /// </summary>
+[Trait("Category", "ProdStyle")]
 public sealed class UnitTestBridgeTests
 {
     public static TheoryData<Type> UnitTestTypes { get; } = BuildTheoryData();

--- a/src/Nexo.Tests.GameDomain/AssemblyAttributes.cs
+++ b/src/Nexo.Tests.GameDomain/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: AssemblyTrait("Category", "ProdStyle")]

--- a/src/Nexo.Tests.Infrastructure/Barriers/Identity/BarrierResolutionIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Barriers/Identity/BarrierResolutionIntegrationTests.cs
@@ -7,6 +7,8 @@ using Xunit;
 
 namespace Nexo.Tests.Infrastructure.Barriers.Identity;
 
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public sealed class BarrierResolutionIntegrationTests
 {
     [Fact]

--- a/src/Nexo.Tests.Infrastructure/Framework/UnitTestBridgeTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Framework/UnitTestBridgeTests.cs
@@ -8,6 +8,7 @@ namespace Nexo.Tests.Infrastructure.Framework;
 /// Bridges <c>UnitTestBase</c> suites in this assembly to xUnit / VSTest via <see cref="UnitTestFrameworkBridge"/>.
 /// Excludes <c>SimpleTestForRunner</c> (helper exercised only from <c>TestRunnerAdapterTests</c>).
 /// </summary>
+[Trait("Category", "ProdStyle")]
 public sealed class UnitTestBridgeTests
 {
     public static TheoryData<Type> UnitTestTypes { get; } = BuildTheoryData();

--- a/src/Nexo.Tests.Infrastructure/Helpers/Ncr/VirtualProductionNcrRoutingHost.cs
+++ b/src/Nexo.Tests.Infrastructure/Helpers/Ncr/VirtualProductionNcrRoutingHost.cs
@@ -1,0 +1,258 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Execution.Routing;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Mesh.Ports;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Core.Domain;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using Nexo.Infrastructure.Execution.Routing;
+using Nexo.Infrastructure.NodeCapabilityRuntime;
+
+namespace Nexo.Tests.Infrastructure.Helpers.Ncr;
+
+/// <summary>
+/// Spins up a minimal <see cref="IHost"/> that mirrors production wiring for capability routing:
+/// real <see cref="NCRCapabilityPoller"/>, <see cref="PeerCapabilitySnapshotPoller"/>,
+/// <see cref="NcrCapabilityRouter"/>, <see cref="CapabilityRoutingBrick"/>, and bound <c>Nexo:RunPod</c> /
+/// <c>Nexo:NodeCapabilityRuntime</c> configuration — with deterministic substitutes for hardware probing,
+/// mesh discovery, queue depth, RunPod HTTP, and local GPU execution.
+/// </summary>
+public sealed class VirtualProductionNcrRoutingHost : IAsyncDisposable
+{
+    private VirtualProductionNcrRoutingHost(IHost underlyingHost, SimulatedHardwareProfiler hardware, SimulatedMeshRegistry mesh, SimulatedQueueDepthProvider queue)
+    {
+        UnderlyingHost = underlyingHost;
+        Hardware = hardware;
+        Mesh = mesh;
+        Queue = queue;
+    }
+
+    /// <summary>The generic host running NCR + peer pollers.</summary>
+    public IHost UnderlyingHost { get; }
+
+    public SimulatedHardwareProfiler Hardware { get; }
+
+    public SimulatedMeshRegistry Mesh { get; }
+
+    public SimulatedQueueDepthProvider Queue { get; }
+
+    public IServiceProvider Services => UnderlyingHost.Services;
+
+    public static async Task<VirtualProductionNcrRoutingHost> StartAsync(
+        Action<VirtualProductionNcrRoutingHostOptions>? configure = null,
+        CancellationToken cancellationToken = default)
+    {
+        var opts = new VirtualProductionNcrRoutingHostOptions();
+        configure?.Invoke(opts);
+
+        var staging = Path.Combine(Path.GetTempPath(), $"nexo-vprod-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(staging);
+        opts.ConfigurationOverrides["Nexo:RunPod:OutputStagingPath"] = staging;
+
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { DisableDefaults = true });
+
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(NullLoggerProvider.Instance);
+
+        foreach (var kv in opts.ConfigurationOverrides)
+            builder.Configuration[kv.Key] = kv.Value;
+
+        builder.Services.AddSingleton(opts.RunPodStub);
+        builder.Services.AddSingleton(opts.LocalExecutor);
+
+        builder.Services.AddSingleton<IBrickRegistry, StubBrickRegistry>();
+
+        // Production capability routing (pollers + router + bricks).
+        builder.Services.AddSingleton<IHardwareProfiler>(opts.HardwareProfiler);
+        builder.Services.AddSingleton<ILocalQueueDepthProvider>(opts.QueueDepthProvider);
+        builder.Services.AddSingleton<IInstanceDiscovery>(opts.MeshRegistry);
+
+        builder.Services.AddOptions<NodeCapabilityRuntimeOptions>()
+            .Bind(builder.Configuration.GetSection(NodeCapabilityRuntimeOptions.SectionName));
+
+        builder.Services.AddRunPodCapabilityRouting(builder.Configuration);
+
+        builder.Services.RemoveAll<IRunPodClient>();
+        builder.Services.AddSingleton<IRunPodClient>(sp => sp.GetRequiredService<StubRunPodClient>());
+
+        builder.Services.RemoveAll<ILocalExecutor>();
+        builder.Services.AddSingleton<ILocalExecutor>(sp => sp.GetRequiredService<StubLocalExecutor>());
+
+        var host = builder.Build();
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        // Give hosted background loops their first tick (NCR + peer mesh refresh).
+        await Task.Delay(opts.PostStartDelay, cancellationToken).ConfigureAwait(false);
+
+        return new VirtualProductionNcrRoutingHost(host, opts.HardwareProfiler, opts.MeshRegistry, opts.QueueDepthProvider);
+    }
+
+    public ICapabilityRouter GetRouter() => UnderlyingHost.Services.GetRequiredService<ICapabilityRouter>();
+
+    public INCRCapabilitySnapshot GetNcrSnapshot() => UnderlyingHost.Services.GetRequiredService<INCRCapabilitySnapshot>();
+
+    public IPeerCapabilitySnapshot GetPeerSnapshot() => UnderlyingHost.Services.GetRequiredService<IPeerCapabilitySnapshot>();
+
+    public CapabilityRoutingBrick GetCapabilityRoutingBrick() => UnderlyingHost.Services.GetRequiredService<CapabilityRoutingBrick>();
+
+    public async ValueTask DisposeAsync()
+    {
+        await UnderlyingHost.StopAsync().ConfigureAwait(false);
+        UnderlyingHost.Dispose();
+    }
+}
+
+/// <summary>Mutable knobs for the virtual production routing host.</summary>
+public sealed class VirtualProductionNcrRoutingHostOptions
+{
+    /// <summary>Defaults tuned for fast, deterministic CI (still uses real poller classes).</summary>
+    public Dictionary<string, string?> ConfigurationOverrides { get; } = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Nexo:RunPod:QueueDepthThreshold"] = "8",
+        ["Nexo:RunPod:Timeout"] = "00:01:00",
+        ["Nexo:RunPod:PollingInterval"] = "00:00:00.050",
+        ["Nexo:RunPod:EnablePeerNetworkRouting"] = "true",
+        ["Nexo:RunPod:PreferPeerNetworkOverCloud"] = "true",
+        ["Nexo:RunPod:PeerTrustPolicy"] = "any",
+        ["Nexo:RunPod:PeerDiscoveryInterval"] = "00:00:00.150",
+        ["Nexo:RunPod:PeerCapabilityId"] = "generation.capability-routing",
+        ["Nexo:NodeCapabilityRuntime:ProfileRefreshInterval"] = "00:00:00.150",
+        ["Nexo:NodeCapabilityRuntime:NodeId"] = "virtual-prod-node"
+    };
+
+    public TimeSpan PostStartDelay { get; set; } = TimeSpan.FromMilliseconds(250);
+
+    public SimulatedHardwareProfiler HardwareProfiler { get; } = new();
+
+    public SimulatedMeshRegistry MeshRegistry { get; } = new();
+
+    public SimulatedQueueDepthProvider QueueDepthProvider { get; } = new();
+
+    public StubRunPodClient RunPodStub { get; } = new();
+
+    public StubLocalExecutor LocalExecutor { get; } = new()
+    {
+        Handler = _ => Result<GenerationExecutionResult>.Success(new GenerationExecutionResult
+        {
+            Payload = [1],
+            Provider = "virtual-local",
+            ModelId = "m",
+            IsRemote = false,
+            Summary = "virtual prod local"
+        })
+    };
+}
+
+/// <summary>Deterministic stand-in for OS / driver hardware probing.</summary>
+public sealed class SimulatedHardwareProfiler : IHardwareProfiler
+{
+    public NodeProfile Profile { get; set; } = new()
+    {
+        AvailableVRAMBytes = 64L * 1024 * 1024 * 1024,
+        TotalVRAMBytes = 64L * 1024 * 1024 * 1024,
+        Tier = NodeTier.Core,
+        CapturedAt = DateTimeOffset.UtcNow
+    };
+
+    public Task<NodeProfile> CaptureAsync(CancellationToken ct = default)
+        => Task.FromResult(Profile with { CapturedAt = DateTimeOffset.UtcNow });
+}
+
+/// <summary>In-memory mesh peer registry — mutate between polls to simulate topology churn.</summary>
+public sealed class SimulatedMeshRegistry : IInstanceDiscovery
+{
+    private readonly object _gate = new();
+    private PeerInfo[] _peers = [];
+
+    public void SetPeers(IEnumerable<PeerInfo> peers)
+    {
+        var next = peers.ToArray();
+        lock (_gate)
+            _peers = next;
+    }
+
+    public Task<IReadOnlyList<PeerInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+            return Task.FromResult<IReadOnlyList<PeerInfo>>(_peers.ToArray());
+    }
+}
+
+/// <summary>Mutable local inference queue depth (mirrors <see cref="EnvironmentQueueDepthProvider"/> role).</summary>
+public sealed class SimulatedQueueDepthProvider : ILocalQueueDepthProvider
+{
+    public int CurrentDepth { get; set; }
+}
+
+public sealed class StubRunPodClient : IRunPodClient
+{
+    public Result<RunPodInstance> SpinUpResult { get; set; } =
+        Result<RunPodInstance>.Failure("stub.spinup", "not configured");
+
+    public Result<JobHandle> DispatchResult { get; set; } =
+        Result<JobHandle>.Failure("stub.dispatch", "not configured");
+
+    public Queue<JobStatus> StatusSequence { get; set; } = new();
+
+    public Result<byte[]> PullResult { get; set; } =
+        Result<byte[]>.Failure("stub.pull", "not configured");
+
+    public Result<Unit> TerminateResult { get; set; } = Result<Unit>.Success(Unit.Value);
+
+    public Task<Result<RunPodInstance>> SpinUpInstance(string modelId, string gpuType, CancellationToken cancellationToken = default)
+        => Task.FromResult(SpinUpResult);
+
+    public Task<Result<JobHandle>> DispatchJob(string instanceId, RunPodJobPayload payload, CancellationToken cancellationToken = default)
+        => Task.FromResult(DispatchResult);
+
+    public Task<Result<JobStatus>> PollJobStatus(JobHandle jobHandle, CancellationToken cancellationToken = default)
+    {
+        if (StatusSequence.Count > 0)
+            return Task.FromResult(Result<JobStatus>.Success(StatusSequence.Dequeue()));
+        return Task.FromResult(Result<JobStatus>.Success(new JobStatus { State = RunPodJobState.Completed }));
+    }
+
+    public Task<Result<byte[]>> PullResults(JobHandle jobHandle, CancellationToken cancellationToken = default)
+        => Task.FromResult(PullResult);
+
+    public Task<Result<Unit>> TerminateInstance(string instanceId, CancellationToken cancellationToken = default)
+        => Task.FromResult(TerminateResult);
+}
+
+public sealed class StubLocalExecutor : ILocalExecutor
+{
+    public Func<RunPodJobPayload, Result<GenerationExecutionResult>> Handler { get; set; } =
+        _ => Result<GenerationExecutionResult>.Failure("stub.local", "not configured");
+
+    public Task<Result<GenerationExecutionResult>> ExecuteAsync(
+        RunPodJobPayload payload,
+        JobRequirements requirements,
+        IExecutionContext context,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(Handler(payload));
+}
+
+public sealed class VirtualProdExecutionContext : IExecutionContext
+{
+    public string AgentId { get; init; } = "virtual-prod-agent";
+    public string BehaviorId { get; init; } = "virtual-prod-behavior";
+    public bool IsAirGapped { get; init; }
+    public bool AuditMode { get; init; } = true;
+    public string Provider { get; init; } = "virtual-prod";
+    public IReadOnlyDictionary<string, object> Variables { get; init; } = new Dictionary<string, object>();
+}
+
+/// <summary>Composite brick resolution is registered by capability routing; minimal no-op for isolated host.</summary>
+internal sealed class StubBrickRegistry : IBrickRegistry
+{
+    public Brick? GetBrick(string id) => null;
+    public IReadOnlyList<Brick> GetAllBricks() => Array.Empty<Brick>();
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/ForgeEndpointsTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 namespace Nexo.Tests.Infrastructure.Tests.API;
 
 [Trait("Category", "E2E")]
+[Trait("Category", "ProdStyle")]
 public sealed class ForgeEndpointsTests : IDisposable
 {
     public ForgeEndpointsTests()

--- a/src/Nexo.Tests.Infrastructure/Tests/Adaptation/AdaptationPipelineIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Adaptation/AdaptationPipelineIntegrationTests.cs
@@ -21,6 +21,7 @@ namespace Nexo.Tests.Infrastructure.Tests.Adaptation;
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Category", "Adaptation")]
+[Trait("Category", "ProdStyle")]
 public sealed class AdaptationPipelineIntegrationTests : IDisposable
 {
     private readonly string _tempDir;

--- a/src/Nexo.Tests.Infrastructure/Tests/Composition/CompositionIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Composition/CompositionIntegrationTests.cs
@@ -11,6 +11,7 @@ namespace Nexo.Tests.Infrastructure.Tests.Composition;
 /// Integration tests for composition engine with AddCompositionInfrastructure.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public sealed class CompositionIntegrationTests
 {
     [Fact(Timeout = TestTimeouts.Integration)]

--- a/src/Nexo.Tests.Infrastructure/Tests/Hosting/HostingDeploymentProfileTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Hosting/HostingDeploymentProfileTests.cs
@@ -13,6 +13,7 @@ namespace Nexo.Tests.Infrastructure.Tests.Hosting;
 /// all deployment profiles and environment variable resolution paths.
 /// </summary>
 [Trait("Category", "E2E")]
+[Trait("Category", "ProdStyle")]
 [Collection("EnvironmentVariables")]
 public sealed class HostingDeploymentProfileTests
 {

--- a/src/Nexo.Tests.Infrastructure/Tests/Hosting/HostingE2ESmokeTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Hosting/HostingE2ESmokeTests.cs
@@ -18,6 +18,7 @@ namespace Nexo.Tests.Infrastructure.Tests.Hosting;
 /// Validates that the full kernel (orchestration, adaptation, persistence, validation) can be resolved and used.
 /// </summary>
 [Trait("Category", "E2E")]
+[Trait("Category", "ProdStyle")]
 public sealed class HostingE2ESmokeTests
 {
     [Fact(Timeout = TestTimeouts.E2E)]

--- a/src/Nexo.Tests.Infrastructure/Tests/Mesh/ArtifactNegotiatorTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Mesh/ArtifactNegotiatorTests.cs
@@ -10,6 +10,7 @@ namespace Nexo.Tests.Infrastructure.Tests.Mesh;
 /// P2.2: Artifact format negotiation tests.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public sealed class ArtifactNegotiatorTests
 {
     private readonly IArtifactNegotiator _negotiator = new ArtifactNegotiator();

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/MultiSystemNcrSimulationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/MultiSystemNcrSimulationTests.cs
@@ -16,6 +16,7 @@ namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
 /// asynchronous brick execution (<see cref="CapabilityRoutingBrick.ExecuteAsync"/>).
 /// </summary>
 [Trait("Category", "NCR")]
+[Trait("Category", "ProdStyle")]
 public sealed class MultiSystemNcrSimulationTests
 {
     [Fact]

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/MultiSystemNcrSimulationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/MultiSystemNcrSimulationTests.cs
@@ -1,0 +1,450 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Execution.Routing;
+using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
+using Nexo.Core.Domain;
+using Nexo.Core.Domain.Execution;
+using Nexo.Infrastructure.Execution.Routing;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+/// <summary>
+/// Simulates a multi-node mesh: each “instance” has its own NCR snapshot plus peer view.
+/// Covers both synchronous routing (<see cref="ICapabilityRouter.ResolveExecutionTarget"/>) and
+/// asynchronous brick execution (<see cref="CapabilityRoutingBrick.ExecuteAsync"/>).
+/// </summary>
+[Trait("Category", "NCR")]
+public sealed class MultiSystemNcrSimulationTests
+{
+    [Fact]
+    public void SyncRouting_SequentialVirtualNodes_ReflectsDistinctLocalAndPeerCapabilityViews()
+    {
+        var reqs = new JobRequirements
+        {
+            ModelId = "gen",
+            MinimumVramBytes = 6L * 1024 * 1024 * 1024,
+            ComputeClass = GpuComputeClass.Medium
+        };
+
+        var gpuCore = CreateRouter(
+            "gpu-core",
+            localVramGiB: 80,
+            GpuComputeClass.Extreme,
+            queueDepth: 0,
+            peers: [],
+            enablePeers: false);
+
+        var edge = CreateRouter(
+            "edge",
+            localVramGiB: 1,
+            GpuComputeClass.Low,
+            queueDepth: 0,
+            peers:
+            [
+                new PeerExecutionCandidate
+                {
+                    PeerId = "gpu-core",
+                    Endpoint = "http://gpu-core.internal:8080",
+                    AvailableVramBytes = 64L * 1024 * 1024 * 1024,
+                    ComputeClass = GpuComputeClass.Extreme,
+                    QueueDepth = 0
+                }
+            ],
+            enablePeers: true);
+
+        var batchOnly = CreateRouter(
+            "batch-satellite",
+            localVramGiB: 1,
+            GpuComputeClass.Low,
+            queueDepth: 0,
+            peers: [],
+            enablePeers: false);
+
+        var tCore = gpuCore.ResolveExecutionTarget(reqs);
+        var tEdge = edge.ResolveExecutionTarget(reqs);
+        var tSat = batchOnly.ResolveExecutionTarget(reqs);
+
+        tCore.Should().BeOfType<ExecutionTarget.Local>();
+        tEdge.Should().BeOfType<ExecutionTarget.Remote>("edge should offload to peer mesh when local NCR is insufficient");
+        ((ExecutionTarget.Remote)tEdge).Executor.Should().BeAssignableTo<IPeerExecutor>();
+        tSat.Should().BeOfType<ExecutionTarget.Remote>("no peers ⇒ cloud RunPod brick");
+        ((ExecutionTarget.Remote)tSat).Executor.Should().BeAssignableTo<RunPodBrick>();
+    }
+
+    [Fact]
+    public async Task AsyncRouting_ParallelVirtualNodes_ConcurrentResolutionWithoutCrossTalk()
+    {
+        const int iterations = 64;
+        var reqs = new JobRequirements
+        {
+            ModelId = "gen",
+            MinimumVramBytes = 4L * 1024 * 1024 * 1024,
+            ComputeClass = GpuComputeClass.Low
+        };
+
+        var gpuCore = CreateRouter(
+            "gpu-core-parallel",
+            localVramGiB: 48,
+            GpuComputeClass.High,
+            queueDepth: 0,
+            peers: [],
+            enablePeers: false);
+
+        var edge = CreateRouter(
+            "edge-parallel",
+            localVramGiB: 0.5,
+            GpuComputeClass.Low,
+            queueDepth: 2,
+            peers:
+            [
+                new PeerExecutionCandidate
+                {
+                    PeerId = "helper",
+                    Endpoint = "http://helper:8080",
+                    AvailableVramBytes = 24L * 1024 * 1024 * 1024,
+                    ComputeClass = GpuComputeClass.High,
+                    QueueDepth = 0
+                }
+            ],
+            enablePeers: true);
+
+        var tasks = new List<Task<bool>>();
+        foreach (var _ in Enumerable.Range(0, iterations))
+        {
+            tasks.Add(Task.Run(() => gpuCore.ResolveExecutionTarget(reqs) is ExecutionTarget.Local));
+            tasks.Add(Task.Run(() => edge.ResolveExecutionTarget(reqs) is ExecutionTarget.Remote));
+        }
+
+        var flags = await Task.WhenAll(tasks);
+        flags.Should().HaveCount(iterations * 2);
+        flags.Should().OnlyContain(x => x);
+    }
+
+    [Fact]
+    public async Task MixedSyncRouterAndAsyncBrick_EndToEnd_LocalPeerAndCloudPaths()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), $"nexo-ncr-multi-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmp);
+
+        var reqs = new JobRequirements
+        {
+            ModelId = "gen",
+            MinimumVramBytes = 8L * 1024 * 1024 * 1024,
+            ComputeClass = GpuComputeClass.Medium,
+            EstimatedDuration = TimeSpan.FromSeconds(30)
+        };
+
+        var payload = new RunPodJobPayload { ModelId = "gen", Prompt = "simulate" };
+
+        var localBrick = CreateBrickBundle(
+            "local-strong",
+            localVramGiB: 48,
+            GpuComputeClass.High,
+            queueDepth: 0,
+            peers: [],
+            enablePeers: false,
+            peerDelayMs: 0,
+            outputDir: tmp,
+            configureRunPodForRemote: false);
+
+        var peerBrick = CreateBrickBundle(
+            "edge-offload",
+            localVramGiB: 1,
+            GpuComputeClass.Low,
+            queueDepth: 0,
+            peers:
+            [
+                new PeerExecutionCandidate
+                {
+                    PeerId = "core-peer",
+                    Endpoint = "http://core-peer:8080",
+                    AvailableVramBytes = 40L * 1024 * 1024 * 1024,
+                    ComputeClass = GpuComputeClass.High,
+                    QueueDepth = 0
+                }
+            ],
+            enablePeers: true,
+            peerDelayMs: 3,
+            outputDir: tmp,
+            configureRunPodForRemote: false);
+
+        var cloudBrick = CreateBrickBundle(
+            "cloud-only",
+            localVramGiB: 1,
+            GpuComputeClass.Low,
+            queueDepth: 0,
+            peers: [],
+            enablePeers: false,
+            peerDelayMs: 0,
+            outputDir: tmp,
+            configureRunPodForRemote: true);
+
+        // Sync routing decisions (no I/O).
+        localBrick.Router.ResolveExecutionTarget(reqs).Should().BeOfType<ExecutionTarget.Local>();
+        peerBrick.Router.ResolveExecutionTarget(reqs).Should().BeOfType<ExecutionTarget.Remote>();
+        cloudBrick.Router.ResolveExecutionTarget(reqs).Should().BeOfType<ExecutionTarget.Remote>();
+
+        var ctx = new TestExecutionContext();
+
+        // Async brick execution — includes deliberately delayed peer executor to mimic async capacity.
+        var tLocal = localBrick.Brick.ExecuteAsync(payload, reqs, ctx);
+        var tPeer = peerBrick.Brick.ExecuteAsync(payload, reqs, ctx);
+        var tCloud = cloudBrick.Brick.ExecuteAsync(payload, reqs, ctx);
+
+        var outcomes = await Task.WhenAll(tLocal, tPeer, tCloud);
+        var lr = outcomes[0];
+        var pr = outcomes[1];
+        var cr = outcomes[2];
+
+        lr.IsSuccess.Should().BeTrue();
+        lr.Value!.IsRemote.Should().BeFalse();
+        lr.Value.Provider.Should().Be("local-sync-async");
+
+        pr.IsSuccess.Should().BeTrue();
+        pr.Value!.IsRemote.Should().BeTrue();
+        pr.Value.Provider.Should().Be("peer-async");
+
+        cr.IsSuccess.Should().BeTrue();
+        cr.Value!.IsRemote.Should().BeTrue();
+        cr.Value.Provider.Should().Be("runpod");
+    }
+
+    private static NcrCapabilityRouter CreateRouter(
+        string nodeId,
+        double localVramGiB,
+        GpuComputeClass computeClass,
+        int queueDepth,
+        IReadOnlyList<PeerExecutionCandidate> peers,
+        bool enablePeers)
+    {
+        var vramBytes = (long)(localVramGiB * 1024 * 1024 * 1024);
+        var snapshot = new SnapshotStub
+        {
+            AvailableVramBytes = vramBytes,
+            ComputeClass = computeClass,
+            CurrentQueueDepth = queueDepth,
+            CapturedAt = DateTimeOffset.UtcNow
+        };
+
+        var config = Options.Create(new RunPodBrickConfig
+        {
+            QueueDepthThreshold = 8,
+            Timeout = TimeSpan.FromSeconds(4),
+            PollingInterval = TimeSpan.FromMilliseconds(30),
+            OutputStagingPath = Path.Combine(Path.GetTempPath(), $"nexo-ncr-sim-{nodeId}"),
+            EnablePeerNetworkRouting = enablePeers,
+            PreferPeerNetworkOverCloud = true
+        });
+
+        var localExecutor = new StubLocalExecutor(_ => Result<GenerationExecutionResult>.Success(new GenerationExecutionResult
+        {
+            Payload = [1],
+            Provider = "local-" + nodeId,
+            ModelId = "gen",
+            IsRemote = false,
+            Summary = "local"
+        }));
+
+        var runPodBrick = new RunPodBrick(new StubRunPodClient(), config, NullLogger<RunPodBrick>.Instance);
+        var peerExecutor = new DelayedPeerExecutor(TimeSpan.FromMilliseconds(2));
+        peerExecutor.NextResult = Result<GenerationExecutionResult>.Success(new GenerationExecutionResult
+        {
+            Payload = [2],
+            Provider = "peer",
+            ModelId = "gen",
+            IsRemote = true,
+            Summary = "peer"
+        });
+
+        var peerSnapshot = new StubPeerSnapshot { Candidates = peers };
+
+        return new NcrCapabilityRouter(
+            snapshot,
+            peerSnapshot,
+            peerExecutor,
+            localExecutor,
+            runPodBrick,
+            config,
+            NullLogger<NcrCapabilityRouter>.Instance);
+    }
+
+    private static BrickBundle CreateBrickBundle(
+        string nodeId,
+        double localVramGiB,
+        GpuComputeClass computeClass,
+        int queueDepth,
+        IReadOnlyList<PeerExecutionCandidate> peers,
+        bool enablePeers,
+        int peerDelayMs,
+        string outputDir,
+        bool configureRunPodForRemote)
+    {
+        var vramBytes = (long)(localVramGiB * 1024 * 1024 * 1024);
+        var snapshot = new SnapshotStub
+        {
+            AvailableVramBytes = vramBytes,
+            ComputeClass = computeClass,
+            CurrentQueueDepth = queueDepth
+        };
+
+        var runPodClient = new StubRunPodClient();
+        if (configureRunPodForRemote)
+        {
+            runPodClient.SpinUpResult = Result<RunPodInstance>.Success(new RunPodInstance
+            {
+                InstanceId = "sim-inst",
+                ModelId = "gen",
+                GpuType = "SIM_GPU"
+            });
+            runPodClient.DispatchResult = Result<JobHandle>.Success(new JobHandle { InstanceId = "sim-inst", JobId = "sim-job" });
+            runPodClient.StatusSequence = new Queue<JobStatus>(
+            [
+                new JobStatus { State = RunPodJobState.Running },
+                new JobStatus { State = RunPodJobState.Completed }
+            ]);
+            runPodClient.PullResult = Result<byte[]>.Success([7, 7, 7]);
+            runPodClient.TerminateResult = Result<Unit>.Success(Unit.Value);
+        }
+
+        var config = Options.Create(new RunPodBrickConfig
+        {
+            QueueDepthThreshold = 8,
+            Timeout = TimeSpan.FromSeconds(6),
+            PollingInterval = TimeSpan.FromMilliseconds(25),
+            OutputStagingPath = Path.Combine(outputDir, nodeId),
+            EnablePeerNetworkRouting = enablePeers,
+            PreferPeerNetworkOverCloud = true
+        });
+
+        var localExecutor = new StubLocalExecutor(_ => Result<GenerationExecutionResult>.Success(new GenerationExecutionResult
+        {
+            Payload = [9],
+            Provider = "local-sync-async",
+            ModelId = "gen",
+            IsRemote = false,
+            Summary = "local ok"
+        }));
+
+        var runPodBrick = new RunPodBrick(runPodClient, config, NullLogger<RunPodBrick>.Instance);
+        var peerExecutor = new DelayedPeerExecutor(TimeSpan.FromMilliseconds(peerDelayMs));
+        peerExecutor.NextResult = Result<GenerationExecutionResult>.Success(new GenerationExecutionResult
+        {
+            Payload = [3, 3],
+            Provider = "peer-async",
+            ModelId = "gen",
+            IsRemote = true,
+            Summary = "peer ok"
+        });
+
+        var peerSnapshot = new StubPeerSnapshot { Candidates = peers };
+
+        var router = new NcrCapabilityRouter(
+            snapshot,
+            peerSnapshot,
+            peerExecutor,
+            localExecutor,
+            runPodBrick,
+            config,
+            NullLogger<NcrCapabilityRouter>.Instance);
+
+        var brick = new CapabilityRoutingBrick(router, NullLogger<CapabilityRoutingBrick>.Instance);
+        return new BrickBundle(router, brick);
+    }
+
+    private sealed record BrickBundle(NcrCapabilityRouter Router, CapabilityRoutingBrick Brick);
+
+    private sealed class SnapshotStub : INCRCapabilitySnapshot
+    {
+        public long AvailableVramBytes { get; set; }
+        public GpuComputeClass ComputeClass { get; set; } = GpuComputeClass.None;
+        public int CurrentQueueDepth { get; set; }
+        public DateTimeOffset CapturedAt { get; set; } = DateTimeOffset.UtcNow;
+    }
+
+    private sealed class StubPeerSnapshot : IPeerCapabilitySnapshot
+    {
+        public IReadOnlyList<PeerExecutionCandidate> Candidates { get; init; } = [];
+    }
+
+    private sealed class StubLocalExecutor : ILocalExecutor
+    {
+        private readonly Func<RunPodJobPayload, Result<GenerationExecutionResult>> _handler;
+
+        public StubLocalExecutor(Func<RunPodJobPayload, Result<GenerationExecutionResult>> handler) => _handler = handler;
+
+        public Task<Result<GenerationExecutionResult>> ExecuteAsync(
+            RunPodJobPayload payload,
+            JobRequirements requirements,
+            IExecutionContext context,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_handler(payload));
+    }
+
+    /// <summary>Peer executor that yields — exercises async scheduling distinct from sync routing.</summary>
+    private sealed class DelayedPeerExecutor : IPeerExecutor
+    {
+        private readonly TimeSpan _delay;
+        public Result<GenerationExecutionResult> NextResult { get; set; } =
+            Result<GenerationExecutionResult>.Failure("peer.not_configured", "not configured");
+
+        public DelayedPeerExecutor(TimeSpan delay) => _delay = delay;
+
+        public async Task<Result<GenerationExecutionResult>> ExecuteAsync(
+            RunPodJobPayload payload,
+            JobRequirements requirements,
+            IExecutionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (_delay > TimeSpan.Zero)
+                await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+            return NextResult;
+        }
+    }
+
+    private sealed class StubRunPodClient : IRunPodClient
+    {
+        public Result<RunPodInstance> SpinUpResult { get; set; } =
+            Result<RunPodInstance>.Failure("stub.spinup", "not configured");
+
+        public Result<JobHandle> DispatchResult { get; set; } =
+            Result<JobHandle>.Failure("stub.dispatch", "not configured");
+
+        public Queue<JobStatus> StatusSequence { get; set; } = new();
+
+        public Result<byte[]> PullResult { get; set; } =
+            Result<byte[]>.Failure("stub.pull", "not configured");
+
+        public Result<Unit> TerminateResult { get; set; } = Result<Unit>.Success(Unit.Value);
+
+        public Task<Result<RunPodInstance>> SpinUpInstance(string modelId, string gpuType, CancellationToken cancellationToken = default)
+            => Task.FromResult(SpinUpResult);
+
+        public Task<Result<JobHandle>> DispatchJob(string instanceId, RunPodJobPayload payload, CancellationToken cancellationToken = default)
+            => Task.FromResult(DispatchResult);
+
+        public Task<Result<JobStatus>> PollJobStatus(JobHandle jobHandle, CancellationToken cancellationToken = default)
+        {
+            if (StatusSequence.Count > 0)
+                return Task.FromResult(Result<JobStatus>.Success(StatusSequence.Dequeue()));
+            return Task.FromResult(Result<JobStatus>.Success(new JobStatus { State = RunPodJobState.Running }));
+        }
+
+        public Task<Result<byte[]>> PullResults(JobHandle jobHandle, CancellationToken cancellationToken = default)
+            => Task.FromResult(PullResult);
+
+        public Task<Result<Unit>> TerminateInstance(string instanceId, CancellationToken cancellationToken = default)
+            => Task.FromResult(TerminateResult);
+    }
+
+    private sealed class TestExecutionContext : IExecutionContext
+    {
+        public string AgentId { get; init; } = "ncr-sim-agent";
+        public string BehaviorId { get; init; } = "ncr-sim-behavior";
+        public bool IsAirGapped { get; init; }
+        public bool AuditMode { get; init; } = true;
+        public string Provider { get; init; } = "simulation";
+        public IReadOnlyDictionary<string, object> Variables { get; init; } = new Dictionary<string, object>();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/VirtualProductionNcrRoutingTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/VirtualProductionNcrRoutingTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Nexo.Core.Application.Execution.Routing;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.NodeCapabilityRuntime.Models;
+using Nexo.Core.Domain;
+using Nexo.Core.Domain.Execution;
+using Nexo.Infrastructure.Execution.Routing;
+using Nexo.Tests.Infrastructure.Helpers.Ncr;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
+
+/// <summary>
+/// Integration-style tests using the real capability-routing DI graph (pollers + router + bricks)
+/// inside a generic host, with deterministic substitutes for hardware and mesh — closest virtual
+/// analogue to production wiring without GPUs or real peers.
+/// </summary>
+[Trait("Category", "NCR")]
+[Trait("Category", "VirtualProduction")]
+public sealed class VirtualProductionNcrRoutingTests
+{
+    [Fact]
+    public async Task NcrCapabilityPoller_exposes_simulated_hardware_snapshot()
+    {
+        const long expectedVram = 24L * 1024 * 1024 * 1024;
+
+        await using var env = await VirtualProductionNcrRoutingHost.StartAsync(o =>
+        {
+            o.HardwareProfiler.Profile = new NodeProfile
+            {
+                AvailableVRAMBytes = expectedVram,
+                TotalVRAMBytes = expectedVram,
+                Tier = NodeTier.Standard,
+                CapturedAt = DateTimeOffset.UtcNow
+            };
+            o.PostStartDelay = TimeSpan.FromMilliseconds(300);
+        });
+
+        var snap = env.GetNcrSnapshot();
+        snap.AvailableVramBytes.Should().Be(expectedVram);
+        snap.ComputeClass.Should().Be(GpuComputeClass.High);
+    }
+
+    [Fact]
+    public async Task Peer_snapshot_refresh_changes_routing_preference_cloud_then_peer()
+    {
+        await using var env = await VirtualProductionNcrRoutingHost.StartAsync(o =>
+        {
+            o.HardwareProfiler.Profile = new NodeProfile
+            {
+                AvailableVRAMBytes = 512L * 1024 * 1024,
+                TotalVRAMBytes = 512L * 1024 * 1024,
+                Tier = NodeTier.Nano,
+                CapturedAt = DateTimeOffset.UtcNow
+            };
+            o.RunPodStub.SpinUpResult = Result<RunPodInstance>.Success(new RunPodInstance
+            {
+                InstanceId = "cloud-inst",
+                ModelId = "m",
+                GpuType = "SIM"
+            });
+            o.RunPodStub.DispatchResult = Result<JobHandle>.Success(new JobHandle { InstanceId = "cloud-inst", JobId = "j1" });
+            o.RunPodStub.StatusSequence = new Queue<JobStatus>(
+            [
+                new JobStatus { State = RunPodJobState.Completed }
+            ]);
+            o.RunPodStub.PullResult = Result<byte[]>.Success([1]);
+            o.RunPodStub.TerminateResult = Result<Unit>.Success(Unit.Value);
+            o.PostStartDelay = TimeSpan.FromMilliseconds(350);
+        });
+
+        var reqs = new JobRequirements
+        {
+            ModelId = "large",
+            MinimumVramBytes = 8L * 1024 * 1024 * 1024,
+            ComputeClass = GpuComputeClass.Medium
+        };
+
+        var router = env.GetRouter();
+
+        var beforePeer = router.ResolveExecutionTarget(reqs);
+        beforePeer.Should().BeOfType<ExecutionTarget.Remote>();
+        ((ExecutionTarget.Remote)beforePeer).Executor.Should().BeOfType<RunPodBrick>();
+
+        env.Mesh.SetPeers(
+        [
+            new PeerInfo
+            {
+                PeerId = "cluster-gpu-1",
+                Endpoint = "http://cluster-gpu-1.mesh.local:8080",
+                TrustTier = PeerTrustTier.Trusted,
+                Capabilities =
+                [
+                    "generation.capability-routing",
+                    "vram:68719476736",
+                    "compute:High",
+                    "queue:0",
+                    "trust:Trusted"
+                ]
+            }
+        ]);
+
+        await Task.Delay(600);
+
+        var afterPeer = router.ResolveExecutionTarget(reqs);
+        afterPeer.Should().BeOfType<ExecutionTarget.Remote>();
+        ((ExecutionTarget.Remote)afterPeer).Executor.Should().BeAssignableTo<IPeerExecutor>();
+    }
+
+    [Fact]
+    public async Task CapabilityRoutingBrick_executes_locally_when_ncr_snapshot_satisfies_job()
+    {
+        await using var env = await VirtualProductionNcrRoutingHost.StartAsync(o =>
+        {
+            o.HardwareProfiler.Profile = new NodeProfile
+            {
+                AvailableVRAMBytes = 96L * 1024 * 1024 * 1024,
+                TotalVRAMBytes = 96L * 1024 * 1024 * 1024,
+                Tier = NodeTier.Core,
+                CapturedAt = DateTimeOffset.UtcNow
+            };
+            o.PostStartDelay = TimeSpan.FromMilliseconds(300);
+        });
+
+        var reqs = new JobRequirements
+        {
+            ModelId = "small",
+            MinimumVramBytes = 4L * 1024 * 1024 * 1024,
+            ComputeClass = GpuComputeClass.Medium
+        };
+
+        var brick = env.GetCapabilityRoutingBrick();
+        var result = await brick.ExecuteAsync(
+            new RunPodJobPayload { ModelId = "small", Prompt = "virtual prod" },
+            reqs,
+            new VirtualProdExecutionContext());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Provider.Should().Be("virtual-local");
+        result.Value.IsRemote.Should().BeFalse();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/VirtualProductionNcrRoutingTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/NodeCapabilityRuntime/VirtualProductionNcrRoutingTests.cs
@@ -17,6 +17,7 @@ namespace Nexo.Tests.Infrastructure.Tests.NodeCapabilityRuntime;
 /// </summary>
 [Trait("Category", "NCR")]
 [Trait("Category", "VirtualProduction")]
+[Trait("Category", "ProdStyle")]
 public sealed class VirtualProductionNcrRoutingTests
 {
     [Fact]

--- a/src/Nexo.Tests.Infrastructure/Tests/Observation/ObservationPipelineIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Observation/ObservationPipelineIntegrationTests.cs
@@ -54,7 +54,7 @@ public sealed class ObservationPipelineIntegrationTests : IDisposable
             new[] { "*.cs" },
             loggerFactory.CreateLogger<FileSystemEventSource>());
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var eventCount = 0;
         var processTask = Task.Run(async () =>
         {
@@ -68,15 +68,24 @@ public sealed class ObservationPipelineIntegrationTests : IDisposable
         }, cts.Token);
 
         await File.WriteAllTextAsync(testFile, "// v1", cts.Token);
-        await Task.Delay(200, cts.Token);
+        await Task.Delay(400, cts.Token);
         await File.WriteAllTextAsync(testFile, "// v2", cts.Token);
-        await Task.Delay(200, cts.Token);
+        await Task.Delay(400, cts.Token);
         await File.WriteAllTextAsync(testFile, "// v3", cts.Token);
 
         await processTask;
+        await Task.Delay(600, CancellationToken.None);
 
-        using var queryCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var patterns = await store.QueryAsync(new PatternStoreQueryParams { MaxCount = 10 }, queryCts.Token);
+        using var queryCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        IReadOnlyList<ObservedPattern> patterns = [];
+        for (var attempt = 0; attempt < 15; attempt++)
+        {
+            patterns = await store.QueryAsync(new PatternStoreQueryParams { MaxCount = 10 }, queryCts.Token);
+            if (patterns.Any(p => p.EventType == "repeated-edits"))
+                break;
+            await Task.Delay(200, queryCts.Token);
+        }
+
         Assert.Contains(patterns, p => p.EventType == "repeated-edits");
         Assert.True(patterns.First(p => p.EventType == "repeated-edits").Frequency >= 3);
     }

--- a/src/Nexo.Tests.Infrastructure/Tests/Observation/ObservationPipelineIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Observation/ObservationPipelineIntegrationTests.cs
@@ -15,6 +15,7 @@ namespace Nexo.Tests.Infrastructure.Tests.Observation;
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public sealed class ObservationPipelineIntegrationTests : IDisposable
 {
     private readonly string _tempDir;

--- a/src/Nexo.Tests.Infrastructure/Tests/SelfContext/SelfContextIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/SelfContext/SelfContextIntegrationTests.cs
@@ -17,6 +17,7 @@ namespace Nexo.Tests.Infrastructure.Tests.SelfContext;
 /// Integration tests for SelfContextAssembler with seeded IAdaptationLog, IExecutionTracer, IPatternStore.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public sealed class SelfContextIntegrationTests : IDisposable
 {
     private readonly IDisposable _tempDirCleanup;

--- a/src/Nexo.Tests.Infrastructure/Tests/Workflows/WorkflowExecutorIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Workflows/WorkflowExecutorIntegrationTests.cs
@@ -20,6 +20,7 @@ namespace Nexo.Tests.Infrastructure.Tests.Workflows;
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public sealed class WorkflowExecutorIntegrationTests
 {
     private static WorkflowExecutor CreateExecutor(IBrickRegistry brickRegistry)

--- a/src/Nexo.Tests.Orchestration/Integration/ArchitectAgentIntegrationTests.cs
+++ b/src/Nexo.Tests.Orchestration/Integration/ArchitectAgentIntegrationTests.cs
@@ -13,6 +13,8 @@ using Xunit;
 
 namespace Nexo.Tests.Orchestration.Integration;
 
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public class ArchitectAgentIntegrationTests
 {
     private readonly Mock<IModel> _modelMock;

--- a/src/Nexo.Tests.Orchestration/Integration/DiverseRequestTests.cs
+++ b/src/Nexo.Tests.Orchestration/Integration/DiverseRequestTests.cs
@@ -16,6 +16,8 @@ namespace Nexo.Tests.Orchestration.Integration;
 /// <summary>
 /// Tests the Architect Agent with diverse request types to ensure it handles various scenarios.
 /// </summary>
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public class DiverseRequestTests
 {
     private readonly Mock<IModel> _modelMock;

--- a/src/Nexo.Tests.Orchestration/Integration/EndToEndOrchestrationTests.cs
+++ b/src/Nexo.Tests.Orchestration/Integration/EndToEndOrchestrationTests.cs
@@ -21,6 +21,8 @@ namespace Nexo.Tests.Orchestration.Integration;
 /// <summary>
 /// End-to-end tests for the complete orchestration flow: request → Architect → spawn agents → outputs.
 /// </summary>
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
 public class EndToEndOrchestrationTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/src/Nexo.Tests.Transport/AssemblyAttributes.cs
+++ b/src/Nexo.Tests.Transport/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: AssemblyTrait("Category", "ProdStyle")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Prime-time testing:** `Nexo.PrimeTime.slnf` lists all nine automated test projects (no MAUI/Android workloads). `make test-prime-time` runs `Category=ProdStyle` across that slice; `make test-prime-time-full` runs the full matrix afterward.
- **ProdStyle coverage:** `UnitTestBridgeTests` (Application, Domain, Infrastructure, CLI), orchestration integration suites, Forge CLI E2E, BackgroundAgents forge/smoke, `[assembly: AssemblyTrait]` on GameDomain + Transport.
- **Reliability:** Observation pipeline integration test uses longer timing + polled pattern query (fixes net8 flake under parallel load).
- **Docs:** `docs/Testing.md`, `docs/architecture/TestingModel.md`.

## Verification

- `dotnet build Nexo.PrimeTime.slnf`
- `dotnet test Nexo.PrimeTime.slnf --filter Category=ProdStyle`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e3a1917-7683-4ea7-89c8-5bed667defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

