### PR TITLE
Middleware ingress: correlation, Swagger, WebSocket lab, SMS simulation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,8 +137,9 @@
   <ItemGroup>
     <PackageVersion Include="CsCheck" Version="4.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <!-- xUnit 2.7+ enforces async-only [Fact(Timeout=...)]; keep 2.6.x until sync tests are migrated. -->
+    <PackageVersion Include="xunit" Version="2.6.6" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.8" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,9 @@ test-prime-time-full: test-prime-time
 
 # Run tests locally (blame-hang-timeout prevents indefinite freeze from hung tests)
 # --blame-hang-dump-type none avoids 6GB+ hang dumps that accumulate in TestResults/
+# NEXO_ALLOW_MOCK=1 matches CI so ProviderFactory / mock-provider tests pass on net9.0.
 test:
-	dotnet test --blame-hang-timeout 30s --blame-hang-dump-type none
+	NEXO_ALLOW_MOCK=1 dotnet test Nexo.sln --blame-hang-timeout 120s --blame-hang-dump-type none
 
 # Run tests on all target platforms: local + Docker (ubuntu, alpine, debian).
 # For native macOS/Windows/Linux use: make test-cross-platform (triggers CI).

--- a/docs/MiddlewareIngress.md
+++ b/docs/MiddlewareIngress.md
@@ -1,0 +1,64 @@
+# Middleware ingress (HTTP, MediatR, WebSocket lab, SMS lab, AWS follow-on)
+
+This document closes the operational gaps around **multi-transport middleware**: how headers flow into Nexo, how MediatR sees them, what is implemented in-process versus what belongs in AWS, and how to gate spend.
+
+## In-repo surfaces
+
+| Surface | Route / artifact | Purpose |
+|--------|-------------------|---------|
+| Correlation | `X-Correlation-Id` (in + out), `Activity` tag `nexo.correlation_id` | End-to-end tracing. |
+| Ingress envelope | `X-Nexo-Tenant`, `X-Nexo-App-Id`, `X-Idempotency-Key`, `X-Nexo-Payload-Version` | Adapter-agnostic metadata on HTTP requests. |
+| Operator echo | `GET /api/middleware/correlation-echo` | Quick sanity check. |
+| Operator snapshot | `GET /api/middleware/ingress-context` | JSON view of mapped ingress (tests + debugging). |
+| Catalog | `GET /api/middleware/ingress-catalog` | Static list of ingress seams (HTTP, Forge, WS lab, SMS lab, Swagger). |
+| OpenAPI | `/swagger/v1/swagger.json`, Swagger UI | Contract visibility for integrators. |
+| WebSocket lab | `GET /ws/v1/echo` | Feature-flagged echo (JSON hello + text echo). |
+| SMS lab | `POST /api/ingress/sms/simulate` | Parses `YES <token>`; in-memory idempotent store. **Not** signed AWS callbacks. |
+
+Configuration: `Nexo:MiddlewareIngress` in `appsettings.json` (`EnableWebSocketIngress`, `EnableSmsSimulationIngress`, `SmsSimulationAllowedAppIds`, `DisabledCapabilities`, `TenantCapabilityAllowlists`).
+
+## MediatR and `INexoIngressAccessor`
+
+- **`INexoIngressAccessor`** exposes correlation, transport, tenant, app id, idempotency, and payload version. Nexo.API registers **`HttpNexoIngressAccessor`** before `AddNexo()` so it overrides the default no-op.
+- **`IngressLoggingPipelineBehavior`** (registered in `AddNexo`) wraps every MediatR request in a logging scope when `CorrelationId` is present, so handlers and validators inherit structured logging fields without changing individual commands.
+- CLI and non-web hosts keep **`NoOpNexoIngressAccessor`** via `TryAddSingleton` when no HTTP implementation is registered.
+
+Handlers that need full detail can also call `HttpContext.GetIngressEnvelope()` in the API layer.
+
+## AWS: production-style inbound SMS (not shipped in-process)
+
+The lab endpoint exists to **parse and unit-test** approval keywords. A production path typically looks like:
+
+1. **End User Messaging (SMS)** two-way number → inbound publishes to **SNS topic**.
+2. **Lambda** (SNS subscription) validates sender, rate limits, parses `YES <run-id>`, writes idempotent state (**DynamoDB** or **SSM**), optionally calls **Step Functions** `SendTaskSuccess` or the **GitHub API** (fine-grained PAT or GitHub App) to satisfy an environment approval.
+3. **Outbound** estimates use **SNS Publish** to the operator handset; enforce **spend limits** and region support.
+4. **IAM**: OIDC from GitHub Actions to a **least-privilege role**; never long-lived keys in the repo.
+5. **Cost**: **AWS Budgets** + billing alarms; fixed **EC2** or **Lambda** memory/timeouts for workers that apply approvals.
+
+Wire contract: treat Lambda’s normalized payload as the same conceptual shape as `SmsInboundSimulationRequest` (from, body, stable external id for idempotency) and map into your approval store interface in application code **outside** Nexo.API if you want strict network boundaries.
+
+## GitHub approval without SMS
+
+Use **GitHub Environments** with required reviewers on the job that assumes AWS OIDC or starts expensive resources. SMS can mirror that approval for on-call, but the environment gate is the simplest hard stop.
+
+## Smoke script
+
+From repo root against a running API:
+
+```bash
+NEXO_BASE_URL=http://127.0.0.1:8080 ./scripts/middleware-ingress-smoke.sh
+```
+
+Set `RUN_SMS_SMOKE=1` only when `EnableSmsSimulationIngress` is true on the server.
+
+## Tests
+
+Integration coverage lives in `Nexo.Tests.Infrastructure` → `MiddlewareIngressIntegrationTests` (net8.0 `WebApplicationFactory` host).
+
+From repo root, full solution tests (matches `make test`):
+
+```bash
+NEXO_ALLOW_MOCK=1 dotnet test Nexo.sln --blame-hang-timeout 120s --blame-hang-dump-type none
+```
+
+`NEXO_ALLOW_MOCK=1` is required for mock-provider integration tests on net9.0; `make test` sets this automatically.

--- a/scripts/middleware-ingress-smoke.sh
+++ b/scripts/middleware-ingress-smoke.sh
@@ -22,6 +22,10 @@ echo "== GET /api/middleware/correlation-echo (X-Correlation-Id: $CID) =="
 curl -fsS -H "X-Correlation-Id: $CID" "$BASE/api/middleware/correlation-echo"
 echo ""
 
+echo "== GET /api/middleware/ingress-context (with X-Correlation-Id) =="
+curl -fsS -H "X-Correlation-Id: $CID" "$BASE/api/middleware/ingress-context"
+echo ""
+
 echo "== GET /swagger/v1/swagger.json (grep IngressCorrelationEcho) =="
 curl -fsS "$BASE/swagger/v1/swagger.json" | grep -q "IngressCorrelationEcho" && echo "ok: swagger mentions IngressCorrelationEcho"
 

--- a/scripts/middleware-ingress-smoke.sh
+++ b/scripts/middleware-ingress-smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Smoke checks for middleware ingress (correlation, catalog, Swagger, optional SMS lab).
+# Usage from repo root against a running Nexo.API:
+#   NEXO_BASE_URL=http://127.0.0.1:8080 ./scripts/middleware-ingress-smoke.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE="${NEXO_BASE_URL:-http://127.0.0.1:8080}"
+
+echo "== Base: $BASE =="
+
+echo "== GET /health =="
+curl -fsS "$BASE/health" | head -c 200 || true
+echo ""
+
+echo "== GET /api/middleware/ingress-catalog =="
+curl -fsS "$BASE/api/middleware/ingress-catalog" | head -c 400 || true
+echo ""
+
+CID="smoke-$(date +%s)"
+echo "== GET /api/middleware/correlation-echo (X-Correlation-Id: $CID) =="
+curl -fsS -H "X-Correlation-Id: $CID" "$BASE/api/middleware/correlation-echo"
+echo ""
+
+echo "== GET /swagger/v1/swagger.json (grep IngressCorrelationEcho) =="
+curl -fsS "$BASE/swagger/v1/swagger.json" | grep -q "IngressCorrelationEcho" && echo "ok: swagger mentions IngressCorrelationEcho"
+
+if [[ "${RUN_SMS_SMOKE:-}" == "1" ]]; then
+  echo "== POST /api/ingress/sms/simulate (requires EnableSmsSimulationIngress on server) =="
+  curl -fsS -X POST "$BASE/api/ingress/sms/simulate" \
+    -H "Content-Type: application/json" \
+    -d '{"from":"+15555550100","body":"YES smoke-token","messageSid":"SM-smoke-1"}'
+  echo ""
+fi
+
+echo "Done."

--- a/src/Nexo.API/Middleware/Ingress/CorrelationIdMiddleware.cs
+++ b/src/Nexo.API/Middleware/Ingress/CorrelationIdMiddleware.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+
+namespace Nexo.API.Middleware.Ingress;
+
+/// <summary>
+/// Accepts or generates <c>X-Correlation-Id</c>, exposes it on <see cref="HttpContext.Items"/> and response headers,
+/// and tags the current <see cref="Activity"/> when present.
+/// </summary>
+public sealed class CorrelationIdMiddleware(RequestDelegate next)
+{
+    public const string HeaderName = "X-Correlation-Id";
+    public const string HttpContextItemKey = "Nexo.CorrelationId";
+
+    public Task InvokeAsync(HttpContext context)
+    {
+        var incoming = context.Request.Headers[HeaderName].FirstOrDefault();
+        var id = string.IsNullOrWhiteSpace(incoming) ? Guid.NewGuid().ToString("N") : incoming.Trim();
+
+        context.Items[HttpContextItemKey] = id;
+        context.Response.Headers.Append(HeaderName, id);
+
+        Activity.Current?.AddTag("nexo.correlation_id", id);
+
+        return next(context);
+    }
+}

--- a/src/Nexo.API/Middleware/Ingress/HttpNexoIngressAccessor.cs
+++ b/src/Nexo.API/Middleware/Ingress/HttpNexoIngressAccessor.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+using Nexo.Core.Application.Middleware.Ports;
+
+namespace Nexo.API.Middleware.Ingress;
+
+/// <summary>
+/// Maps ASP.NET Core <see cref="HttpContext"/> ingress items to <see cref="INexoIngressAccessor"/> for MediatR and handlers.
+/// </summary>
+public sealed class HttpNexoIngressAccessor(IHttpContextAccessor httpContextAccessor) : INexoIngressAccessor
+{
+    public string? CorrelationId
+    {
+        get
+        {
+            var ctx = httpContextAccessor.HttpContext;
+            return ctx?.Items.TryGetValue(CorrelationIdMiddleware.HttpContextItemKey, out var c) == true && c is string s
+                ? s
+                : null;
+        }
+    }
+
+    public string? Transport => GetEnvelope()?.Transport;
+
+    public string? TenantId => GetEnvelope()?.TenantId;
+
+    public string? AppId => GetEnvelope()?.AppId;
+
+    public string? IdempotencyKey => GetEnvelope()?.IdempotencyKey;
+
+    public string? PayloadVersion => GetEnvelope()?.PayloadVersion;
+
+    private Nexo.Contracts.NexoIngressEnvelope? GetEnvelope() =>
+        httpContextAccessor.HttpContext?.GetIngressEnvelope();
+}

--- a/src/Nexo.API/Middleware/Ingress/ISmsIngressApprovalStore.cs
+++ b/src/Nexo.API/Middleware/Ingress/ISmsIngressApprovalStore.cs
@@ -1,0 +1,12 @@
+using Nexo.Contracts;
+
+namespace Nexo.API.Middleware.Ingress;
+
+public interface ISmsIngressApprovalStore
+{
+    Task<SmsInboundSimulationResponse> TryRecordApprovalAsync(
+        string from,
+        string approvalToken,
+        string? messageSid,
+        CancellationToken cancellationToken);
+}

--- a/src/Nexo.API/Middleware/Ingress/IngressCapability.cs
+++ b/src/Nexo.API/Middleware/Ingress/IngressCapability.cs
@@ -1,0 +1,7 @@
+namespace Nexo.API.Middleware.Ingress;
+
+public static class IngressCapability
+{
+    public const string WebSocket = "websocket";
+    public const string SmsSimulation = "sms-simulation";
+}

--- a/src/Nexo.API/Middleware/Ingress/IngressCatalog.cs
+++ b/src/Nexo.API/Middleware/Ingress/IngressCatalog.cs
@@ -11,7 +11,7 @@ public static class IngressCatalog
         new IngressCatalogEntry("ForgeHttpApi", "/forge/*", "Forge session HTTP surface (tenant middleware)."),
         new IngressCatalogEntry("Health", "/health", "Liveness probe."),
         new IngressCatalogEntry("OpenApi", "/swagger/v1/swagger.json", "Swagger/OpenAPI document when enabled."),
-        new IngressCatalogEntry("MiddlewareIngress", "/api/middleware/*", "Correlation echo + ingress catalog."),
+        new IngressCatalogEntry("MiddlewareIngress", "/api/middleware/*", "Correlation echo, ingress catalog, ingress context snapshot."),
         new IngressCatalogEntry("WebSocketLab", "/ws/v1/echo", "Optional lab echo (feature-flagged)."),
         new IngressCatalogEntry("SmsSimulation", "/api/ingress/sms/simulate", "Optional inbound SMS keyword lab (feature-flagged)."),
         new IngressCatalogEntry("GrpcTransportHost", "(separate host)", "See Nexo.Transport.Grpc.Server.Host — not co-hosted in Nexo.API."),

--- a/src/Nexo.API/Middleware/Ingress/IngressCatalog.cs
+++ b/src/Nexo.API/Middleware/Ingress/IngressCatalog.cs
@@ -1,0 +1,19 @@
+using Nexo.Contracts;
+
+namespace Nexo.API.Middleware.Ingress;
+
+/// <summary>Phase A inventory — canonical HTTP/WebSocket/SMS lab seams (no secrets).</summary>
+public static class IngressCatalog
+{
+    public static IngressCatalogResponse Current { get; } = new(
+    [
+        new IngressCatalogEntry("HttpApi", "/api/*", "Primary REST ingress via MapNexoEndpoints (MediatR-backed handlers)."),
+        new IngressCatalogEntry("ForgeHttpApi", "/forge/*", "Forge session HTTP surface (tenant middleware)."),
+        new IngressCatalogEntry("Health", "/health", "Liveness probe."),
+        new IngressCatalogEntry("OpenApi", "/swagger/v1/swagger.json", "Swagger/OpenAPI document when enabled."),
+        new IngressCatalogEntry("MiddlewareIngress", "/api/middleware/*", "Correlation echo + ingress catalog."),
+        new IngressCatalogEntry("WebSocketLab", "/ws/v1/echo", "Optional lab echo (feature-flagged)."),
+        new IngressCatalogEntry("SmsSimulation", "/api/ingress/sms/simulate", "Optional inbound SMS keyword lab (feature-flagged)."),
+        new IngressCatalogEntry("GrpcTransportHost", "(separate host)", "See Nexo.Transport.Grpc.Server.Host — not co-hosted in Nexo.API."),
+    ]);
+}

--- a/src/Nexo.API/Middleware/Ingress/IngressEndpoints.cs
+++ b/src/Nexo.API/Middleware/Ingress/IngressEndpoints.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Nexo.Contracts;
+using Nexo.Core.Application.Middleware.Ports;
 
 namespace Nexo.API.Middleware.Ingress;
 
@@ -29,6 +30,17 @@ public static class IngressEndpoints
         ingressGroup.MapGet("/ingress-catalog", () => Results.Ok(IngressCatalog.Current))
             .WithName("IngressCatalog")
             .WithSummary("Operator inventory of ingress seams (Phase A)");
+
+        ingressGroup.MapGet("/ingress-context", (INexoIngressAccessor ingress) =>
+                Results.Ok(new IngressContextResponse(
+                    ingress.CorrelationId,
+                    ingress.Transport,
+                    ingress.TenantId,
+                    ingress.AppId,
+                    ingress.IdempotencyKey,
+                    ingress.PayloadVersion)))
+            .WithName("IngressContext")
+            .WithSummary("Snapshot of ingress headers mapped for this request (MediatR logging scope source)");
 
         app.MapPost("/api/ingress/sms/simulate", HandleSmsSimulateAsync)
             .WithTags("MiddlewareIngress")

--- a/src/Nexo.API/Middleware/Ingress/IngressEndpoints.cs
+++ b/src/Nexo.API/Middleware/Ingress/IngressEndpoints.cs
@@ -1,0 +1,157 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Nexo.Contracts;
+
+namespace Nexo.API.Middleware.Ingress;
+
+public static class IngressEndpoints
+{
+    private static readonly Regex YesTokenPattern = new(@"^\s*YES\s+(?<token>\S+)\s*$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    public static WebApplication MapIngressEndpoints(this WebApplication app)
+    {
+        var ingressGroup = app.MapGroup("/api/middleware").WithTags("MiddlewareIngress");
+
+        ingressGroup.MapGet("/correlation-echo", (HttpContext ctx) =>
+            {
+                var id = ctx.Items.TryGetValue(CorrelationIdMiddleware.HttpContextItemKey, out var v) && v is string s
+                    ? s
+                    : string.Empty;
+                return Results.Ok(new { correlationId = id });
+            })
+            .WithName("IngressCorrelationEcho")
+            .WithSummary("Echoes the active correlation id for this HTTP request");
+
+        ingressGroup.MapGet("/ingress-catalog", () => Results.Ok(IngressCatalog.Current))
+            .WithName("IngressCatalog")
+            .WithSummary("Operator inventory of ingress seams (Phase A)");
+
+        app.MapPost("/api/ingress/sms/simulate", HandleSmsSimulateAsync)
+            .WithTags("MiddlewareIngress")
+            .WithName("SmsInboundSimulate")
+            .WithSummary("Lab-only simulated inbound SMS approval line (keyword YES &lt;token&gt;)");
+
+        app.Map("/ws/v1/echo", HandleWebSocketEchoAsync);
+
+        return app;
+    }
+
+    private static async Task<IResult> HandleSmsSimulateAsync(
+        HttpContext httpContext,
+        [FromServices] IOptionsMonitor<NexoMiddlewareIngressOptions> optsMonitor,
+        [FromServices] ISmsIngressApprovalStore smsStore,
+        [FromBody] SmsInboundSimulationRequest? body,
+        CancellationToken cancellationToken)
+    {
+        var options = optsMonitor.CurrentValue;
+        if (!options.EnableSmsSimulationIngress)
+            return Results.NotFound();
+
+        if (IsCapabilityDisabled(options, IngressCapability.SmsSimulation))
+            return Results.StatusCode(StatusCodes.Status403Forbidden);
+
+        var tenantId = httpContext.Request.Headers["X-Nexo-Tenant"].FirstOrDefault();
+        if (!TenantAllowsCapability(options, tenantId, IngressCapability.SmsSimulation))
+            return Results.StatusCode(StatusCodes.Status403Forbidden);
+
+        if (body is null || string.IsNullOrWhiteSpace(body.From) || string.IsNullOrWhiteSpace(body.Body))
+            return Results.BadRequest(new { title = "Invalid body", detail = "From and Body are required." });
+
+        var appId = body.AppId ?? httpContext.Request.Headers["X-Nexo-App-Id"].FirstOrDefault();
+        if (options.SmsSimulationAllowedAppIds.Length > 0)
+        {
+            if (string.IsNullOrWhiteSpace(appId)
+                || !options.SmsSimulationAllowedAppIds.Contains(appId.Trim(), StringComparer.Ordinal))
+            {
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+        }
+
+        var match = YesTokenPattern.Match(body.Body);
+        if (!match.Success)
+        {
+            return Results.Ok(new SmsInboundSimulationResponse(false, null, "Body must match \"YES <token>\".", false));
+        }
+
+        var token = match.Groups["token"].Value.Trim();
+        var response = await smsStore.TryRecordApprovalAsync(body.From.Trim(), token, body.MessageSid, cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(response);
+    }
+
+    private static bool IsCapabilityDisabled(NexoMiddlewareIngressOptions options, string capability) =>
+        options.DisabledCapabilities.Contains(capability, StringComparer.OrdinalIgnoreCase);
+
+    private static bool TenantAllowsCapability(NexoMiddlewareIngressOptions options, string? tenantId, string capability)
+    {
+        if (options.TenantCapabilityAllowlists.Count == 0 || string.IsNullOrWhiteSpace(tenantId))
+            return true;
+
+        if (!options.TenantCapabilityAllowlists.TryGetValue(tenantId.Trim(), out var allow))
+            return true;
+
+        return allow.Contains(capability, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static async Task HandleWebSocketEchoAsync(HttpContext context)
+    {
+        var opts = context.RequestServices.GetRequiredService<IOptionsMonitor<NexoMiddlewareIngressOptions>>().CurrentValue;
+        if (!opts.EnableWebSocketIngress || IsCapabilityDisabled(opts, IngressCapability.WebSocket))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        var tenantHeader = context.Request.Headers["X-Nexo-Tenant"].FirstOrDefault();
+        if (!TenantAllowsCapability(opts, tenantHeader, IngressCapability.WebSocket))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return;
+        }
+
+        if (!context.WebSockets.IsWebSocketRequest)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync("Expected WebSocket upgrade.", context.RequestAborted).ConfigureAwait(false);
+            return;
+        }
+
+        using var socket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
+
+        var correlation =
+            context.Items.TryGetValue(CorrelationIdMiddleware.HttpContextItemKey, out var c) && c is string cs
+                ? cs
+                : Guid.NewGuid().ToString("N");
+
+        var hello = JsonSerializer.Serialize(new { type = "hello", correlationId = correlation, transport = NexoIngressTransports.WebSocket });
+        await SendTextAsync(socket, hello, context.RequestAborted).ConfigureAwait(false);
+
+        var buffer = new byte[4096];
+        while (socket.State == WebSocketState.Open)
+        {
+            var result = await socket.ReceiveAsync(buffer.AsMemory(), context.RequestAborted).ConfigureAwait(false);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", context.RequestAborted).ConfigureAwait(false);
+                break;
+            }
+
+            if (result.MessageType == WebSocketMessageType.Text)
+            {
+                var text = Encoding.UTF8.GetString(buffer.AsSpan(0, result.Count));
+                var echo = JsonSerializer.Serialize(new { type = "echo", correlationId = correlation, text });
+                await SendTextAsync(socket, echo, context.RequestAborted).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task SendTextAsync(WebSocket socket, string text, CancellationToken cancellationToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        await socket.SendAsync(bytes.AsMemory(), WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Nexo.API/Middleware/Ingress/IngressEnvelopeMiddleware.cs
+++ b/src/Nexo.API/Middleware/Ingress/IngressEnvelopeMiddleware.cs
@@ -1,0 +1,32 @@
+using Nexo.Contracts;
+
+namespace Nexo.API.Middleware.Ingress;
+
+/// <summary>
+/// Builds a transport-agnostic <see cref="NexoIngressEnvelope"/> for HTTP requests (WebSocket + SMS adapters set their own).
+/// </summary>
+public sealed class IngressEnvelopeMiddleware(RequestDelegate next)
+{
+    public Task InvokeAsync(HttpContext context)
+    {
+        var correlation =
+            context.Items.TryGetValue(CorrelationIdMiddleware.HttpContextItemKey, out var c) && c is string s
+                ? s
+                : Guid.NewGuid().ToString("N");
+
+        var idempotency = context.Request.Headers["X-Idempotency-Key"].FirstOrDefault();
+        var payloadVersion = context.Request.Headers["X-Nexo-Payload-Version"].FirstOrDefault();
+        var tenantId = context.Request.Headers["X-Nexo-Tenant"].FirstOrDefault();
+        var appId = context.Request.Headers["X-Nexo-App-Id"].FirstOrDefault();
+
+        context.Items[NexoIngressEnvelope.HttpContextItemKey] = new NexoIngressEnvelope(
+            correlation,
+            NexoIngressTransports.Http,
+            string.IsNullOrWhiteSpace(idempotency) ? null : idempotency.Trim(),
+            string.IsNullOrWhiteSpace(payloadVersion) ? null : payloadVersion.Trim(),
+            string.IsNullOrWhiteSpace(tenantId) ? null : tenantId.Trim(),
+            string.IsNullOrWhiteSpace(appId) ? null : appId.Trim());
+
+        return next(context);
+    }
+}

--- a/src/Nexo.API/Middleware/Ingress/MemorySmsIngressApprovalStore.cs
+++ b/src/Nexo.API/Middleware/Ingress/MemorySmsIngressApprovalStore.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using Nexo.Contracts;
+
+namespace Nexo.API.Middleware.Ingress;
+
+/// <summary>In-memory idempotent approvals for SMS simulation labs only.</summary>
+public sealed class MemorySmsIngressApprovalStore : ISmsIngressApprovalStore
+{
+    private readonly ConcurrentDictionary<string, SmsInboundSimulationResponse> _byExternalId = new(StringComparer.Ordinal);
+
+    public Task<SmsInboundSimulationResponse> TryRecordApprovalAsync(
+        string from,
+        string approvalToken,
+        string? messageSid,
+        CancellationToken cancellationToken)
+    {
+        var externalId = !string.IsNullOrWhiteSpace(messageSid)
+            ? $"sid:{messageSid.Trim()}"
+            : $"hash:{from}:{approvalToken}";
+
+        if (_byExternalId.TryGetValue(externalId, out var existing))
+            return Task.FromResult(existing with { IdempotentReplay = true });
+
+        var fresh = new SmsInboundSimulationResponse(true, approvalToken, "Recorded YES approval.", false);
+        _byExternalId[externalId] = fresh;
+        return Task.FromResult(fresh);
+    }
+}

--- a/src/Nexo.API/Middleware/Ingress/NexoIngressHttpContextExtensions.cs
+++ b/src/Nexo.API/Middleware/Ingress/NexoIngressHttpContextExtensions.cs
@@ -1,0 +1,12 @@
+using Nexo.Contracts;
+
+namespace Nexo.API.Middleware.Ingress;
+
+/// <summary>HTTP helpers for adapters mapping into shared ingress metadata.</summary>
+public static class NexoIngressHttpContextExtensions
+{
+    public static NexoIngressEnvelope? GetIngressEnvelope(this HttpContext httpContext) =>
+        httpContext.Items.TryGetValue(NexoIngressEnvelope.HttpContextItemKey, out var v) && v is NexoIngressEnvelope env
+            ? env
+            : null;
+}

--- a/src/Nexo.API/Middleware/Ingress/NexoMiddlewareIngressOptions.cs
+++ b/src/Nexo.API/Middleware/Ingress/NexoMiddlewareIngressOptions.cs
@@ -1,0 +1,31 @@
+namespace Nexo.API.Middleware.Ingress;
+
+/// <summary>
+/// Feature flags for optional ingress surfaces (WebSocket labs, SMS simulation webhook, tenant/app guardrails).
+/// </summary>
+public sealed class NexoMiddlewareIngressOptions
+{
+    public const string SectionPath = "Nexo:MiddlewareIngress";
+
+    public bool EnableWebSocketIngress { get; set; } = true;
+
+    /// <summary>When true, exposes POST /api/ingress/sms/simulate for labs (not a substitute for signed SNS/Lambda).</summary>
+    public bool EnableSmsSimulationIngress { get; set; }
+
+    /// <summary>
+    /// When non-empty, SMS simulation requests must include matching <c>X-Nexo-App-Id</c> header or body app id field.
+    /// </summary>
+    public string[] SmsSimulationAllowedAppIds { get; set; } = [];
+
+    /// <summary>
+    /// Capability keys disabled globally for guarded ingress routes.
+    /// Known keys: <c>websocket</c>, <c>sms-simulation</c>.
+    /// </summary>
+    public string[] DisabledCapabilities { get; set; } = [];
+
+    /// <summary>
+    /// Optional per-tenant allowlists for guarded capabilities (fail closed when the tenant header matches a key).
+    /// Keys are matched against <c>X-Nexo-Tenant</c>.
+    /// </summary>
+    public Dictionary<string, string[]> TenantCapabilityAllowlists { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Nexo.API/Nexo.API.csproj
+++ b/src/Nexo.API/Nexo.API.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="LiteDB" />
     <ProjectReference Include="..\Nexo.BackgroundAgents.HostRunners\Nexo.BackgroundAgents.HostRunners.csproj" />
     <ProjectReference Include="..\Nexo.Brick.Contracts\Nexo.Brick.Contracts.csproj" />

--- a/src/Nexo.API/Program.cs
+++ b/src/Nexo.API/Program.cs
@@ -36,8 +36,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
 using Nexo.API.Endpoints;
 using Nexo.API.Forge;
+using Nexo.API.Middleware.Ingress;
 using Nexo.API.Security;
 using Nexo.GameDomain.Mapping;
 using Nexo.GameDomain.Materials;
@@ -75,6 +77,12 @@ builder.Services.Configure<NexoSecurityOptions>(
     builder.Configuration.GetSection(NexoSecurityOptions.SectionPath));
 builder.Services.Configure<ForgeSessionOptions>(
     builder.Configuration.GetSection(ForgeSessionOptions.SectionPath));
+builder.Services.Configure<NexoMiddlewareIngressOptions>(
+    builder.Configuration.GetSection(NexoMiddlewareIngressOptions.SectionPath));
+builder.Services.AddSingleton<ISmsIngressApprovalStore, MemorySmsIngressApprovalStore>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(static options =>
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "Nexo.API", Version = "v1" }));
 builder.Services.AddNexoRuntimeRouting(builder.Configuration);
 
 builder.Services.AddHttpContextAccessor();
@@ -117,6 +125,10 @@ builder.Services.AddSingleton<IVectorMapIntelligenceService>(sp =>
 builder.Services.AddSingleton<MapPipelineRunner>();
 
 var app = builder.Build();
+
+app.UseMiddleware<CorrelationIdMiddleware>();
+app.UseMiddleware<IngressEnvelopeMiddleware>();
+app.UseWebSockets();
 
 // --- Security: advisory exposure profile + optional built-in auth ---
 {
@@ -193,7 +205,10 @@ app.UseNexoApiKeyAuth();
 app.UseMiddleware<ForgeAuthenticationMiddleware>();
 app.UseMiddleware<ForgeTenantMiddleware>();
 
+app.UseSwagger();
+app.UseSwaggerUI(static c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Nexo.API v1"));
 app.MapNexoEndpoints();
+app.MapIngressEndpoints();
 app.MapForgeEndpoints();
 app.MapFallbackToFile("index.html");
 

--- a/src/Nexo.API/Program.cs
+++ b/src/Nexo.API/Program.cs
@@ -41,6 +41,7 @@ using Nexo.API.Endpoints;
 using Nexo.API.Forge;
 using Nexo.API.Middleware.Ingress;
 using Nexo.API.Security;
+using Nexo.Core.Application.Middleware.Ports;
 using Nexo.GameDomain.Mapping;
 using Nexo.GameDomain.Materials;
 using Nexo.BackgroundAgents.Extending;
@@ -86,6 +87,7 @@ builder.Services.AddSwaggerGen(static options =>
 builder.Services.AddNexoRuntimeRouting(builder.Configuration);
 
 builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<INexoIngressAccessor, HttpNexoIngressAccessor>();
 builder.Services.AddHttpClient("forge-map")
     .ConfigurePrimaryHttpMessageHandler(sp =>
         ForgeMapHttpSocketsHandlerFactory.Create(

--- a/src/Nexo.API/appsettings.Testing.json
+++ b/src/Nexo.API/appsettings.Testing.json
@@ -6,6 +6,13 @@
     }
   },
   "Nexo": {
-    "RegisterBackgroundAgentHostedService": false
+    "RegisterBackgroundAgentHostedService": false,
+    "MiddlewareIngress": {
+      "EnableWebSocketIngress": true,
+      "EnableSmsSimulationIngress": true,
+      "SmsSimulationAllowedAppIds": [],
+      "DisabledCapabilities": [],
+      "TenantCapabilityAllowlists": {}
+    }
   }
 }

--- a/src/Nexo.API/appsettings.json
+++ b/src/Nexo.API/appsettings.json
@@ -51,6 +51,13 @@
       "Endpoints": [],
       "HealthCheckIntervalSeconds": 30
     },
+    "MiddlewareIngress": {
+      "EnableWebSocketIngress": true,
+      "EnableSmsSimulationIngress": false,
+      "SmsSimulationAllowedAppIds": [],
+      "DisabledCapabilities": [],
+      "TenantCapabilityAllowlists": {}
+    },
     "ForgeSession": {
       "LiteDbPath": null,
       "TenantHeaderName": "X-Forge-Tenant",

--- a/src/Nexo.Contracts/MiddlewareIngressContracts.cs
+++ b/src/Nexo.Contracts/MiddlewareIngressContracts.cs
@@ -1,0 +1,41 @@
+namespace Nexo.Contracts;
+
+/// <summary>Stable transport labels for logging, envelopes, and capability checks.</summary>
+public static class NexoIngressTransports
+{
+    public const string Http = "http";
+    public const string WebSocket = "websocket";
+    public const string SmsSimulated = "sms-simulated";
+}
+
+/// <summary>
+/// Cross-cutting ingress metadata adapters map into before invoking Nexo use cases.
+/// Correlation id is always populated (generated or from <c>X-Correlation-Id</c>).
+/// </summary>
+public sealed record NexoIngressEnvelope(
+    string CorrelationId,
+    string Transport,
+    string? IdempotencyKey = null,
+    string? PayloadVersion = null,
+    string? TenantId = null,
+    string? AppId = null)
+{
+    public const string HttpContextItemKey = "Nexo.IngressEnvelope";
+}
+
+public sealed record SmsInboundSimulationRequest(
+    string From,
+    string Body,
+    string? MessageSid = null,
+    string? AppId = null);
+
+public sealed record SmsInboundSimulationResponse(
+    bool Accepted,
+    string? ApprovalToken,
+    string Message,
+    bool IdempotentReplay);
+
+/// <summary>Static inventory for operators (Phase A — ingress seams).</summary>
+public sealed record IngressCatalogEntry(string Kind, string Route, string Notes);
+
+public sealed record IngressCatalogResponse(IReadOnlyList<IngressCatalogEntry> EntryPoints);

--- a/src/Nexo.Contracts/MiddlewareIngressContracts.cs
+++ b/src/Nexo.Contracts/MiddlewareIngressContracts.cs
@@ -39,3 +39,12 @@ public sealed record SmsInboundSimulationResponse(
 public sealed record IngressCatalogEntry(string Kind, string Route, string Notes);
 
 public sealed record IngressCatalogResponse(IReadOnlyList<IngressCatalogEntry> EntryPoints);
+
+/// <summary>Snapshot of the current HTTP ingress context (for operators and tests).</summary>
+public sealed record IngressContextResponse(
+    string? CorrelationId,
+    string? Transport,
+    string? TenantId,
+    string? AppId,
+    string? IdempotencyKey,
+    string? PayloadVersion);

--- a/src/Nexo.Core.Application/Behaviors/IngressLoggingPipelineBehavior.cs
+++ b/src/Nexo.Core.Application/Behaviors/IngressLoggingPipelineBehavior.cs
@@ -1,0 +1,47 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Middleware.Ports;
+
+namespace Nexo.Core.Application.Behaviors;
+
+/// <summary>
+/// Wraps MediatR handlers in a logging scope derived from <see cref="INexoIngressAccessor"/> when correlation is present.
+/// </summary>
+public sealed class IngressLoggingPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly INexoIngressAccessor _ingress;
+    private readonly ILogger<IngressLoggingPipelineBehavior<TRequest, TResponse>> _logger;
+
+    public IngressLoggingPipelineBehavior(
+        INexoIngressAccessor ingress,
+        ILogger<IngressLoggingPipelineBehavior<TRequest, TResponse>> logger)
+    {
+        _ingress = ingress;
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrEmpty(_ingress.CorrelationId))
+            return await next().ConfigureAwait(false);
+
+        var state = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["Nexo.CorrelationId"] = _ingress.CorrelationId,
+            ["Nexo.IngressTransport"] = _ingress.Transport,
+            ["Nexo.TenantId"] = _ingress.TenantId,
+            ["Nexo.AppId"] = _ingress.AppId,
+            ["Nexo.IdempotencyKey"] = _ingress.IdempotencyKey,
+            ["Nexo.PayloadVersion"] = _ingress.PayloadVersion,
+            ["Nexo.MediatRRequest"] = typeof(TRequest).Name,
+        };
+
+        using (_logger.BeginScope(state))
+            return await next().ConfigureAwait(false);
+    }
+}

--- a/src/Nexo.Core.Application/Middleware/NoOpNexoIngressAccessor.cs
+++ b/src/Nexo.Core.Application/Middleware/NoOpNexoIngressAccessor.cs
@@ -1,0 +1,19 @@
+using Nexo.Core.Application.Middleware.Ports;
+
+namespace Nexo.Core.Application.Middleware;
+
+/// <summary>Default <see cref="INexoIngressAccessor"/> when no HTTP request context exists (CLI, tests, workers).</summary>
+public sealed class NoOpNexoIngressAccessor : INexoIngressAccessor
+{
+    public string? CorrelationId => null;
+
+    public string? Transport => null;
+
+    public string? TenantId => null;
+
+    public string? AppId => null;
+
+    public string? IdempotencyKey => null;
+
+    public string? PayloadVersion => null;
+}

--- a/src/Nexo.Core.Application/Middleware/Ports/INexoIngressAccessor.cs
+++ b/src/Nexo.Core.Application/Middleware/Ports/INexoIngressAccessor.cs
@@ -1,0 +1,20 @@
+namespace Nexo.Core.Application.Middleware.Ports;
+
+/// <summary>
+/// Read-only view of HTTP ingress metadata for the current async context (when hosted in ASP.NET Core).
+/// Non-web hosts use a no-op implementation returning nulls.
+/// </summary>
+public interface INexoIngressAccessor
+{
+    string? CorrelationId { get; }
+
+    string? Transport { get; }
+
+    string? TenantId { get; }
+
+    string? AppId { get; }
+
+    string? IdempotencyKey { get; }
+
+    string? PayloadVersion { get; }
+}

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.cs
@@ -164,7 +164,9 @@ public static class NexoServiceCollectionExtensions
         });
 
         services.AddValidatorsFromAssembly(typeof(AnalyzeCodeValidator).Assembly);
+        services.AddTransient(typeof(MediatR.IPipelineBehavior<,>), typeof(Nexo.Core.Application.Behaviors.IngressLoggingPipelineBehavior<,>));
         services.AddTransient(typeof(MediatR.IPipelineBehavior<,>), typeof(Nexo.Core.Application.Behaviors.ValidationBehavior<,>));
+        services.TryAddSingleton<Nexo.Core.Application.Middleware.Ports.INexoIngressAccessor, Nexo.Core.Application.Middleware.NoOpNexoIngressAccessor>();
 
         // ── Configuration service adapter ──────────────────────────────
         // Bridges the domain-level IConfigurationService port to the

--- a/src/Nexo.Tests.Infrastructure/Tests/Observation/FileSystemEventSourceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Observation/FileSystemEventSourceTests.cs
@@ -34,7 +34,7 @@ public class FileSystemEventSourceTests : IDisposable
     {
         var source = new FileSystemEventSource(new[] { _tempDir }, _tempDir, new[] { "*" }, null);
         var events = new List<Nexo.Core.Application.Observation.Models.NormalizedEvent>();
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
 
         var consumeTask = Task.Run(async () =>
         {

--- a/src/Nexo.Tests.Infrastructure/Tests/Testing/TestRunnerAdapterTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Testing/TestRunnerAdapterTests.cs
@@ -137,6 +137,9 @@ public class TestRunnerAdapterTests : UnitTestBase
 
         await runner.RunTestsAsync("SimpleTestForRunner", progress, CancellationToken.None);
 
+        // Progress<T> may post callbacks asynchronously; allow the queue to drain before asserting.
+        await Task.Delay(300, CancellationToken.None).ConfigureAwait(false);
+
         // Should have progress reports
         AssertTrue(progressReports.Count > 0, "Should have progress reports");
         AssertTrue(progressReports.Any(r => r.Message.Contains("Discovering", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/MiddlewareIngressIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/MiddlewareIngressIntegrationTests.cs
@@ -1,0 +1,86 @@
+using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.TestHost;
+using Nexo.API.Middleware.Ingress;
+using Nexo.Contracts;
+using Nexo.Tests.Infrastructure.Helpers.VirtualProduction;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.VirtualProduction;
+
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
+public sealed class MiddlewareIngressIntegrationTests : IClassFixture<NexoApiWebApplicationFactory>
+{
+    private readonly NexoApiWebApplicationFactory _factory;
+
+    public MiddlewareIngressIntegrationTests(NexoApiWebApplicationFactory factory) => _factory = factory;
+
+    [Fact(Timeout = 60000)]
+    public async Task Correlation_id_round_trips_on_http_and_echo_endpoint()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Correlation-Id", "corr-test-1");
+        using var resp = await client.GetAsync(new Uri("api/middleware/correlation-echo", UriKind.Relative));
+        resp.EnsureSuccessStatusCode();
+        resp.Headers.TryGetValues(CorrelationIdMiddleware.HeaderName, out var hdrs);
+        hdrs.Should().ContainSingle().Which.Should().Be("corr-test-1");
+        var doc = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        doc.GetProperty("correlationId").GetString().Should().Be("corr-test-1");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Swagger_document_lists_middleware_ingress_operations()
+    {
+        var client = _factory.CreateClient();
+        using var resp = await client.GetAsync(new Uri("swagger/v1/swagger.json", UriKind.Relative));
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadAsStringAsync();
+        json.Should().Contain("IngressCorrelationEcho");
+        json.Should().Contain("SmsInboundSimulate");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Sms_simulation_accepts_yes_token_and_replays_idempotently()
+    {
+        var client = _factory.CreateClient();
+        var body = new SmsInboundSimulationRequest("+15555550100", "YES approve-z", MessageSid: "SM123");
+        using var resp = await client.PostAsJsonAsync(new Uri("api/ingress/sms/simulate", UriKind.Relative), body);
+        resp.EnsureSuccessStatusCode();
+        var dto = await resp.Content.ReadFromJsonAsync<SmsInboundSimulationResponse>();
+        dto.Should().NotBeNull();
+        dto!.Accepted.Should().BeTrue();
+        dto.ApprovalToken.Should().Be("approve-z");
+        dto.IdempotentReplay.Should().BeFalse();
+
+        using var resp2 = await client.PostAsJsonAsync(new Uri("api/ingress/sms/simulate", UriKind.Relative), body);
+        resp2.EnsureSuccessStatusCode();
+        var dto2 = await resp2.Content.ReadFromJsonAsync<SmsInboundSimulationResponse>();
+        dto2!.IdempotentReplay.Should().BeTrue();
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task WebSocket_echo_returns_hello_and_echo()
+    {
+        var server = (TestServer)_factory.Server;
+        var wsClient = server.CreateWebSocketClient();
+        var uri = new UriBuilder(server.BaseAddress!) { Scheme = "ws", Path = "ws/v1/echo" }.Uri;
+        using var ws = await wsClient.ConnectAsync(uri, CancellationToken.None);
+        var buf = new byte[8192];
+        var r1 = await ws.ReceiveAsync(buf.AsMemory(), CancellationToken.None);
+        r1.MessageType.Should().Be(WebSocketMessageType.Text);
+        var hello = Encoding.UTF8.GetString(buf.AsSpan(0, r1.Count));
+        hello.Should().Contain("hello");
+
+        var send = Encoding.UTF8.GetBytes("{\"ping\":true}");
+        await ws.SendAsync(send.AsMemory(), WebSocketMessageType.Text, true, CancellationToken.None);
+        var r2 = await ws.ReceiveAsync(buf.AsMemory(), CancellationToken.None);
+        var echo = Encoding.UTF8.GetString(buf.AsSpan(0, r2.Count));
+        echo.Should().Contain("echo");
+        echo.Should().Contain("ping");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/MiddlewareIngressIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/MiddlewareIngressIntegrationTests.cs
@@ -34,6 +34,27 @@ public sealed class MiddlewareIngressIntegrationTests : IClassFixture<NexoApiWeb
     }
 
     [Fact(Timeout = 60000)]
+    public async Task Ingress_context_reflects_optional_headers()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Correlation-Id", "corr-ctx-1");
+        client.DefaultRequestHeaders.Add("X-Nexo-Tenant", "tenant-x");
+        client.DefaultRequestHeaders.Add("X-Nexo-App-Id", "app-y");
+        client.DefaultRequestHeaders.Add("X-Idempotency-Key", "idem-z");
+        client.DefaultRequestHeaders.Add("X-Nexo-Payload-Version", "v2");
+        using var resp = await client.GetAsync(new Uri("api/middleware/ingress-context", UriKind.Relative));
+        resp.EnsureSuccessStatusCode();
+        var dto = await resp.Content.ReadFromJsonAsync<IngressContextResponse>();
+        dto.Should().NotBeNull();
+        dto!.CorrelationId.Should().Be("corr-ctx-1");
+        dto.Transport.Should().Be(NexoIngressTransports.Http);
+        dto.TenantId.Should().Be("tenant-x");
+        dto.AppId.Should().Be("app-y");
+        dto.IdempotencyKey.Should().Be("idem-z");
+        dto.PayloadVersion.Should().Be("v2");
+    }
+
+    [Fact(Timeout = 60000)]
     public async Task Swagger_document_lists_middleware_ingress_operations()
     {
         var client = _factory.CreateClient();
@@ -42,6 +63,7 @@ public sealed class MiddlewareIngressIntegrationTests : IClassFixture<NexoApiWeb
         var json = await resp.Content.ReadAsStringAsync();
         json.Should().Contain("IngressCorrelationEcho");
         json.Should().Contain("SmsInboundSimulate");
+        json.Should().Contain("IngressContext");
     }
 
     [Fact(Timeout = 60000)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delivers middleware ingress phases A–H plus the previously called-out gaps: MediatR-wide ingress logging via `INexoIngressAccessor`, operator `ingress-context` endpoint, AWS/SNS/GitHub runbook in `docs/MiddlewareIngress.md`, a working `make test` target (`Nexo.sln` + `NEXO_ALLOW_MOCK=1`), xUnit pin for sync `[Fact(Timeout)]` compatibility, and two small test stabilizations.

## Changes

- **MediatR:** `IngressLoggingPipelineBehavior` + `INexoIngressAccessor` / `NoOpNexoIngressAccessor` (Hosting `TryAdd`); `HttpNexoIngressAccessor` registered in Nexo.API before `AddNexo()`.
- **API:** `GET /api/middleware/ingress-context`, `IngressContextResponse`, smoke script extended.
- **Docs:** `docs/MiddlewareIngress.md` (AWS two-way SMS → SNS → Lambda, GitHub Environments, OIDC, budgets).
- **Tooling:** `Makefile` `test` runs `NEXO_ALLOW_MOCK=1 dotnet test Nexo.sln` with 120s blame hang (fixes ambiguous multi-sln root).
- **Packages:** xunit 2.6.6 + xunit.runner.visualstudio 2.5.8 with rationale comment.
- **Tests:** `FileSystemEventSourceTests` longer CTS; `TestRunnerAdapterTests` drains `Progress<T>` callbacks before assert.

## Testing

- `make test` (full `Nexo.sln`, green in this workspace).
- `dotnet test src/Nexo.Tests.Infrastructure/... --filter FullyQualifiedName~MiddlewareIngressIntegrationTests -f net8.0`

## Checklist

- [x] `make test` passes locally
- [x] Documentation updated (`docs/MiddlewareIngress.md`)
- [x] No `TODO` or `NotImplementedException` left unresolved
- [x] Breaking changes are documented (none expected; xUnit pin may affect consumers of central package versions)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a75e865-7d95-45e2-bc64-627c37d959b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a75e865-7d95-45e2-bc64-627c37d959b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

