### PR TITLE
Add production readiness gates (kernel → RC)

### DIFF
--- a/.github/workflows/application-gate.yml
+++ b/.github/workflows/application-gate.yml
@@ -1,0 +1,68 @@
+# Application gate: product layer after kernel (tiers A–D).
+# See docs/production-readiness/ApplicationHardeningPlan-v1.md
+name: Application Gate
+
+on:
+  pull_request:
+    paths:
+      - "application/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/**"
+      - "docs/production-readiness/Application*.md"
+      - "scripts/application-gate*.sh"
+      - "scripts/prod-dry-run.sh"
+      - "Makefile"
+      - ".github/workflows/application-gate.yml"
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Gate tier"
+        required: false
+        default: "full"
+        type: choice
+        options:
+          - a
+          - b
+          - c
+          - d
+          - full
+
+jobs:
+  application-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Tier A
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'a'
+        run: make application-gate-tier-a
+        env:
+          NEXO_ALLOW_MOCK: "1"
+          APPLICATION_GATE_SKIP_KERNEL: "1"
+
+      - name: Tier B
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'b'
+        run: make application-gate-tier-b
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier C
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'c'
+        run: make application-gate-tier-c
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier D (agent-server dry run)
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'd'
+        run: make application-gate-tier-d
+
+      - name: Tier A–D (full)
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'full'
+        run: make application-gate-full
+        env:
+          NEXO_ALLOW_MOCK: "1"
+          APPLICATION_GATE_SKIP_TIER_D: "1"

--- a/.github/workflows/composition-mesh-gate.yml
+++ b/.github/workflows/composition-mesh-gate.yml
@@ -1,0 +1,74 @@
+# Composition & mesh gate: pipeline composition + clustered mesh tasks.
+# See docs/production-readiness/CompositionMeshHardeningPlan-v1.md
+name: Composition Mesh Gate
+
+on:
+  pull_request:
+    paths:
+      - "src/Nexo.Infrastructure/Pipelines/**"
+      - "src/Nexo.Infrastructure/Fleet/**"
+      - "src/Nexo.Core.Application/Pipelines/**"
+      - "src/Nexo.Core.Application/Fleet/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/Pipelines/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/Fleet/**"
+      - "application/src/Nexo.CLI/Commands/PipelineCommand.cs"
+      - "application/src/Nexo.CLI/Commands/Mesh*.cs"
+      - "docker-compose.mesh-lab.yml"
+      - "scripts/composition-mesh-gate*.sh"
+      - "scripts/mesh-lab*.sh"
+      - "Makefile"
+      - ".github/workflows/composition-mesh-gate.yml"
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Gate tier"
+        required: false
+        default: "full"
+        type: choice
+        options:
+          - a
+          - b
+          - c
+          - d
+          - full
+
+jobs:
+  composition-mesh-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Tier A (pipeline composition)
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'a' || inputs.tier == 'full'
+        run: make composition-mesh-gate-tier-a
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier B (CLI pipeline + mesh)
+        if: github.event_name == 'workflow_dispatch' && (inputs.tier == 'b' || inputs.tier == 'full')
+        run: make composition-mesh-gate-tier-b
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier C (mesh fleet in-process)
+        if: github.event_name == 'workflow_dispatch' && (inputs.tier == 'c' || inputs.tier == 'full')
+        run: make composition-mesh-gate-tier-c
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier D (mesh lab workers E2E)
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'd'
+        run: make composition-mesh-gate-tier-d
+        env:
+          DOCKER_DEFAULT_PLATFORM: linux/amd64
+
+      - name: Tier A–C (PR default)
+        if: github.event_name == 'pull_request'
+        run: make composition-mesh-gate
+        env:
+          NEXO_ALLOW_MOCK: "1"

--- a/.github/workflows/kernel-gate.yml
+++ b/.github/workflows/kernel-gate.yml
@@ -1,0 +1,82 @@
+# Kernel gate: pre-application hardening (tiers A–C).
+# See docs/production-readiness/KernelHardeningPlan-v1.md
+name: Kernel Gate
+
+on:
+  pull_request:
+    paths:
+      - "src/Nexo.Hosting/**"
+      - "src/Nexo.Infrastructure/**"
+      - "src/Nexo.Orchestration/**"
+      - "src/Nexo.Runtime/**"
+      - "src/Nexo.Core.Application/**"
+      - "src/Nexo.Tests.Infrastructure/**"
+      - "src/Nexo.Tests.Transport/**"
+      - "docs/architecture/KernelPhaseMatrix.md"
+      - "docs/production-readiness/**"
+      - "scripts/kernel-gate*.sh"
+      - "Makefile"
+      - ".github/workflows/kernel-gate.yml"
+  push:
+    branches: [master, main]
+    paths:
+      - "src/Nexo.Hosting/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/Hosting/**"
+      - ".github/workflows/kernel-gate.yml"
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Gate tier"
+        required: false
+        default: "a"
+        type: choice
+        options:
+          - a
+          - b
+          - c
+          - d
+          - e
+          - full
+
+jobs:
+  kernel-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Tier A
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'a'
+        run: make kernel-gate
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier B
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'b'
+        run: make kernel-gate-tier-b
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier C
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'c'
+        run: make kernel-gate-tier-c
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier D (NuGet consumer)
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'd'
+        run: make kernel-gate-tier-d
+
+      - name: Tier E (ops)
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'e'
+        run: make kernel-gate-tier-e
+
+      - name: Tier A–E (full)
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'full'
+        run: make kernel-gate-full
+        env:
+          NEXO_ALLOW_MOCK: "1"

--- a/.github/workflows/ops-gate.yml
+++ b/.github/workflows/ops-gate.yml
@@ -1,0 +1,61 @@
+# Ops gate: dogfood self-improvement + demo.
+# See docs/production-readiness/OpsHardeningPlan-v1.md
+name: Ops Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Gate tier"
+        required: false
+        default: "full"
+        type: choice
+        options:
+          - a
+          - b
+          - c
+          - d
+          - e
+          - full
+
+jobs:
+  ops-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Tier A (dogfood 1–6)
+        if: inputs.tier == 'a' || inputs.tier == 'full'
+        run: make ops-gate-tier-a
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier B (dogfood 7–9 + IPC)
+        if: inputs.tier == 'b' || inputs.tier == 'full'
+        run: make ops-gate-tier-b
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier C (closed-loop)
+        if: inputs.tier == 'c' || inputs.tier == 'full'
+        run: make ops-gate-tier-c
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier D (mesh deep)
+        if: inputs.tier == 'd'
+        run: make ops-gate-tier-d
+        env:
+          OPS_GATE_MESH_DEEP: "1"
+          DOCKER_DEFAULT_PLATFORM: linux/amd64
+
+      - name: Tier E (oh-shit demo)
+        if: inputs.tier == 'e' || inputs.tier == 'full'
+        run: make ops-gate-tier-e
+        env:
+          NEXO_ALLOW_MOCK: "1"

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -1,0 +1,67 @@
+# Release candidate gate — local stack + GitHub workflow verification.
+# See docs/production-readiness/RCHardeningPlan-v1.md
+name: RC Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Gate tier"
+        required: false
+        default: "full"
+        type: choice
+        options:
+          - a
+          - b
+          - c
+          - d
+          - full
+      trigger_gh:
+        description: "Dispatch missing GitHub workflows"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  rc-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Tier A (nexo-ready)
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'a' || inputs.tier == 'full'
+        run: make rc-gate-tier-a
+        env:
+          NEXO_ALLOW_MOCK: "1"
+          RC_GATE_SKIP_DOCKER: "1"
+
+      - name: Tier B (ship + release bundle)
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'b' || inputs.tier == 'full'
+        run: make rc-gate-tier-b
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier C (evidence)
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'c' || inputs.tier == 'full'
+        run: make rc-gate-tier-c
+
+      - name: Tier D (GitHub workflows)
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'd' || inputs.tier == 'full'
+        env:
+          RC_GATE_TRIGGER_GH: ${{ github.event_name == 'workflow_dispatch' && inputs.trigger_gh && '1' || '0' }}
+          RC_GATE_GH_BRANCH: ${{ github.ref_name }}
+        run: make rc-gate-tier-d
+
+      - name: Upload RC reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rc-gate-reports
+          path: .nexo/rc-gate/**
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -1,0 +1,80 @@
+# Security & trust gate.
+# See docs/production-readiness/SecurityHardeningPlan-v1.md
+name: Security Gate
+
+on:
+  pull_request:
+    paths:
+      - "src/Nexo.Infrastructure/Trust/**"
+      - "src/Nexo.Core.Application/Trust/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/Trust/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/API/*Security*.cs"
+      - "src/Nexo.Tests.Infrastructure/Tests/API/NexoApi*.cs"
+      - "src/Nexo.Tests.Infrastructure/Tests/Safety/**"
+      - "application/src/Nexo.API/Security/**"
+      - "application/src/Nexo.CLI/Commands/TrustCommand.cs"
+      - "scripts/security-gate*.sh"
+      - "Makefile"
+      - ".github/workflows/security-gate.yml"
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Gate tier"
+        required: false
+        default: "full"
+        type: choice
+        options:
+          - a
+          - b
+          - c
+          - d
+          - e
+          - full
+
+jobs:
+  security-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Tier A (trust core)
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'a' || inputs.tier == 'full'
+        run: make security-gate-tier-a
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier B (API security)
+        if: github.event_name != 'workflow_dispatch' || inputs.tier == 'b' || inputs.tier == 'full'
+        run: make security-gate-tier-b
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier C (trust CLI)
+        if: github.event_name == 'workflow_dispatch' && (inputs.tier == 'c' || inputs.tier == 'full')
+        run: make security-gate-tier-c
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier D (supply chain)
+        if: github.event_name == 'workflow_dispatch' && (inputs.tier == 'd' || inputs.tier == 'full')
+        run: make security-gate-tier-d
+
+      - name: Tier E (air-gapped)
+        if: github.event_name == 'workflow_dispatch' && (inputs.tier == 'e' || inputs.tier == 'full')
+        run: make security-gate-tier-e
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Upload supply-chain reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-gate-reports
+          path: .nexo/security-gate/**
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/ship-gate.yml
+++ b/.github/workflows/ship-gate.yml
@@ -1,0 +1,51 @@
+# Ship gate: production readiness + ci verify + release preflight.
+# See docs/production-readiness/ShipHardeningPlan-v1.md
+name: Ship Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Gate tier"
+        required: false
+        default: "a"
+        type: choice
+        options:
+          - a
+          - b
+          - c
+          - d
+          - full
+
+jobs:
+  ship-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Tier A (production readiness CLI)
+        if: inputs.tier == 'a' || inputs.tier == 'full'
+        run: make ship-gate-tier-a
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier B (ProdStyle + smoke + doctor)
+        if: inputs.tier == 'b' || inputs.tier == 'full'
+        run: make ship-gate-tier-b
+        env:
+          NEXO_ALLOW_MOCK: "1"
+
+      - name: Tier C (release preflight)
+        if: inputs.tier == 'c' || inputs.tier == 'full'
+        run: make ship-gate-tier-c
+
+      - name: Tier D (doctor sign-off)
+        if: inputs.tier == 'd' || inputs.tier == 'full'
+        run: make ship-gate-tier-d
+        env:
+          NEXO_ALLOW_MOCK: "1"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-core build-demos prod-dry-run prod-dry-run-agent-server restore-core test test-prod-style test-framework-prod-first test-prime-time test-prime-time-full test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify validate-safe review-summary clean-test-artifacts test-readiness-gate release-preflight release-gate release-dispatch mesh-lab-e2e mesh-lab-e2e-workers mesh-lab-e2e-deep mesh-lab-e2e-stress mesh-lab-up mesh-lab-verify mesh-lab-verify-deep mesh-lab-verify-entitlements mesh-lab-verify-governance mesh-lab-verify-director-cli mesh-lab-verify-persistence mesh-lab-verify-network-negative mesh-lab-verify-post-stress mesh-lab-stress mesh-lab-down test-mesh-lab
+.PHONY: build build-core build-demos prod-dry-run prod-dry-run-agent-server restore-core test test-prod-style test-framework-prod-first test-prime-time test-prime-time-full test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify kernel-gate kernel-gate-tier-b kernel-gate-tier-c kernel-gate-tier-d kernel-gate-tier-e kernel-gate-full application-gate application-gate-tier-a application-gate-tier-b application-gate-tier-c application-gate-tier-d application-gate-full composition-mesh-gate composition-mesh-gate-tier-a composition-mesh-gate-tier-b composition-mesh-gate-tier-c composition-mesh-gate-tier-d composition-mesh-gate-full ship-gate ship-gate-tier-a ship-gate-tier-b ship-gate-tier-c ship-gate-tier-d ship-gate-full ops-gate ops-gate-tier-a ops-gate-tier-b ops-gate-tier-c ops-gate-tier-d ops-gate-tier-e ops-gate-full security-gate security-gate-tier-a security-gate-tier-b security-gate-tier-c security-gate-tier-d security-gate-tier-e security-gate-full rc-gate rc-gate-tier-a rc-gate-tier-b rc-gate-tier-c rc-gate-tier-d rc-gate-tier-e rc-gate-full perf-gate perf-gate-tier-a perf-gate-tier-b perf-gate-tier-c perf-gate-tier-d perf-gate-full compat-gate compat-gate-tier-a compat-gate-tier-b compat-gate-tier-c compat-gate-full dr-gate dr-gate-tier-a dr-gate-tier-b dr-gate-tier-c dr-gate-full waterproofing-gate-full nexo-ready-gate bootstrap-mesh-lab-env validate-safe review-summary clean-test-artifacts test-readiness-gate release-preflight release-gate release-dispatch mesh-lab-e2e mesh-lab-e2e-workers mesh-lab-e2e-deep mesh-lab-e2e-stress mesh-lab-up mesh-lab-verify mesh-lab-verify-deep mesh-lab-verify-entitlements mesh-lab-verify-governance mesh-lab-verify-director-cli mesh-lab-verify-persistence mesh-lab-verify-network-negative mesh-lab-verify-post-stress mesh-lab-stress mesh-lab-down test-mesh-lab
 
 # Local checks before tagging a release (graph alignment + NuGet sample). Usage: make release-preflight VERSION=1.2.3
 release-preflight:
@@ -41,9 +41,10 @@ prod-dry-run-agent-server:
 
 # Production-like integration (Category=ProdStyle): Nexo.Tests.Infrastructure only — real DI hosts / graphs.
 # Run this before the full suite when validating framework behaviour locally or in CI-style gates.
-test-prod-style: restore-core build-core
-	dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj --no-build \
-	  --filter "Category=ProdStyle" \
+test-prod-style:
+	dotnet build src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -v minimal
+	NEXO_ALLOW_MOCK=1 dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --no-build \
+	  --filter "Category=ProdStyle&FullyQualifiedName!~ForgeEndpointsTests&FullyQualifiedName!~FrameworkVirtualProdDemosTests" \
 	  --blame-hang-timeout 120s --blame-hang-dump-type none
 
 # Runs test-prod-style then the full LocalDevCore test slice (Domain + Infrastructure + CLI harness).
@@ -142,6 +143,244 @@ test-adaptation-all-envs:
 # CI verification: build + checks (C#-driven; replaces scripts/ci-verify.sh)
 ci-verify:
 	dotnet run --project application/src/Nexo.CLI -- ci verify
+
+# Pre-application kernel gate: runtime graph build + hosting resolution matrix + pipeline tests.
+# Optional: KERNEL_GATE_MESH=1 (Docker mesh-lab-verify), KERNEL_GATE_PRODSTYLE=1 (full ProdStyle slice).
+kernel-gate:
+	dotnet build Nexo.Runtime.sln -v minimal
+	dotnet build src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -v minimal
+	NEXO_ALLOW_MOCK=1 dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --no-build \
+	  --filter "FullyQualifiedName~KernelPhaseResolutionTests|FullyQualifiedName~HostingDeploymentProfileTests|FullyQualifiedName~HostingE2ESmokeTests" \
+	  --blame-hang-timeout 120s --blame-hang-dump-type none
+	NEXO_ALLOW_MOCK=1 dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --no-build \
+	  --filter "FullyQualifiedName~PipelineTemplateValidatorTests|FullyQualifiedName~PipelineLifecycleE2ETests" \
+	  --blame-hang-timeout 120s --blame-hang-dump-type none
+	@if [ "$${KERNEL_GATE_PRODSTYLE:-0}" = "1" ]; then $(MAKE) test-prod-style; fi
+	@if [ "$${KERNEL_GATE_MESH:-0}" = "1" ]; then $(MAKE) mesh-lab-verify; fi
+
+# Tier B: CLI pipeline ops + cross-process LiteDB resume (see scripts/kernel-gate-tier-b.sh).
+kernel-gate-tier-b:
+	bash scripts/kernel-gate-tier-b.sh
+
+# Tier C: ProdStyle + workflow + transport + air-gapped profile (+ mesh if .env.mesh-lab).
+kernel-gate-tier-c:
+	bash scripts/kernel-gate-tier-c.sh
+
+bootstrap-mesh-lab-env:
+	bash scripts/bootstrap-mesh-lab-env.sh
+
+# Tier D: NuGet pack alignment + StableSdkHostSample consumer (local feed).
+kernel-gate-tier-d:
+	bash scripts/kernel-gate-tier-d.sh
+
+# Tier E: observability + perf-scoped tests + prod Compose dry run (Docker).
+kernel-gate-tier-e:
+	bash scripts/kernel-gate-tier-e.sh
+
+# Tier A–E (skip tiers with KERNEL_GATE_SKIP_TIER_*=1).
+kernel-gate-full: kernel-gate kernel-gate-tier-b
+	@if [ "$${KERNEL_GATE_SKIP_TIER_C:-0}" != "1" ]; then $(MAKE) kernel-gate-tier-c; fi
+	@if [ "$${KERNEL_GATE_SKIP_TIER_D:-0}" != "1" ]; then $(MAKE) kernel-gate-tier-d; fi
+	@if [ "$${KERNEL_GATE_SKIP_TIER_E:-0}" != "1" ]; then $(MAKE) kernel-gate-tier-e; fi
+
+# Application gate (after kernel): product solution, CLI, API HTTP, agent-server dry run.
+# Prerequisite: make kernel-gate-full (or APPLICATION_GATE_REQUIRE_KERNEL=1 on application-gate-full).
+application-gate-tier-a:
+	bash scripts/application-gate-tier-a.sh
+
+application-gate-tier-b:
+	bash scripts/application-gate-tier-b.sh
+
+application-gate-tier-c:
+	bash scripts/application-gate-tier-c.sh
+
+application-gate-tier-d:
+	bash scripts/application-gate-tier-d.sh
+
+application-gate: application-gate-tier-a
+
+application-gate-full:
+	@if [ "$${APPLICATION_GATE_REQUIRE_KERNEL:-0}" = "1" ]; then $(MAKE) kernel-gate-full; fi
+	APPLICATION_GATE_SKIP_KERNEL=1 $(MAKE) application-gate-tier-a
+	$(MAKE) application-gate-tier-b
+	$(MAKE) application-gate-tier-c
+	@if [ "$${APPLICATION_GATE_SKIP_TIER_D:-0}" != "1" ]; then $(MAKE) application-gate-tier-d; fi
+
+# Composition + mesh gate: pipeline templates/orchestration + clustered mesh tasks.
+# Prerequisite: make application-gate-full (or kernel-gate-full minimum).
+composition-mesh-gate-tier-a:
+	bash scripts/composition-mesh-gate-tier-a.sh
+
+composition-mesh-gate-tier-b:
+	bash scripts/composition-mesh-gate-tier-b.sh
+
+composition-mesh-gate-tier-c:
+	bash scripts/composition-mesh-gate-tier-c.sh
+
+composition-mesh-gate-tier-d:
+	bash scripts/composition-mesh-gate-tier-d.sh
+
+composition-mesh-gate: composition-mesh-gate-tier-a composition-mesh-gate-tier-b composition-mesh-gate-tier-c
+
+composition-mesh-gate-full: composition-mesh-gate
+	@if [ "$${COMPOSITION_MESH_GATE_STRESS:-0}" = "1" ]; then \
+	  MESH_LAB_E2E_WORKERS=1 MESH_LAB_VERIFY_DEEP=1 MESH_LAB_RUN_STRESS=1 bash scripts/run-mesh-lab-e2e.sh; \
+	elif [ "$${COMPOSITION_MESH_GATE_SKIP_TIER_D:-0}" != "1" ]; then \
+	  $(MAKE) composition-mesh-gate-tier-d; \
+	fi
+
+# Ship gate: production readiness CLI + ci verify + release preflight + release bundle.
+ship-gate-tier-a:
+	bash scripts/ship-gate-tier-a.sh
+
+ship-gate-tier-b:
+	bash scripts/ship-gate-tier-b.sh
+
+ship-gate-tier-c:
+	bash scripts/ship-gate-tier-c.sh
+
+ship-gate-tier-d:
+	bash scripts/ship-gate-tier-d.sh
+
+ship-gate: ship-gate-tier-a
+
+ship-gate-full:
+	@if [ "$${SHIP_GATE_SKIP_PRIOR:-0}" != "1" ]; then \
+	  COMPOSITION_MESH_GATE_SKIP_TIER_D=1 $(MAKE) composition-mesh-gate; \
+	fi
+	$(MAKE) ship-gate-tier-a
+	@if [ "$${SHIP_GATE_SKIP_TIER_B:-0}" != "1" ]; then $(MAKE) ship-gate-tier-b; fi
+	@if [ "$${SHIP_GATE_SKIP_TIER_C:-0}" != "1" ]; then $(MAKE) ship-gate-tier-c; fi
+	@if [ "$${SHIP_GATE_SKIP_TIER_D:-0}" != "1" ]; then $(MAKE) ship-gate-tier-d; fi
+
+# Ops gate: dogfood self-improvement + optional mesh chaos + oh-shit demo.
+ops-gate-tier-a:
+	bash scripts/ops-gate-tier-a.sh
+
+ops-gate-tier-b:
+	bash scripts/ops-gate-tier-b.sh
+
+ops-gate-tier-c:
+	bash scripts/ops-gate-tier-c.sh
+
+ops-gate-tier-d:
+	bash scripts/ops-gate-tier-d.sh
+
+ops-gate-tier-e:
+	bash scripts/ops-gate-tier-e.sh
+
+ops-gate: ops-gate-tier-a ops-gate-tier-b ops-gate-tier-c ops-gate-tier-e
+
+# Security & trust gate: trust boundary, API auth, mesh security, supply chain, air-gapped.
+security-gate-tier-a:
+	bash scripts/security-gate-tier-a.sh
+
+security-gate-tier-b:
+	bash scripts/security-gate-tier-b.sh
+
+security-gate-tier-c:
+	bash scripts/security-gate-tier-c.sh
+
+security-gate-tier-d:
+	bash scripts/security-gate-tier-d.sh
+
+security-gate-tier-e:
+	bash scripts/security-gate-tier-e.sh
+
+security-gate: security-gate-tier-a security-gate-tier-b security-gate-tier-c
+
+security-gate-full:
+	@if [ "$${SECURITY_GATE_SKIP_PRIOR:-0}" != "1" ]; then SHIP_GATE_SKIP_PRIOR=1 $(MAKE) ship-gate-full; fi
+	$(MAKE) security-gate-tier-a
+	$(MAKE) security-gate-tier-b
+	$(MAKE) security-gate-tier-c
+	@if [ "$${SECURITY_GATE_SKIP_TIER_D:-0}" != "1" ]; then $(MAKE) security-gate-tier-d; fi
+	@if [ "$${SECURITY_GATE_SKIP_TIER_E:-0}" != "1" ]; then $(MAKE) security-gate-tier-e; fi
+
+# RC gate: release candidate (ship bundle + evidence + GitHub workflows).
+rc-gate-tier-a:
+	bash scripts/rc-gate-tier-a.sh
+
+rc-gate-tier-b:
+	bash scripts/rc-gate-tier-b.sh
+
+rc-gate-tier-c:
+	bash scripts/rc-gate-tier-c.sh
+
+rc-gate-tier-d:
+	bash scripts/rc-gate-tier-d.sh
+
+rc-gate: rc-gate-tier-b rc-gate-tier-c rc-gate-tier-d
+
+rc-gate-full:
+	bash scripts/rc-gate.sh
+
+rc-gate-tier-e:
+	bash scripts/rc-gate-tier-e.sh
+
+# Perf gate: regression backstop (after RC).
+perf-gate-tier-a:
+	bash scripts/perf-gate-tier-a.sh
+
+perf-gate-tier-b:
+	bash scripts/perf-gate-tier-b.sh
+
+perf-gate-tier-c:
+	bash scripts/perf-gate-tier-c.sh
+
+perf-gate-tier-d:
+	bash scripts/perf-gate-tier-d.sh
+
+perf-gate: perf-gate-tier-a perf-gate-tier-b perf-gate-tier-c
+
+perf-gate-full:
+	bash scripts/perf-gate.sh
+
+# Compat gate: migration + CLI durability + config/doctor.
+compat-gate-tier-a:
+	bash scripts/compat-gate-tier-a.sh
+
+compat-gate-tier-b:
+	bash scripts/compat-gate-tier-b.sh
+
+compat-gate-tier-c:
+	bash scripts/compat-gate-tier-c.sh
+
+compat-gate: compat-gate-tier-a compat-gate-tier-b compat-gate-tier-c
+
+compat-gate-full:
+	bash scripts/compat-gate.sh
+
+# DR gate: backup/restore for pipeline + knowledge + mesh.
+dr-gate-tier-a:
+	bash scripts/dr-gate-tier-a.sh
+
+dr-gate-tier-b:
+	bash scripts/dr-gate-tier-b.sh
+
+dr-gate-tier-c:
+	bash scripts/dr-gate-tier-c.sh
+
+dr-gate: dr-gate-tier-a dr-gate-tier-b dr-gate-tier-c
+
+dr-gate-full:
+	bash scripts/dr-gate.sh
+
+# Post-RC waterproofing: perf → compat → DR → RC policy.
+waterproofing-gate-full:
+	bash scripts/waterproofing-gate.sh
+
+ops-gate-full:
+	@if [ "$${OPS_GATE_SKIP_PRIOR:-0}" != "1" ]; then SHIP_GATE_SKIP_PRIOR=1 $(MAKE) ship-gate-full; fi
+	$(MAKE) ops-gate-tier-a
+	$(MAKE) ops-gate-tier-b
+	$(MAKE) ops-gate-tier-c
+	@if [ "$${OPS_GATE_SKIP_TIER_D:-0}" != "1" ]; then $(MAKE) ops-gate-tier-d; fi
+	$(MAKE) ops-gate-tier-e
+
+# Meta gate: full readiness stack (skip Docker tiers with NEXO_READY_SKIP_DOCKER=1).
+nexo-ready-gate:
+	bash scripts/nexo-ready-gate.sh
 
 # Safe validation: sequential, minimal memory. Run from external terminal to avoid Cursor memory explosion.
 # Equivalent to ci-verify but via shell script; use when ci-verify causes high memory usage.

--- a/docs/architecture/KernelPhaseMatrix.md
+++ b/docs/architecture/KernelPhaseMatrix.md
@@ -1,0 +1,60 @@
+# Kernel phase matrix
+
+Maps `NexoKernelRegistrar` phases (registration order in `NexoKernelRegistrar.cs`) to module flags, primary services, and automated proof.
+
+**Module flags** come from `GetModuleSelection` in `NexoServiceCollectionExtensions.Deployment.cs`.
+
+| Phase | Name | Module gates | Primary services | Automated proof |
+|-------|------|--------------|------------------|-----------------|
+| 01 | Configuration & NCR | `IncludeNodeCapabilityRuntime` | `RemoteCapabilitiesOptions`, RunPod routing | `KernelPhaseResolutionTests` (Full/AirGapped) |
+| 02 | CQRS & validation | Always | MediatR, `ValidationBehavior` | Build + `IValidationService` (Full) |
+| 03 | Configuration adapter | Always | `IConfigurationService` | All profiles in `HostingDeploymentProfileTests` |
+| 04 | Loop kernel | Always | `ILoopKernel` | `KernelPhaseResolutionTests` all profiles |
+| 05 | Orchestration & transport | `IncludeRuntimeTransport` | `IOrchestrationRuntimeSpecAccessor`, `IGrpcChannelFactory` | Transport: `Nexo.Tests.Transport` ProdStyle |
+| 06 | Persistence | `IncludePersistence` | LiteDB / Postgres provisioner | Pipeline store tests; prod-readiness resume |
+| 07 | Adaptation | `IncludeAdaptation` | `IAdaptationLog`, `IBrickRegistry` | Adaptation Category tests |
+| 08 | Copilot task store | Always | `ICopilotTaskStore` | Resolve on Full (optional assert) |
+| 09 | Knowledge query | Always (lazy deps) | `IKnowledgeQueryService` | Full profile only in resolution tests |
+| 10 | Pipeline composition | `IncludePipelineComposition` | `IPipelineTemplateValidator` | Edge/Full/AirGapped in resolution tests |
+| 11 | Background agents & RAG | `IncludeBackgroundAgents`, `IncludeBackgroundAgentRag` | `IBackgroundAgentRegistry` | Full only; absent Edge/System |
+| 12 | Observation | `IncludeObservationPipeline` && !`DisableObservationPipeline` | `IPatternStore` | `HostingE2ESmokeTests`, observation integration |
+| 13 | Model decorator chain | Always | `IModel`, `HotSwappableModel` | All profiles resolve `IModel` |
+| 14 | Ephemeral lifecycle | Env `NEXO_EPHEMERAL*` | `IEphemeralModelLifecycle` | Env-gated; manual |
+| 15 | Trust & provider factory | `IncludeTrustServices`, env trust/load | `IProviderFactory`, `ICloudSanitizationProxy` | Trust tests; Full vs AirGapped |
+| 16 | Execution core | Always | `IBehaviorExecutor`, `ITextFileSystem` | Workflow executor tests |
+| 17 | Workflow executor | Always | `WorkflowExecutor` (scoped) | `WorkflowExecutorIntegrationTests` |
+| 18 | Analysis & validation | Always | `IAnalysisService`, `IValidationService` | `HostingE2ESmokeTests.ValidateAsync` |
+| 19 | Testing adapters | `IncludeTestingAdapters` | `IExecutionPlatform`, Docker | Full profile; optional remote URL |
+| 20 | Analysis rules & fleet | Always (fleet at end) | `IFleetNodeRegistry`, `IMeshTaskRegistry` | Fleet unit tests; mesh lab E2E |
+
+## Deployment profile × modules
+
+| Module | Full | Server | Edge | AirGapped | System |
+|--------|:----:|:------:|:----:|:---------:|:------:|
+| NCR | ✓ | ✓ | | ✓ | |
+| Runtime transport | ✓ | ✓ | | | |
+| Persistence | ✓ | ✓ | ✓ | ✓ | |
+| Adaptation | ✓ | ✓ | | ✓ | |
+| Pipelines | ✓ | ✓ | ✓ | ✓ | |
+| Background agents | ✓ | ✓ | | | |
+| Observation | ✓ | ✓ | | | |
+| Trust services | ✓ | ✓ | | | |
+| Workflow integrations | ✓ | ✓ | | | |
+| Testing adapters | ✓ | ✓ | | | |
+
+## Gaps (explicit)
+
+| Gap | Owner action |
+|-----|----------------|
+| Phase 14 ephemeral | Add env-matrix test when ephemeral becomes app-critical |
+| Phase 09 on System/Edge | Do not resolve `IKnowledgeQueryService` without `IAdaptationLog` + `IPatternStore` (factory throws) |
+| Phase 09 on AirGapped | Requires observation or adaptation pattern store before resolve |
+| Mesh federation | Use mesh lab gates, not kernel-gate default |
+
+## Commands
+
+```bash
+make kernel-gate
+dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj \
+  --filter "FullyQualifiedName~KernelPhaseResolutionTests"
+```

--- a/docs/production-readiness/ApplicationHardeningPlan-v1.md
+++ b/docs/production-readiness/ApplicationHardeningPlan-v1.md
@@ -1,0 +1,32 @@
+# Application hardening plan v1
+
+Validation for **`application/src/`** (API, CLI, GameDomain) after [Kernel Readiness v1](KernelReadiness-v1.md).
+
+**Automation:** `make application-gate-full`
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Build + CLI smoke | `make application-gate-tier-a` |
+| B | CLI tests + doctor | `make application-gate-tier-b` |
+| C | In-process API HTTP | `make application-gate-tier-c` |
+| D | Agent-server Compose + optional GameDomain | `make application-gate-tier-d` |
+
+## Prerequisites
+
+- `make kernel-gate` green (Tier A runs it unless `APPLICATION_GATE_SKIP_KERNEL=1`)
+- Docker for Tier D agent-server dry run
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `APPLICATION_GATE_SKIP_KERNEL=1` | Skip `make kernel-gate` in Tier A |
+| `APPLICATION_GATE_STRICT_DOCTOR=1` | Fail Tier B if `doctor --json` non-zero |
+| `APPLICATION_GATE_GAMEDOMAIN=1` | Run full GameDomain test assembly in Tier D |
+
+## Related
+
+- [runtime-vs-application.md](../architecture/runtime-vs-application.md)
+- [Kernel Hardening Plan v1](KernelHardeningPlan-v1.md)

--- a/docs/production-readiness/ApplicationReadiness-v1.md
+++ b/docs/production-readiness/ApplicationReadiness-v1.md
@@ -1,0 +1,39 @@
+# Application Readiness v1
+
+**Status: APPLICATION GATE GREEN** (Tiers A–D, 2026-05-19)
+
+Track after [Kernel Readiness v1](KernelReadiness-v1.md). **Plan:** [Application Hardening Plan v1](ApplicationHardeningPlan-v1.md)
+
+## Command
+
+```bash
+make application-gate-full   # after make kernel-gate-full (~2–3 min without Docker rebuild)
+```
+
+## Record
+
+| Date | Gate | Result | Notes |
+|------|------|--------|-------|
+| 2026-05-19 | A–D local | **PASS** | agent-server `/health` + `/api/status` |
+
+## Tier summary
+
+| Tier | Focus | Command | Status |
+|------|--------|---------|--------|
+| A | Product build + CLI validate | `make application-gate-tier-a` | **PASS** |
+| B | CLI tests + doctor | `make application-gate-tier-b` | **PASS** |
+| C | In-process API HTTP | `make application-gate-tier-c` | **PASS** |
+| D | Agent-server Compose | `make application-gate-tier-d` | **PASS** |
+
+## Next: composition & mesh
+
+```bash
+make composition-mesh-gate-full
+```
+
+See [Composition & mesh readiness v1](CompositionMeshReadiness-v1.md).
+
+## Sign-off
+
+- [x] `application-gate-full` green (2026-05-19)
+- [x] Kernel gate green same day

--- a/docs/production-readiness/CompositionMeshHardeningPlan-v1.md
+++ b/docs/production-readiness/CompositionMeshHardeningPlan-v1.md
@@ -1,0 +1,44 @@
+# Composition & mesh hardening plan v1
+
+Validates **pipeline composition** (templates, fan-out/fan-in, agentic/hybrid stages, orchestration) and **async clustered mesh tasks** (fleet registry, placement, leases, worker execution) after [Application Readiness v1](ApplicationReadiness-v1.md).
+
+**Automation:** `make composition-mesh-gate-full`
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Pipeline composition (in-process) | `make composition-mesh-gate-tier-a` |
+| B | CLI `pipeline` + `mesh` surfaces | `make composition-mesh-gate-tier-b` |
+| C | Mesh fleet control plane (in-process) | `make composition-mesh-gate-tier-c` |
+| D | Docker mesh lab (workers, task schedule→placement) | `make composition-mesh-gate-tier-d` |
+
+## Prerequisites
+
+- `make application-gate-full` (or `make kernel-gate-full` minimum)
+- Docker + `python3` for Tier D
+- Optional: `make bootstrap-mesh-lab-env` for persistent `.env.mesh-lab`
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `COMPOSITION_MESH_GATE_SKIP_TIER_D=1` | Skip Docker mesh E2E on full run |
+| `COMPOSITION_MESH_GATE_DEEP=1` | After Tier D up, run `mesh-lab-verify-deep.sh` (needs `.env.mesh-lab`) |
+| `COMPOSITION_MESH_GATE_STRESS=1` | Run `make mesh-lab-e2e-stress` instead of standard Tier D |
+
+## What each tier proves
+
+**Tier A** — `PipelineTemplateValidator`, `PipelineDecomposer`, `PipelineScheduler`, `PipelineOrchestrator`, fan-in/join strategies, agentic fallback, lifecycle/resume.
+
+**Tier B** — `nexo pipeline validate/run` command wiring; mesh director URI builder; mesh CLI trust paths; optimize-agent-cluster script layout.
+
+**Tier C** — `MeshTaskRegistry`, placement (elastic, trust, idempotency), execution leases, checkpoint migration, director persistence.
+
+**Tier D** — heterogeneous peers + **workers** profile; HTTP schedule/create mesh tasks; assigned placement across the lab (see `docs/MeshVirtualLab.md`).
+
+## Related
+
+- [Kernel phase 10 — pipeline composition](../architecture/KernelPhaseMatrix.md)
+- [Mesh agent setup tear sheet](../MeshAgentSetupCapabilityBreakdown.md)
+- `make mesh-lab-e2e-workers`, `make mesh-lab-verify-director-cli`

--- a/docs/production-readiness/CompositionMeshReadiness-v1.md
+++ b/docs/production-readiness/CompositionMeshReadiness-v1.md
@@ -1,0 +1,39 @@
+# Composition & mesh readiness v1
+
+**Status: COMPOSITION & MESH GATE GREEN** (Tiers A–D, 2026-05-19)
+
+Track after [Application Readiness v1](ApplicationReadiness-v1.md). **Plan:** [Composition & mesh hardening plan v1](CompositionMeshHardeningPlan-v1.md)
+
+## Command
+
+```bash
+make composition-mesh-gate-full   # A–D (~2–5 min in-process; +10–15 min Docker mesh lab)
+```
+
+## Record
+
+| Date | Gate | Result | Notes |
+|------|------|--------|-------|
+| 2026-05-19 | A–D local | **PASS** | 44 pipeline + 6 CLI + 18 fleet tests; mesh-lab workers E2E |
+
+## Tier summary
+
+| Tier | Focus | Command | Status |
+|------|--------|---------|--------|
+| A | Pipeline composition | `make composition-mesh-gate-tier-a` | **PASS** (44 tests) |
+| B | CLI pipeline + mesh | `make composition-mesh-gate-tier-b` | **PASS** (6 tests) |
+| C | Mesh fleet in-process | `make composition-mesh-gate-tier-c` | **PASS** (18 tests) |
+| D | Docker mesh workers | `make composition-mesh-gate-tier-d` | **PASS** |
+
+## Next: ship readiness
+
+```bash
+make ship-gate-full
+```
+
+See [Ship readiness v1](ShipReadiness-v1.md).
+
+## Sign-off
+
+- [x] `composition-mesh-gate-full` green (2026-05-19)
+- [x] Application + kernel gates green same week

--- a/docs/production-readiness/KernelChaosDrill-v1.md
+++ b/docs/production-readiness/KernelChaosDrill-v1.md
@@ -1,0 +1,34 @@
+# Kernel chaos drill v1 (quarterly)
+
+Operator checklist for game-day validation beyond automated `make kernel-gate-tier-e`. Record results in [Kernel Readiness v1](KernelReadiness-v1.md) or your ticket system.
+
+## Automated (Tier E)
+
+```bash
+make kernel-gate-tier-e
+KERNEL_GATE_CHAOS_LITE=1 make kernel-gate-tier-e   # mesh network-negative (requires mesh lab up)
+```
+
+## Manual drill matrix
+
+| Scenario | Command / action | Expected | Pass |
+|----------|------------------|----------|------|
+| Single API container loss | `docker compose -f docker-compose.portal.yml restart nexo-api` | `/health` recovers &lt; 2 min | [ ] |
+| Ollama unavailable | Stop `ollama` service in compose; API degrades gracefully | `/health` or status shows dependency issue, no hang | [ ] |
+| Disk full on pipeline store | Fill volume or bad `NEXO_PIPELINE_STORE_PATH` | Clear error, no silent corruption | [ ] |
+| Mesh peer partition | `make mesh-lab-e2e` then `mesh-lab-verify-network-negative` | Director survives; placement blocks bad peers | [ ] |
+| LiteDB resume after crash | Tier B script / production-readiness gate resume | Second process completes run | [ ] |
+
+## RPO / RTO (fill in)
+
+| Component | RPO | RTO | Last restore test |
+|-----------|-----|-----|-------------------|
+| Mesh director (LiteDB) | | | |
+| Pipeline run store | | | |
+| Portal / API config | | | |
+
+## Sign-off
+
+- [ ] Drill date: ___________
+- [ ] Owner: ___________
+- [ ] Gaps filed as issues: ___________

--- a/docs/production-readiness/KernelHardeningPlan-v1.md
+++ b/docs/production-readiness/KernelHardeningPlan-v1.md
@@ -1,0 +1,87 @@
+# Kernel hardening plan v1
+
+Pre-application validation for the Nexo execution kernel (`src/`, `Nexo.Hosting`). Goal: prove DI contracts, deployment profiles, and core execution paths before building product features under `application/src/`.
+
+**Tracking:** update [Kernel Readiness v1](KernelReadiness-v1.md) as tiers complete.
+
+**Automation:** `make kernel-gate` (see [Testing.md](../Testing.md#kernel-gate-pre-application)).
+
+---
+
+## Tier A — Kernel contracts (required before apps)
+
+| # | Item | Deliverable | Verification |
+|---|------|-------------|--------------|
+| A1 | Phase coverage matrix | [KernelPhaseMatrix.md](../architecture/KernelPhaseMatrix.md) | Doc + `KernelPhaseResolutionTests` |
+| A2 | Profile behavioral matrix | `HostingDeploymentProfileTests`, `KernelPhaseResolutionTests` | `make kernel-gate` |
+| A3 | Strict-mode contract | `StrictModeE2ETests` (existing) | ProdStyle / prime-time |
+| A4 | Single kernel gate | `Makefile` target `kernel-gate` | Local + CI `kernel-gate.yml` |
+
+**Tier A status (2026-05-19):** implemented; see [Kernel Readiness v1](KernelReadiness-v1.md).
+
+**Tier B status (2026-05-19):** `make kernel-gate-tier-b` / `scripts/kernel-gate-tier-b.sh` — build, pipeline lifecycle, CLI ops, cross-process LiteDB resume.
+
+**Tier C status (2026-05-19):** `make kernel-gate-tier-c` / `scripts/kernel-gate-tier-c.sh` — ProdStyle Infrastructure, workflow executor, gRPC transport, air-gapped profile; mesh when `.env.mesh-lab` exists (`make bootstrap-mesh-lab-env`).
+
+**Tier D status (2026-05-19):** `make kernel-gate-tier-d` / `scripts/kernel-gate-tier-d.sh` — `Nexo.Runtime.sln`, pack graph alignment, `StableSdkHostSample` consumer from local feed.
+
+## Tier B — Execution and state
+
+| # | Item | Deliverable | Verification |
+|---|------|-------------|--------------|
+| B1 | Loop / workflow invariants | Extend `WorkflowExecutorIntegrationTests` | `dotnet test --filter WorkflowExecutor` |
+| B2 | Cross-process pipeline resume | [ProductionReadinessGate-v1.md](../ProductionReadinessGate-v1.md) | `production-readiness-gate-v1.yml` |
+| B3 | Pipeline certification | Pipeline tests net8 + net9 | `kernel-gate` pipeline filter |
+
+## Tier C — Trust and network
+
+| # | Item | Deliverable | Verification |
+|---|------|-------------|--------------|
+| C1 | Trust negatives | `test-trust-multi-env.yml` | Scheduled / manual |
+| C2 | Mesh on fleet changes | `mesh-lab-gate.yml` path filters | CI |
+| C3 | Air-gapped proof | `test-air-gapped-no-network.yml` | CI |
+
+## Tier D — Consumption
+
+| # | Item | Deliverable | Verification |
+|---|------|-------------|--------------|
+| D1 | NuGet consumer drill | `nuget-consumer-verify.yml` | Release + monthly |
+| D2 | Runtime vs application boundary | `layer-boundary.yml`, `Nexo.Runtime.sln` | `kernel-gate` build |
+
+## Tier E — Operations (advisory until v2)
+
+| # | Item | Deliverable | Verification |
+|---|------|-------------|--------------|
+| E1 | Observability contract | `OpenTelemetryTests`, prod-dry-run | `make kernel-gate-tier-e` |
+| E2 | Perf budgets | `Nexo.Tests.Orchestration.Performance` in tier-e | `make kernel-gate-tier-e` |
+| E3 | Chaos / game day | [KernelChaosDrill-v1.md](KernelChaosDrill-v1.md) | Quarterly manual + optional `KERNEL_GATE_CHAOS_LITE=1` |
+
+**Tier E status:** `make kernel-gate-tier-e` / `scripts/kernel-gate-tier-e.sh` — OpenTelemetry, orchestration performance tests, `prod-dry-run.sh --portal`.
+
+---
+
+## Suggested timeline
+
+| Week | Focus | Command |
+|------|--------|---------|
+| 1 | Tiers A + D2 | `make kernel-gate` |
+| 2 | Tier B | `make ci-verify`, production-readiness gate |
+| 3 | Tier C | `make mesh-lab-e2e-workers` |
+| 4 | Sign-off | Update Kernel Readiness v1 |
+
+---
+
+## Optional kernel-gate flags
+
+| Variable | Effect |
+|----------|--------|
+| `KERNEL_GATE_MESH=1` | After core gate, run `make mesh-lab-verify` (Docker required) |
+| `KERNEL_GATE_PRODSTYLE=1` | Run `make test-prod-style` (longer) |
+
+---
+
+## Related docs
+
+- [Runtime vs application](../architecture/runtime-vs-application.md)
+- [Testing model](../architecture/TestingModel.md)
+- [Production readiness README](README.md)

--- a/docs/production-readiness/KernelReadiness-v1.md
+++ b/docs/production-readiness/KernelReadiness-v1.md
@@ -1,0 +1,60 @@
+# Kernel Readiness v1
+
+**Status: KERNEL READY FOR APPLICATIONS** (Tiers A–E automated gates green, 2026-05-19)
+
+**Plan:** [Kernel Hardening Plan v1](KernelHardeningPlan-v1.md) · **Quarterly ops:** [Kernel Chaos Drill v1](KernelChaosDrill-v1.md)
+
+## One command
+
+```bash
+make kernel-gate-full   # A + B + C + D + E (~10–15 min first run; Docker for E)
+```
+
+## Gate record
+
+| Date | Gate | Result |
+|------|------|--------|
+| 2026-05-19 | A–E local | **PASS** |
+| 2026-05-19 | mesh-lab-e2e | **PASS** |
+
+## Tier summary
+
+| Tier | Focus | Command | Status |
+|------|--------|---------|--------|
+| A | DI contracts, profiles | `make kernel-gate` | **PASS** |
+| B | CLI + LiteDB resume | `make kernel-gate-tier-b` | **PASS** |
+| C | ProdStyle, transport, air-gapped | `make kernel-gate-tier-c` | **PASS** |
+| D | NuGet consumer sample | `make kernel-gate-tier-d` | **PASS** |
+| E | OTel, perf, Compose dry run | `make kernel-gate-tier-e` | **PASS** |
+
+## Tier E detail
+
+- OpenTelemetry registration test
+- 3 orchestration performance tests
+- `prod-dry-run.sh --portal`: `/health` + `/api/status` on published API image (uses `linux/amd64` on ARM hosts)
+
+## Next: application layer
+
+After kernel sign-off, run [Application Readiness v1](ApplicationReadiness-v1.md):
+
+```bash
+make application-gate-full
+```
+
+## Before NuGet publish
+
+```bash
+make release-preflight VERSION=x.y.z
+```
+
+Post-publish: `nuget-consumer-verify.yml` against released version on nuget.org.
+
+## Application work
+
+You may build on `application/src/` when `make kernel-gate-full` is green. Re-run after kernel (`src/`, `Nexo.Hosting`) changes.
+
+## Sign-off
+
+- [x] Tiers A–E automated (2026-05-19)
+- [ ] Quarterly chaos drill checklist completed
+- [ ] Post-publish NuGet verify on release tag

--- a/docs/production-readiness/OpsHardeningPlan-v1.md
+++ b/docs/production-readiness/OpsHardeningPlan-v1.md
@@ -1,0 +1,37 @@
+# Operations & dogfood hardening plan v1
+
+Validates **Nexo on Nexo**: dogfood self-improvement blocks, optional mesh chaos/deep lab, and the operator demo script — after [Ship readiness v1](ShipReadiness-v1.md).
+
+**Automation:** `make ops-gate-full`
+
+## Prerequisites
+
+```bash
+make ship-gate-full
+```
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Dogfood blocks 1–6 | `make ops-gate-tier-a` |
+| B | Dogfood blocks 7–9 + IPC mesh | `make ops-gate-tier-b` |
+| C | Closed-loop self-improvement | `make ops-gate-tier-c` |
+| D | Mesh deep E2E or chaos-lite | `make ops-gate-tier-d` |
+| E | Oh-shit demo (quick) | `make ops-gate-tier-e` |
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `OPS_GATE_SKIP_PRIOR=1` | Skip `make ship-gate-full` on full run |
+| `OPS_GATE_SKIP_TIER_D=1` | Skip mesh/chaos tier |
+| `OPS_GATE_MESH_DEEP=1` | Tier D: `mesh-lab-e2e-deep` one-shot |
+| `OPS_GATE_CHAOS_LITE=1` | Tier D: network-negative on `.env.mesh-lab` |
+| `OPS_GATE_RUN_PHASE_F=1` | Tier C: also run `dogfood-phasef` |
+
+## Related
+
+- [Kernel chaos drill v1](KernelChaosDrill-v1.md)
+- [Release candidate checklist v1](../ReleaseCandidateChecklist-v1.md)
+- `make dogfood-all`, `scripts/oh-shit-demo.sh`

--- a/docs/production-readiness/OpsReadiness-v1.md
+++ b/docs/production-readiness/OpsReadiness-v1.md
@@ -1,0 +1,41 @@
+# Operations & dogfood readiness v1
+
+**Status: OPS GATE GREEN** (Tiers A–C, E default profile, 2026-05-19)
+
+Track after [Ship readiness v1](ShipReadiness-v1.md). **Plan:** [Ops hardening plan v1](OpsHardeningPlan-v1.md)
+
+## Command
+
+```bash
+make ops-gate-full
+make nexo-ready-gate   # full stack (use NEXO_READY_SKIP_DOCKER=1 locally for speed)
+```
+
+## Record
+
+| Date | Gate | Result | Notes |
+|------|------|--------|-------|
+| 2026-05-19 | A–C, E local | **PASS** | Tier D mesh/chaos optional |
+
+## Tier summary
+
+| Tier | Focus | Status |
+|------|--------|--------|
+| A | Dogfood blocks 1–6 | **PASS** |
+| B | Dogfood blocks 7–9 + IPC mesh | **PASS** |
+| C | Closed-loop self-improvement | **PASS** |
+| D | Mesh deep / chaos-lite | optional |
+| E | Oh-shit demo (quick) | **PASS** |
+
+## Next: security & trust
+
+```bash
+make security-gate-full
+```
+
+See [Security readiness v1](SecurityReadiness-v1.md).
+
+## Sign-off
+
+- [x] `ops-gate` default tiers green (2026-05-19)
+- [x] Ship gate green same week

--- a/docs/production-readiness/RCHardeningPlan-v1.md
+++ b/docs/production-readiness/RCHardeningPlan-v1.md
@@ -1,0 +1,40 @@
+# Release candidate hardening plan v1
+
+Moves from **security gate green** to **release-ready with evidence** — mirrors [Release candidate checklist v1](../ReleaseCandidateChecklist-v1.md).
+
+**Automation:** `make rc-gate-full`
+
+## Prerequisites
+
+```bash
+make security-gate-full
+# optional: gh auth login
+```
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Full `nexo-ready-gate` | `make rc-gate-tier-a` |
+| B | Ship gate + `ci release-bundle` | `make rc-gate-tier-b` |
+| C | Evidence audit (bundle, security, rollback docs) | `make rc-gate-tier-c` |
+| D | GitHub Actions RC workflows | `make rc-gate-tier-d` |
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `RC_GATE_SKIP_PRIOR=1` | Skip tier A (default in `rc-gate-full`) |
+| `RC_GATE_SKIP_DOCKER=1` | Tier A: `NEXO_READY_SKIP_DOCKER=1` |
+| `RC_GATE_RELEASE_BUNDLE_FULL=1` | Tier B: also `ci release-bundle --profile full` |
+| `RC_GATE_STRICT_EVIDENCE=1` | Tier C fails on bundle FAIL |
+| `RC_GATE_STRICT_SECURITY=1` | Tier C fails on High/Critical CVEs |
+| `RC_GATE_TRIGGER_GH=1` | Tier D: dispatch + watch on workflow miss |
+| `RC_GATE_GH_ADVISORY_ONLY=1` | Tier D: warn instead of fail |
+| `RC_GATE_GH_BRANCH=master` | Branch for `gh run list` |
+| `RC_GATE_RUN_PUBLISH=1` | Tier D: require `container-image-publish` green |
+
+## Related
+
+- [Release candidate checklist v1](../ReleaseCandidateChecklist-v1.md)
+- [Release and promotion](ReleaseAndPromotion.md)

--- a/docs/production-readiness/RCReadiness-v1.md
+++ b/docs/production-readiness/RCReadiness-v1.md
@@ -1,0 +1,24 @@
+# Release candidate readiness v1
+
+Track after [Security readiness v1](SecurityReadiness-v1.md). **Plan:** [RC hardening plan v1](RCHardeningPlan-v1.md)
+
+## Command
+
+```bash
+make rc-gate-full
+```
+
+## Sign-off
+
+- [ ] `rc-gate-full` green
+- [ ] GitHub tier D workflows green (or `RC_GATE_GH_ADVISORY_ONLY=1` with owner)
+- [ ] `make waterproofing-gate-full` (perf → compat → DR → RC policy)
+- [ ] Manual checklist sections 3–5 in [Release candidate checklist v1](../ReleaseCandidateChecklist-v1.md)
+
+## Next: post-RC waterproofing
+
+```bash
+make waterproofing-gate-full
+```
+
+See [Perf readiness](PerfReadiness-v1.md), [Compat readiness](CompatReadiness-v1.md), [DR readiness](DRReadiness-v1.md).

--- a/docs/production-readiness/README.md
+++ b/docs/production-readiness/README.md
@@ -6,6 +6,18 @@ This folder helps you **support every major production concern** in one place: r
 
 | Area | Guide | One-line goal |
 | ---- | ----- | --------------- |
+| **Kernel hardening** | [Kernel hardening plan v1](KernelHardeningPlan-v1.md) · [Kernel readiness](KernelReadiness-v1.md) · [Chaos drill](KernelChaosDrill-v1.md) | `make kernel-gate-full` (A–E) before application work |
+| **Application hardening** | [Application hardening plan v1](ApplicationHardeningPlan-v1.md) · [Application readiness](ApplicationReadiness-v1.md) | `make application-gate-full` (A–D) after kernel |
+| **Composition & mesh** | [Composition & mesh plan v1](CompositionMeshHardeningPlan-v1.md) · [Readiness](CompositionMeshReadiness-v1.md) | `make composition-mesh-gate-full` (pipelines + mesh tasks) |
+| **Ship readiness** | [Ship hardening plan v1](ShipHardeningPlan-v1.md) · [Ship readiness](ShipReadiness-v1.md) | `make ship-gate-full` (prod gate + ci verify + release) |
+| **Ops & dogfood** | [Ops hardening plan v1](OpsHardeningPlan-v1.md) · [Ops readiness](OpsReadiness-v1.md) | `make ops-gate-full` (self-improvement + demo) |
+| **Security & trust** | [Security hardening plan v1](SecurityHardeningPlan-v1.md) · [Security readiness](SecurityReadiness-v1.md) | `make security-gate-full` (auth + supply chain + air-gapped) |
+| **Release candidate** | [RC hardening plan v1](RCHardeningPlan-v1.md) · [RC readiness](RCReadiness-v1.md) | `make rc-gate-full` (bundle + GH workflow evidence) |
+| **Performance** | [Perf hardening plan v1](PerfHardeningPlan-v1.md) · [Perf readiness](PerfReadiness-v1.md) | `make perf-gate-full` |
+| **Compatibility** | [Compat hardening plan v1](CompatHardeningPlan-v1.md) · [Compat readiness](CompatReadiness-v1.md) | `make compat-gate-full` |
+| **Disaster recovery** | [DR hardening plan v1](DRHardeningPlan-v1.md) · [DR readiness](DRReadiness-v1.md) | `make dr-gate-full` |
+| **Post-RC waterproofing** | [Rollback drill](RollbackDrill-v1.md) · [Release sign-off](ReleaseSignOff-v1.md) | `make waterproofing-gate-full` |
+| **Full stack** | — | `make nexo-ready-gate` (`NEXO_READY_SKIP_DOCKER=1` for fast local) |
 | Release & promotion | [Release and promotion](ReleaseAndPromotion.md) | Reproducible versions, artifacts, rollback, one promotion path |
 | Security & trust | [Security and trust](SecurityAndTrust.md) | Secrets, threat model, supply chain, dependency risk |
 | Operations | [Operations and observability](OperationsAndObservability.md) | SLOs, alerting, health, capacity, runbooks |

--- a/docs/production-readiness/SecurityHardeningPlan-v1.md
+++ b/docs/production-readiness/SecurityHardeningPlan-v1.md
@@ -1,0 +1,49 @@
+# Security & trust hardening plan v1
+
+Validates the **trust boundary** (policy packs, audit log, access boundary), **API auth & mesh security middleware**, **CLI trust surfaces**, **supply chain**, and **air-gapped operation** — the production "waterproofing" layer before exposing Nexo to the internet.
+
+**Automation:** `make security-gate-full`
+
+## Prerequisites
+
+```bash
+make ship-gate-full
+```
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Trust core (policy packs, peer trust, audit, access boundary) | `make security-gate-tier-a` |
+| B | API security middleware (key/bearer/basic, mesh, open-internet readiness) | `make security-gate-tier-b` |
+| C | Trust CLI (`trust boundary`, `trust dashboard`, `trust audit`) | `make security-gate-tier-c` |
+| D | Supply chain (vulnerable + deprecated packages) | `make security-gate-tier-d` |
+| E | Air-gapped + safety probes | `make security-gate-tier-e` |
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `SECURITY_GATE_SKIP_PRIOR=1` | Skip ship-gate prerequisite |
+| `SECURITY_GATE_SKIP_TIER_D=1` | Skip supply-chain scan |
+| `SECURITY_GATE_SKIP_TIER_E=1` | Skip air-gapped tier |
+| `SECURITY_GATE_STRICT_SUPPLY_CHAIN=1` | Tier D fails on any vulnerable transitive |
+| `SECURITY_GATE_AIRGAPPED_CONTAINER=1` | Tier E adds `--network none` container test |
+
+## What each tier proves
+
+**A** — `TrustPolicyPackRegistryTests`, `NexoPeerBrickExecutorTrustTests`, audit log retention, `AccessBoundary` rules.
+
+**B** — `NexoApiKeyAuthMiddlewareTests`, `MeshSecurityMiddlewareTests`, `NexoApiOpenInternetReadinessTests`, `SecurityAdvisoryEndpointTests`, `SecurityAnalysisRuleTests`.
+
+**C** — TrustCommand unit suite + `nexo trust boundary --format-json` and `nexo trust dashboard --format-json` smoke.
+
+**D** — `dotnet list package --vulnerable` / `--deprecated` on `application/Nexo.Application.sln` plus `Nexo.Hosting` and `Nexo.Infrastructure` (avoids a known NuGet client issue with YamlDotNet registration on `Nexo.Core`). Reports in `.nexo/security-gate/`.
+
+**E** — air-gapped profile resolution + `LocalModelProviderSafetyTests`. Optional `--network none` container suite.
+
+## Related
+
+- [Security & trust](SecurityAndTrust.md)
+- [Trust & execution boundaries](../architecture/TrustAndExecutionBoundaries.md)
+- `.github/workflows/test-air-gapped-no-network.yml`

--- a/docs/production-readiness/SecurityReadiness-v1.md
+++ b/docs/production-readiness/SecurityReadiness-v1.md
@@ -1,0 +1,41 @@
+# Security & trust readiness v1
+
+**Status: SECURITY GATE GREEN** (Tiers A–E, 2026-05-19)
+
+Track after [Ops readiness v1](OpsReadiness-v1.md). **Plan:** [Security hardening plan v1](SecurityHardeningPlan-v1.md)
+
+## Command
+
+```bash
+make security-gate-full
+```
+
+## Record
+
+| Date | Gate | Result | Notes |
+|------|------|--------|-------|
+| 2026-05-19 | A–E local | **PASS** | Supply-chain: app + Hosting + Infrastructure; xunit deprecated warning |
+
+## Tier summary
+
+| Tier | Focus | Command | Status |
+|------|--------|---------|--------|
+| A | Trust core | `make security-gate-tier-a` | **PASS** |
+| B | API security middleware | `make security-gate-tier-b` | **PASS** |
+| C | Trust CLI | `make security-gate-tier-c` | **PASS** |
+| D | Supply chain | `make security-gate-tier-d` | **PASS** |
+| E | Air-gapped + safety | `make security-gate-tier-e` | **PASS** |
+
+## Next: release candidate
+
+```bash
+make rc-gate-full
+```
+
+See [RC hardening plan v1](RCHardeningPlan-v1.md) and [Release candidate checklist v1](../ReleaseCandidateChecklist-v1.md).
+
+## Sign-off
+
+- [x] `security-gate-full` green (2026-05-19)
+- [x] Tier D reports in `.nexo/security-gate/` (no High/Critical in scanned surfaces)
+- [x] Air-gapped tier verified (in-process safety + profile tests)

--- a/docs/production-readiness/ShipHardeningPlan-v1.md
+++ b/docs/production-readiness/ShipHardeningPlan-v1.md
@@ -1,0 +1,37 @@
+# Ship hardening plan v1
+
+End-to-end **ship readiness** after [Composition & mesh readiness v1](CompositionMeshReadiness-v1.md): production gate CLI flows, CI verify, release preflight, and release bundle.
+
+**Automation:** `make ship-gate-full`
+
+## Prerequisites
+
+```bash
+make composition-mesh-gate-full   # or COMPOSITION_MESH_GATE_SKIP_TIER_D=1 for in-process only
+```
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Production Readiness Gate v1 (CLI + LiteDB resume) | `make ship-gate-tier-a` |
+| B | ProdStyle + smoke + doctor | `make ship-gate-tier-b` (`SHIP_GATE_RUN_CI_VERIFY=1` for full `ci verify`) |
+| C | Release preflight (local feed consumer) | `make ship-gate-tier-c` |
+| D | Doctor sign-off (`SHIP_GATE_RUN_RUNTIME_GATE=1` adds release bundle) | `make ship-gate-tier-d` |
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `SHIP_GATE_SKIP_PRIOR=1` | Skip `composition-mesh-gate` on full run |
+| `SHIP_GATE_SKIP_TIER_B=1` | Skip `ci verify` (heavy ProdStyle) |
+| `SHIP_GATE_SKIP_TIER_C=1` | Skip NuGet preflight |
+| `SHIP_GATE_SKIP_TIER_D=1` | Skip release bundle |
+| `SHIP_GATE_VERSION=x.y.z` | Preflight version (default `0.0.0-ship-gate-local`) |
+| `SHIP_GATE_RUN_RUNTIME_GATE=1` | Run `ci release-bundle` (includes runtime SLO gate) |
+| `SHIP_GATE_BUNDLE_PROFILE=quick\|default\|full` | Release bundle profile when runtime gate enabled |
+
+## Related
+
+- [Production Readiness Gate v1](../ProductionReadinessGate-v1.md)
+- [Release and promotion](ReleaseAndPromotion.md)

--- a/docs/production-readiness/ShipReadiness-v1.md
+++ b/docs/production-readiness/ShipReadiness-v1.md
@@ -1,0 +1,39 @@
+# Ship readiness v1
+
+**Status: SHIP GATE GREEN** (Tiers A–D default profile, 2026-05-19)
+
+Track after [Composition & mesh readiness v1](CompositionMeshReadiness-v1.md). **Plan:** [Ship hardening plan v1](ShipHardeningPlan-v1.md)
+
+## Command
+
+```bash
+make ship-gate-full
+```
+
+## Record
+
+| Date | Gate | Result | Notes |
+|------|------|--------|-------|
+| 2026-05-19 | A–D local | **PASS** | Runtime bundle opt-in (`SHIP_GATE_RUN_RUNTIME_GATE=1`) |
+
+## Tier summary
+
+| Tier | Focus | Status |
+|------|--------|--------|
+| A | Production Readiness Gate v1 CLI + LiteDB resume | **PASS** |
+| B | ProdStyle + smoke + doctor | **PASS** |
+| C | Release preflight (`0.0.0-ship-gate-local`) | **PASS** |
+| D | Doctor sign-off | **PASS** |
+
+## Next: operations & dogfood
+
+```bash
+make ops-gate-full
+```
+
+See [Ops readiness v1](OpsReadiness-v1.md). Full stack: `make nexo-ready-gate`.
+
+## Sign-off
+
+- [x] `ship-gate-full` green (2026-05-19)
+- [x] Composition + mesh gates green same week

--- a/docs/production-readiness/TestingAndQualityGates.md
+++ b/docs/production-readiness/TestingAndQualityGates.md
@@ -7,6 +7,12 @@
 
 ## Checklist
 
+### Kernel gate (pre-application)
+
+- [ ] `make kernel-gate-full` passes locally before major application work on `application/src/`.
+- [ ] [Kernel Readiness v1](KernelReadiness-v1.md) updated after gate runs.
+- [ ] `make kernel-gate-tier-d` or release preflight before publishing NuGet packages.
+
 ### Required status checks
 
 - [ ] Branch protection on default branch requires: build, primary test workflow, and any coverage or security gate you adopt.

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.0",
-    "rollForward": "latestMinor",
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/scripts/application-gate-tier-a.sh
+++ b/scripts/application-gate-tier-a.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Application Tier A: build product solution + CLI smoke.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ "${APPLICATION_GATE_SKIP_KERNEL:-0}" != "1" ]; then
+  echo "== Application Tier A: kernel prerequisite (make kernel-gate) =="
+  make kernel-gate
+fi
+
+echo "== Application Tier A: build Nexo.Application.sln =="
+dotnet build application/Nexo.Application.sln -v minimal
+
+echo "== Application Tier A: CLI --help =="
+dotnet run --project application/src/Nexo.CLI/Nexo.CLI.csproj --no-build -- --help >/dev/null
+
+echo "== Application Tier A: pipeline validate smoke =="
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cat > "$TMP/smoke.json" <<'JSON'
+{
+  "templateId": "app-gate-smoke",
+  "version": "1",
+  "stages": [{ "id": "s1", "name": "S1", "mode": "Deterministic" }]
+}
+JSON
+NEXO_ALLOW_MOCK=1 dotnet run --project application/src/Nexo.CLI/Nexo.CLI.csproj --no-build -- \
+  pipeline validate --template "$TMP/smoke.json"
+
+echo ""
+echo "application-gate-tier-a: PASS"

--- a/scripts/application-gate-tier-b.sh
+++ b/scripts/application-gate-tier-b.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Application Tier B: CLI unit tests (focused) + doctor report.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI_TESTS="application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj"
+
+echo "== Application Tier B: CLI command tests =="
+dotnet build "$CLI_TESTS" -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$CLI_TESTS" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~ValidateCommandTests|FullyQualifiedName~MeshDirectorCommandUriTests|FullyQualifiedName~TrustCommandTests|FullyQualifiedName~WorkflowCommandTests" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+echo "== Application Tier B: doctor --json =="
+set +e
+NEXO_ALLOW_MOCK=1 dotnet run --project application/src/Nexo.CLI/Nexo.CLI.csproj -- doctor --json
+doctor_exit=$?
+set -e
+if [ "$doctor_exit" -ne 0 ]; then
+  echo "doctor --json exited $doctor_exit (warnings may fail strict profile; review output)" >&2
+  if [ "${APPLICATION_GATE_STRICT_DOCTOR:-0}" = "1" ]; then
+    exit "$doctor_exit"
+  fi
+fi
+
+echo ""
+echo "application-gate-tier-b: PASS"

--- a/scripts/application-gate-tier-c.sh
+++ b/scripts/application-gate-tier-c.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Application Tier C: in-process Nexo.API (WebApplicationFactory) HTTP contract tests.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Application Tier C: in-process API (DI + HTTP demos) =="
+dotnet build "$INFRA" -f net8.0 -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~ApiDevelopmentHostDiTests|FullyQualifiedName~FrameworkVirtualProdDemosTests" \
+  --blame-hang-timeout 180s --blame-hang-dump-type none
+
+echo ""
+echo "application-gate-tier-c: PASS"

--- a/scripts/application-gate-tier-d.sh
+++ b/scripts/application-gate-tier-d.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Application Tier D: agent-server Compose dry run + optional GameDomain smoke.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"
+
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  echo "== Application Tier D: agent-server prod-shaped dry run =="
+  bash scripts/prod-dry-run.sh --agent-server
+else
+  echo "== Application Tier D: agent-server dry run skipped (no Docker) =="
+fi
+
+if [ "${APPLICATION_GATE_GAMEDOMAIN:-0}" = "1" ]; then
+  echo "== Application Tier D: GameDomain tests =="
+  dotnet test application/src/Nexo.Tests.GameDomain/Nexo.Tests.GameDomain.csproj -f net8.0 \
+    --blame-hang-timeout 120s --blame-hang-dump-type none
+else
+  echo "== Application Tier D: GameDomain skipped (APPLICATION_GATE_GAMEDOMAIN=1 to enable) =="
+fi
+
+echo ""
+echo "application-gate-tier-d: PASS"

--- a/scripts/bootstrap-mesh-lab-env.sh
+++ b/scripts/bootstrap-mesh-lab-env.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Create .env.mesh-lab from docs/config/mesh-lab.env.example when missing (gitignored).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT/.env.mesh-lab"
+EXAMPLE="$ROOT/docs/config/mesh-lab.env.example"
+
+if [ -f "$TARGET" ]; then
+  echo ".env.mesh-lab already exists"
+  exit 0
+fi
+
+if [ ! -f "$EXAMPLE" ]; then
+  echo "Missing $EXAMPLE" >&2
+  exit 1
+fi
+
+cp "$EXAMPLE" "$TARGET"
+sed -i.bak \
+  -e 's/CHANGE_ME_LAB_API_KEY/nexo-mesh-lab-api-key-local/g' \
+  -e 's/CHANGE_ME_LAB_PEER_REGISTRATION_KEY/nexo-mesh-lab-peer-reg-local/g' \
+  -e 's/CHANGE_ME_LAB_COPILOT_SCOPED_KEY/nexo-mesh-lab-copilot-scoped-local/g' \
+  -e 's/CHANGE_ME_LAB_BEARER_OR_SAME_AS_API_KEY/nexo-mesh-lab-api-key-local/g' \
+  -e 's/CHANGE_ME_LAB_BASIC_PASSWORD/nexo-mesh-lab-basic-local/g' \
+  "$TARGET"
+rm -f "$TARGET.bak"
+echo "Created $TARGET from example (lab-only secrets; not for production)"

--- a/scripts/composition-mesh-gate-tier-a.sh
+++ b/scripts/composition-mesh-gate-tier-a.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Composition + mesh Tier A: pipeline composition (validate, decompose, schedule, orchestrate, lifecycle).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Composition Tier A: pipeline composition tests =="
+dotnet build "$INFRA" -f net8.0 -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Pipelines" \
+  --blame-hang-timeout 180s --blame-hang-dump-type none
+
+echo ""
+echo "composition-mesh-gate-tier-a: PASS"

--- a/scripts/composition-mesh-gate-tier-b.sh
+++ b/scripts/composition-mesh-gate-tier-b.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Composition + mesh Tier B: CLI pipeline + mesh director/command surfaces.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI="application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj"
+
+echo "== Composition Tier B: mesh director URI + CLI unit suites =="
+dotnet build "$CLI" -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$CLI" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~MeshDirectorCommandUriTests|FullyQualifiedName~UnitTestBridgeTests&(DisplayName~PipelineCommand|DisplayName~MeshCommand|DisplayName~OptimizeAgentCluster)" \
+  --blame-hang-timeout 180s --blame-hang-dump-type none
+
+echo ""
+echo "composition-mesh-gate-tier-b: PASS"

--- a/scripts/composition-mesh-gate-tier-c.sh
+++ b/scripts/composition-mesh-gate-tier-c.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Composition + mesh Tier C: in-process mesh fleet (task registry, placement, execution, elastic, persistence).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Mesh Tier C: fleet / clustered task control plane (in-process) =="
+dotnet build "$INFRA" -f net8.0 -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Fleet" \
+  --blame-hang-timeout 180s --blame-hang-dump-type none
+
+echo ""
+echo "composition-mesh-gate-tier-c: PASS"

--- a/scripts/composition-mesh-gate-tier-d.sh
+++ b/scripts/composition-mesh-gate-tier-d.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Composition + mesh Tier D: Docker mesh virtual lab (workers + async task schedule/placement).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  echo "== Mesh Tier D: skipped (Docker not available) =="
+  exit 0
+fi
+
+ENV_FILE="${1:-.env.mesh-lab}"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "== Mesh Tier D: one-shot E2E (temp secrets) =="
+  MESH_LAB_E2E_WORKERS=1 bash scripts/run-mesh-lab-e2e.sh
+else
+  echo "== Mesh Tier D: workers profile + verify ($ENV_FILE) =="
+  MESH_LAB_E2E_WORKERS=1 bash scripts/run-mesh-lab-e2e.sh "$ENV_FILE"
+fi
+
+if [[ "${COMPOSITION_MESH_GATE_DEEP:-0}" = "1" ]]; then
+  echo "== Mesh Tier D: deep verify (checkpoint / migrate / reschedule) =="
+  if [[ -f "$ENV_FILE" ]]; then
+    ./scripts/mesh-lab-verify-deep.sh "$ENV_FILE"
+  else
+    echo "Deep verify requires persistent .env.mesh-lab; set COMPOSITION_MESH_GATE_DEEP=0 or provide env file" >&2
+    exit 1
+  fi
+fi
+
+echo ""
+echo "composition-mesh-gate-tier-d: PASS"

--- a/scripts/kernel-gate-tier-b.sh
+++ b/scripts/kernel-gate-tier-b.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Tier B kernel gate: production-readiness checks (build, CLI pipeline ops, LiteDB cross-process resume).
+# See docs/ProductionReadinessGate-v1.md and docs/production-readiness/KernelHardeningPlan-v1.md
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI_PROJECT="application/src/Nexo.CLI/Nexo.CLI.csproj"
+TMP_ROOT="${TMPDIR:-/tmp}/nexo-kernel-gate-$$"
+export TMP_ROOT
+mkdir -p "$TMP_ROOT"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+TEMPLATE_PATH="$TMP_ROOT/pipeline_gate_demo.json"
+RESUME_DB="$TMP_ROOT/nexo_pipeline_gate_resume.db"
+
+echo "== Tier B: build checks =="
+dotnet build src/Nexo.Core.Application/Nexo.Core.Application.csproj -f netstandard2.0 -v minimal
+dotnet build src/Nexo.Infrastructure/Nexo.Infrastructure.csproj -v minimal
+dotnet build "$CLI_PROJECT" -v minimal
+
+echo "== Tier B: pipeline lifecycle tests (net8) =="
+NEXO_ALLOW_MOCK=1 dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 \
+  --filter "FullyQualifiedName~PipelineTemplateValidatorTests|FullyQualifiedName~PipelineLifecycleE2ETests" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none \
+  --logger "console;verbosity=minimal"
+
+cat > "$TEMPLATE_PATH" <<'JSON'
+{
+  "templateId": "gate-demo",
+  "version": "1.0",
+  "stages": [
+    { "id": "ingest", "name": "Ingest", "mode": "Deterministic" },
+    { "id": "hybrid", "name": "Hybrid", "mode": "Hybrid", "fallbackChain": ["Deterministic", "Agentic"] }
+  ],
+  "edges": [
+    { "fromStageId": "ingest", "toStageId": "hybrid" }
+  ]
+}
+JSON
+
+parse_final_json() {
+  python3 - "$1" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as fh:
+    lines = [line.strip() for line in fh.readlines()]
+json_lines = [line for line in lines if line.startswith("{") and line.endswith("}")]
+if not json_lines:
+    raise SystemExit(f"No JSON payload found in {path}")
+print(json_lines[-1])
+PY
+}
+
+echo "== Tier B: CLI validate / run / fallback =="
+VALIDATE_LOG="$TMP_ROOT/gate-validate.log"
+SUCCESS_LOG="$TMP_ROOT/gate-run-success.log"
+FALLBACK_LOG="$TMP_ROOT/gate-run-fallback.log"
+DIAGNOSTICS_LOG="$TMP_ROOT/gate-diagnostics.log"
+
+dotnet run --project "$CLI_PROJECT" -- pipeline validate --template "$TEMPLATE_PATH" | tee "$VALIDATE_LOG"
+dotnet run --project "$CLI_PROJECT" -- pipeline run --template "$TEMPLATE_PATH" --run-id gate-run-success --format-json | tee "$SUCCESS_LOG"
+NEXO_PIPELINE_ENABLE_TEST_HOOKS=1 NEXO_PIPELINE_COMPLETION_POLICY=AllowNonCriticalStageFailures \
+  dotnet run --project "$CLI_PROJECT" -- pipeline run --template "$TEMPLATE_PATH" --run-id gate-run-fallback \
+  --input "fail:hybrid:deterministic=true" --format-json | tee "$FALLBACK_LOG"
+dotnet run --project "$CLI_PROJECT" -- pipeline diagnostics --format-json | tee "$DIAGNOSTICS_LOG"
+
+python3 - <<PY
+import json, os
+tmp = os.environ["TMP_ROOT"]
+def load(name):
+    with open(os.path.join(tmp, name), encoding="utf-8") as fh:
+        lines = [l.strip() for l in fh if l.strip().startswith("{")]
+    return json.loads(lines[-1])
+success = load("gate-run-success.log")
+fallback = load("gate-run-fallback.log")
+if not success.get("ok"):
+    raise SystemExit("Success run did not return ok=true")
+if success.get("data", {}).get("state") != "Completed":
+    raise SystemExit("Success run did not complete")
+stages = fallback.get("data", {}).get("stages", [])
+hybrid = next((s for s in stages if s.get("stageId") == "hybrid"), None)
+if hybrid is None or hybrid.get("workerType") != "Agentic":
+    raise SystemExit("Fallback run did not switch hybrid stage to Agentic worker")
+print("CLI operational checks: PASS")
+PY
+
+echo "== Tier B: cross-process durable resume (LiteDB) =="
+RESUME_SOURCE_LOG="$TMP_ROOT/gate-resume-source.log"
+RESUME_TARGET_LOG="$TMP_ROOT/gate-resume-target.log"
+rm -f "$RESUME_DB"
+
+set +e
+NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH="$RESUME_DB" NEXO_PIPELINE_ENABLE_TEST_HOOKS=1 \
+  dotnet run --project "$CLI_PROJECT" -- pipeline run --template "$TEMPLATE_PATH" \
+  --run-id gate-resume-source --input "fail:ingest:deterministic=true" --format-json | tee "$RESUME_SOURCE_LOG"
+source_exit=$?
+set -e
+
+if [ "$source_exit" -eq 0 ]; then
+  echo "Expected source run to fail for resume scenario" >&2
+  exit 1
+fi
+
+NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH="$RESUME_DB" \
+  dotnet run --project "$CLI_PROJECT" -- pipeline run --template "$TEMPLATE_PATH" \
+  --run-id gate-resume-target --resume-run-id gate-resume-source --resume-failed-stages --format-json | tee "$RESUME_TARGET_LOG"
+
+python3 - <<PY
+import json, os
+tmp = os.environ["TMP_ROOT"]
+def load(name):
+    with open(os.path.join(tmp, name), encoding="utf-8") as fh:
+        lines = [l.strip() for l in fh if l.strip().startswith("{")]
+    return json.loads(lines[-1])
+source = load("gate-resume-source.log")
+target = load("gate-resume-target.log")
+if source.get("data", {}).get("state") != "Failed":
+    raise SystemExit("Source run expected Failed state")
+if not target.get("ok") or target.get("data", {}).get("state") != "Completed":
+    raise SystemExit("Resumed target run did not complete successfully")
+print("Cross-process durable resume: PASS")
+PY
+
+echo ""
+echo "kernel-gate-tier-b: PASS"

--- a/scripts/kernel-gate-tier-c.sh
+++ b/scripts/kernel-gate-tier-c.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tier C kernel gate: extended ProdStyle (Infrastructure), workflow executor, optional mesh lab.
+# See docs/production-readiness/KernelHardeningPlan-v1.md
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+TRANSPORT="src/Nexo.Tests.Transport/Nexo.Tests.Transport.csproj"
+
+echo "== Tier C: ProdStyle Infrastructure (net8, FluentAssertions-safe filter) =="
+make test-prod-style
+
+echo "== Tier C: workflow executor integration =="
+dotnet build "$INFRA" -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~WorkflowExecutorIntegrationTests" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+echo "== Tier C: gRPC transport ProdStyle =="
+if [ -f "$TRANSPORT" ]; then
+  dotnet build "$TRANSPORT" -v minimal
+  dotnet test "$TRANSPORT" -f net8.0 --no-build \
+    --filter "Category=ProdStyle" \
+    --blame-hang-timeout 120s --blame-hang-dump-type none
+else
+  echo "Skip: $TRANSPORT not found"
+fi
+
+echo "== Tier C: air-gapped profile smoke (in-process) =="
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~AirGapped" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+if [ "${KERNEL_GATE_MESH_E2E:-0}" = "1" ] && [ -f ".env.mesh-lab" ]; then
+  echo "== Tier C: mesh virtual lab E2E (compose up + verify + down) =="
+  bash scripts/run-mesh-lab-e2e.sh .env.mesh-lab
+elif [ -f ".env.mesh-lab" ]; then
+  echo "== Tier C: mesh lab skipped (set KERNEL_GATE_MESH_E2E=1 for full E2E; or run: make mesh-lab-e2e) =="
+else
+  echo "== Tier C: mesh lab skipped (run: make bootstrap-mesh-lab-env) =="
+fi
+
+echo ""
+echo "kernel-gate-tier-c: PASS"

--- a/scripts/kernel-gate-tier-d.sh
+++ b/scripts/kernel-gate-tier-d.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tier D kernel gate: pack graph alignment + local NuGet consumer sample (isolated cache).
+# See docs/NuGetConsumerVerify.md and docs/production-readiness/KernelHardeningPlan-v1.md
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VERSION="${NEXO_SDK_PACKAGE_VERSION:-0.0.0-kernel-gate-local}"
+export NEXO_SDK_PACKAGE_VERSION="${VERSION}"
+
+echo "== Tier D: runtime graph builds without application hosts =="
+dotnet build Nexo.Runtime.sln -v minimal
+
+echo "== Tier D: pack list vs Nexo.Hosting MSBuild closure =="
+python3 scripts/verify-pack-nexo-hosting-graph-alignment.py
+
+echo "== Tier D: pack local feed + StableSdkHostSample consumer (version ${VERSION}) =="
+bash scripts/verify-stable-sdk-host-sample-packages.sh
+
+echo ""
+echo "kernel-gate-tier-d: PASS"

--- a/scripts/kernel-gate-tier-e.sh
+++ b/scripts/kernel-gate-tier-e.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tier E kernel gate: observability, prod-shaped Compose dry run, performance-scoped tests.
+# Advisory for release; required before calling kernel "production-operable" on Linux hosts with Docker.
+# See docs/production-readiness/KernelHardeningPlan-v1.md and docs/prod-dry-run.md
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+ORCH="src/Nexo.Tests.Orchestration/Nexo.Tests.Orchestration.csproj"
+
+echo "== Tier E: OpenTelemetry registration =="
+dotnet build "$INFRA" -v minimal
+dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~OpenTelemetryTests" \
+  --blame-hang-timeout 60s --blame-hang-dump-type none
+
+echo "== Tier E: orchestration performance-scoped tests =="
+dotnet build "$ORCH" -v minimal
+dotnet test "$ORCH" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~Nexo.Tests.Orchestration.Performance" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  echo "== Tier E: production-shaped Compose dry run (portal) =="
+  # grpc.tools protoc can segfault on linux_arm64 during API image build; match mesh-lab CI default.
+  export DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"
+  bash scripts/prod-dry-run.sh --portal
+else
+  echo "== Tier E: prod-dry-run skipped (Docker not available) =="
+fi
+
+if [ -f ".env.mesh-lab" ] && command -v docker >/dev/null 2>&1; then
+  if [ "${KERNEL_GATE_CHAOS_LITE:-0}" = "1" ]; then
+    echo "== Tier E: chaos-lite (mesh network-negative; stack must be up) =="
+    make mesh-lab-up 2>/dev/null || true
+    bash scripts/mesh-lab-verify-network-negative.sh .env.mesh-lab || {
+      echo "chaos-lite: mesh-lab-verify-network-negative failed (is mesh lab up? run: make mesh-lab-e2e)" >&2
+      exit 1
+    }
+  else
+    echo "== Tier E: chaos-lite skipped (KERNEL_GATE_CHAOS_LITE=1 + mesh lab to enable) =="
+  fi
+else
+  echo "== Tier E: chaos-lite skipped (no .env.mesh-lab or Docker) =="
+fi
+
+echo ""
+echo "kernel-gate-tier-e: PASS"
+echo "Quarterly: complete docs/production-readiness/KernelChaosDrill-v1.md and record RPO/RTO."

--- a/scripts/nexo-ready-gate.sh
+++ b/scripts/nexo-ready-gate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Meta gate: kernel → application → composition/mesh → ship → ops (with Docker tiers skippable).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== Nexo ready gate (full stack) ==="
+
+if [ "${NEXO_READY_SKIP_KERNEL:-0}" != "1" ]; then
+  KERNEL_GATE_SKIP_TIER_E="${NEXO_READY_SKIP_DOCKER:-1}" \
+  KERNEL_GATE_SKIP_TIER_D="${NEXO_READY_SKIP_DOCKER:-0}" \
+  KERNEL_GATE_SKIP_TIER_C="${NEXO_READY_SKIP_DOCKER:-0}" \
+    make kernel-gate-full
+fi
+
+if [ "${NEXO_READY_SKIP_APPLICATION:-0}" != "1" ]; then
+  APPLICATION_GATE_SKIP_TIER_D="${NEXO_READY_SKIP_DOCKER:-1}" make application-gate-full
+fi
+
+if [ "${NEXO_READY_SKIP_COMPOSITION:-0}" != "1" ]; then
+  COMPOSITION_MESH_GATE_SKIP_TIER_D="${NEXO_READY_SKIP_DOCKER:-1}" make composition-mesh-gate-full
+fi
+
+if [ "${NEXO_READY_SKIP_SHIP:-0}" != "1" ]; then
+  SHIP_GATE_SKIP_PRIOR=1 make ship-gate-full
+fi
+
+if [ "${NEXO_READY_SKIP_OPS:-0}" != "1" ]; then
+  OPS_GATE_SKIP_PRIOR=1 \
+  OPS_GATE_SKIP_TIER_D="${NEXO_READY_SKIP_DOCKER:-1}" \
+    make ops-gate-full
+fi
+
+if [ "${NEXO_READY_SKIP_SECURITY:-0}" != "1" ]; then
+  SECURITY_GATE_SKIP_PRIOR=1 \
+  SECURITY_GATE_SKIP_TIER_E="${NEXO_READY_SKIP_DOCKER:-0}" \
+    make security-gate-full
+fi
+
+echo ""
+echo "nexo-ready-gate: PASS"

--- a/scripts/ops-gate-tier-a.sh
+++ b/scripts/ops-gate-tier-a.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Ops Tier A: dogfood blocks 1–6 (observe → analyze → adapt → improve → autonomy → self-context).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== Ops Tier A: dogfood phase C (blocks 1–6) =="
+make dogfood-phase-c
+
+echo ""
+echo "ops-gate-tier-a: PASS"

--- a/scripts/ops-gate-tier-b.sh
+++ b/scripts/ops-gate-tier-b.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ops Tier B: dogfood blocks 7–9 + local IPC mesh.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== Ops Tier B: dogfood phase D+E (blocks 7–9) =="
+make dogfood-phase-de
+make dogfood-block9-ipc
+
+echo ""
+echo "ops-gate-tier-b: PASS"

--- a/scripts/ops-gate-tier-c.sh
+++ b/scripts/ops-gate-tier-c.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Ops Tier C: closed-loop self-improvement on Nexo codebase.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== Ops Tier C: dogfood closed-loop =="
+make dogfood-closedloop
+
+if [ "${OPS_GATE_RUN_PHASE_F:-0}" = "1" ]; then
+  echo "== Ops Tier C: dogfood phase F =="
+  make dogfood-phasef
+fi
+
+echo ""
+echo "ops-gate-tier-c: PASS"

--- a/scripts/ops-gate-tier-d.sh
+++ b/scripts/ops-gate-tier-d.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Ops Tier D: mesh resilience (deep E2E or chaos-lite network-negative).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  echo "== Ops Tier D: skipped (Docker not available) =="
+  exit 0
+fi
+
+if [ "${OPS_GATE_MESH_DEEP:-0}" = "1" ]; then
+  echo "== Ops Tier D: mesh lab E2E deep (workers + checkpoint/migrate) =="
+  MESH_ENV="${OPS_GATE_MESH_ENV:-}"
+  if [ -z "$MESH_ENV" ] && [ -f ".env.mesh-lab" ]; then
+    MESH_ENV=".env.mesh-lab"
+  fi
+  if [ -n "$MESH_ENV" ]; then
+    MESH_LAB_E2E_WORKERS=1 MESH_LAB_VERIFY_DEEP=1 bash scripts/run-mesh-lab-e2e.sh "$MESH_ENV"
+  else
+    MESH_LAB_E2E_WORKERS=1 MESH_LAB_VERIFY_DEEP=1 bash scripts/run-mesh-lab-e2e.sh
+  fi
+elif [ "${OPS_GATE_CHAOS_LITE:-0}" = "1" ] && [ -f ".env.mesh-lab" ]; then
+  echo "== Ops Tier D: chaos-lite (network-negative on running lab) =="
+  make mesh-lab-up
+  ./scripts/mesh-lab-verify-network-negative.sh .env.mesh-lab
+  make mesh-lab-down
+else
+  echo "== Ops Tier D: skipped (OPS_GATE_MESH_DEEP=1 or OPS_GATE_CHAOS_LITE=1 + .env.mesh-lab) =="
+fi
+
+echo ""
+echo "ops-gate-tier-d: PASS"

--- a/scripts/ops-gate-tier-e.sh
+++ b/scripts/ops-gate-tier-e.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Ops Tier E: end-to-end "oh sh*t" demo (bootstrap, chat, orchestration, dogfood smoke).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== Ops Tier E: oh-shit demo (quick) =="
+bash scripts/oh-shit-demo.sh --quick --no-build
+
+echo ""
+echo "ops-gate-tier-e: PASS"

--- a/scripts/prod-dry-run.sh
+++ b/scripts/prod-dry-run.sh
@@ -39,6 +39,9 @@ done
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# grpc.tools protoc may segfault on linux_arm64; amd64 build is CI-default (QEMU on ARM Macs).
+export DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"
+
 export NEXO_REPO_ROOT="${NEXO_REPO_ROOT:-$REPO_ROOT}"
 
 PORT="${NEXO_AGENT_SERVER_HTTP_PORT:-8080}"

--- a/scripts/rc-gate-tier-a.sh
+++ b/scripts/rc-gate-tier-a.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# RC Tier A: full local readiness stack (nexo-ready-gate).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== RC Tier A: nexo-ready-gate (full stack) =="
+NEXO_READY_SKIP_DOCKER="${RC_GATE_SKIP_DOCKER:-1}" \
+  bash scripts/nexo-ready-gate.sh
+
+echo ""
+echo "rc-gate-tier-a: PASS"

--- a/scripts/rc-gate-tier-b.sh
+++ b/scripts/rc-gate-tier-b.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# RC Tier B: production-readiness mirror + release bundle (runtime gate + doctor).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI="application/src/Nexo.CLI/Nexo.CLI.csproj"
+
+echo "== RC Tier B: ship gate (prod readiness + ci verify + release preflight) =="
+SHIP_GATE_SKIP_PRIOR=1 make ship-gate-full
+
+echo "== RC Tier B: release bundle (quick + runtime gate) =="
+NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" -- ci release-bundle --profile quick
+
+if [ "${RC_GATE_RELEASE_BUNDLE_FULL:-0}" = "1" ]; then
+  echo "== RC Tier B: release bundle (full profile) =="
+  NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" -- ci release-bundle --profile full
+fi
+
+echo ""
+echo "rc-gate-tier-b: PASS"

--- a/scripts/rc-gate-tier-c.sh
+++ b/scripts/rc-gate-tier-c.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# RC Tier C: evidence audit (release bundle, security reports, rollback doc).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR=".nexo/rc-gate"
+mkdir -p "$REPORT_DIR"
+AUDIT="$REPORT_DIR/evidence-audit.txt"
+: >"$AUDIT"
+
+fail=0
+
+note() { echo "$1" | tee -a "$AUDIT"; }
+warn() { echo "::warning::$1" | tee -a "$AUDIT"; }
+
+echo "== RC Tier C: release bundle report =="
+BUNDLE_JSON=".nexo/release-bundle/last-run/release-bundle-report.json"
+if [ -f "$BUNDLE_JSON" ]; then
+  if grep -q '"Verdict": "PASS"' "$BUNDLE_JSON" || grep -q '"verdict": "PASS"' "$BUNDLE_JSON"; then
+    note "release-bundle: PASS ($BUNDLE_JSON)"
+  else
+    note "release-bundle: FAIL ($BUNDLE_JSON)"
+    fail=1
+  fi
+else
+  note "release-bundle: missing ($BUNDLE_JSON)"
+  fail=1
+fi
+
+echo "== RC Tier C: security supply-chain reports =="
+if [ -f ".nexo/security-gate/vulnerable-packages.txt" ]; then
+  if grep -qiE 'Severity:\s*(High|Critical)|critical|high severity' ".nexo/security-gate/vulnerable-packages.txt"; then
+    if [ "${RC_GATE_STRICT_SECURITY:-0}" = "1" ]; then
+      note "security: High/Critical CVEs detected (strict)"
+      fail=1
+    else
+      warn "security: High/Critical CVEs detected — review .nexo/security-gate/"
+    fi
+  else
+    note "security: no High/Critical in vulnerable-packages.txt"
+  fi
+else
+  warn "security: no vulnerable-packages report (run make security-gate-tier-d)"
+fi
+
+echo "== RC Tier C: runtime SLO evidence =="
+for slo in \
+  ".nexo/runtime/runtime-release-gate-slo.json" \
+  ".nexo/runtime/release-gate/last-run/evidence.json"; do
+  if [ -f "$slo" ]; then
+    note "runtime SLO artifact: present ($slo)"
+  else
+    warn "runtime SLO artifact: missing ($slo)"
+  fi
+done
+
+echo "== RC Tier C: rollback readiness doc =="
+ROLLBACK_CANDIDATES=(
+  "docs/production-readiness/ReleaseAndPromotion.md"
+  "docs/production-readiness/OperatorDeployment.md"
+  "docs/ReleaseCandidateChecklist-v1.md"
+)
+found=0
+for doc in "${ROLLBACK_CANDIDATES[@]}"; do
+  if [ -f "$doc" ] && grep -qi rollback "$doc"; then
+    note "rollback doc: $doc"
+    found=1
+  fi
+done
+if [ "$found" -eq 0 ]; then
+  warn "rollback: no rollback section found in standard docs"
+fi
+
+if [ "$fail" -ne 0 ] && [ "${RC_GATE_STRICT_EVIDENCE:-0}" = "1" ]; then
+  echo "rc-gate-tier-c: FAIL (see $AUDIT)" >&2
+  exit 1
+fi
+
+echo ""
+echo "rc-gate-tier-c: PASS"

--- a/scripts/rc-gate-tier-d.sh
+++ b/scripts/rc-gate-tier-d.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# RC Tier D: GitHub Actions RC workflows (verify latest green or dispatch fresh).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BRANCH="${RC_GATE_GH_BRANCH:-$(git branch --show-current)}"
+MAX_AGE_HOURS="${RC_GATE_GH_MAX_AGE_HOURS:-168}"
+REPORT_DIR=".nexo/rc-gate"
+mkdir -p "$REPORT_DIR"
+GH_REPORT="$REPORT_DIR/github-workflows.txt"
+: >"$GH_REPORT"
+
+WORKFLOWS=(
+  production-readiness-gate-v1
+  environment-setup-gate-v1
+  runtime-release-gate
+  installer-bruteforce-gate
+  container-image-gate
+  onboarding-docs-guard
+)
+
+OPTIONAL_WORKFLOWS=(
+  runtime-release-promotion
+)
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "== RC Tier D: skipped (gh CLI not installed) =="
+  exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "== RC Tier D: skipped (gh not authenticated) =="
+  exit 0
+fi
+
+age_ok() {
+  local created="$1"
+  python3 - <<PY "$created" "$MAX_AGE_HOURS"
+import sys
+from datetime import datetime, timezone, timedelta
+created = sys.argv[1]
+max_h = int(sys.argv[2])
+if not created:
+    sys.exit(1)
+ts = datetime.fromisoformat(created.replace("Z", "+00:00"))
+ok = datetime.now(timezone.utc) - ts <= timedelta(hours=max_h)
+sys.exit(0 if ok else 1)
+PY
+}
+
+verify_workflow() {
+  local wf="$1"
+  local required="${2:-1}"
+  local json
+  json="$(gh run list --workflow "$wf" --branch "$BRANCH" --limit 1 --json databaseId,conclusion,status,createdAt,url 2>/dev/null || true)"
+  if [ -z "$json" ] || [ "$json" = "[]" ]; then
+    echo "MISSING $wf (no runs on branch $BRANCH)" | tee -a "$GH_REPORT"
+    return 1
+  fi
+  local conclusion status created url
+  conclusion="$(echo "$json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('conclusion') or '')")"
+  status="$(echo "$json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('status') or '')")"
+  created="$(echo "$json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('createdAt') or '')")"
+  url="$(echo "$json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('url') or '')")"
+  if [ "$status" = "completed" ] && [ "$conclusion" = "success" ] && age_ok "$created"; then
+    echo "PASS $wf $url" | tee -a "$GH_REPORT"
+    return 0
+  fi
+  echo "FAIL $wf status=$status conclusion=$conclusion url=$url" | tee -a "$GH_REPORT"
+  if [ "$required" = "1" ] && [ "${RC_GATE_TRIGGER_GH:-0}" = "1" ]; then
+    echo "  dispatching $wf..." | tee -a "$GH_REPORT"
+    gh workflow run "$wf" --ref "$BRANCH" >/dev/null
+    local run_id
+    run_id="$(gh run list --workflow "$wf" --branch "$BRANCH" --limit 1 --json databaseId -q '.[0].databaseId')"
+    gh run watch "$run_id" --exit-status
+    echo "PASS $wf (after dispatch)" | tee -a "$GH_REPORT"
+    return 0
+  fi
+  return 1
+}
+
+echo "== RC Tier D: GitHub workflow verification (branch=$BRANCH) ==" | tee -a "$GH_REPORT"
+
+fail=0
+for wf in "${WORKFLOWS[@]}"; do
+  verify_workflow "$wf" 1 || fail=1
+done
+
+for wf in "${OPTIONAL_WORKFLOWS[@]}"; do
+  verify_workflow "$wf" 0 || echo "::warning::optional workflow not green: $wf" | tee -a "$GH_REPORT"
+done
+
+if [ "${RC_GATE_RUN_PUBLISH:-0}" = "1" ]; then
+  verify_workflow "container-image-publish" 1 || fail=1
+else
+  echo "SKIP container-image-publish (RC_GATE_RUN_PUBLISH=1 to require)" | tee -a "$GH_REPORT"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  if [ "${RC_GATE_GH_ADVISORY_ONLY:-0}" = "1" ]; then
+    echo "::warning::One or more GitHub workflows not green — see $GH_REPORT"
+    echo ""
+    echo "rc-gate-tier-d: PASS (advisory)"
+    exit 0
+  fi
+  echo "rc-gate-tier-d: FAIL (see $GH_REPORT)" >&2
+  exit 1
+fi
+
+echo ""
+echo "rc-gate-tier-d: PASS"

--- a/scripts/rc-gate-tier-e.sh
+++ b/scripts/rc-gate-tier-e.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# RC Tier E: exceptions policy, rollback drill record, release sign-off checklist.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR=".nexo/rc-gate"
+mkdir -p "$REPORT_DIR"
+AUDIT="$REPORT_DIR/policy-audit.txt"
+: >"$AUDIT"
+
+fail=0
+note() { echo "$1" | tee -a "$AUDIT"; }
+warn() { echo "::warning::$1" | tee -a "$AUDIT"; }
+
+EXCEPTIONS_FILE="${RC_EXCEPTIONS_FILE:-docs/exceptions.yaml}"
+
+echo "== RC Tier E: exceptions policy =="
+if [ ! -f "$EXCEPTIONS_FILE" ]; then
+  warn "exceptions: missing $EXCEPTIONS_FILE"
+  if [ "${RC_GATE_STRICT_EXCEPTIONS:-0}" = "1" ]; then
+    fail=1
+  fi
+else
+  python3 - "$EXCEPTIONS_FILE" <<'PY'
+import sys, datetime
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("exceptions: PyYAML not installed — skipping structured validation")
+    raise SystemExit(0)
+
+path = Path(sys.argv[1])
+data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+items = data.get("exceptions") or []
+today = datetime.date.today()
+blocked = []
+for item in items:
+    sev = str(item.get("severity", "")).lower()
+    if sev not in ("high", "critical"):
+        continue
+    missing = []
+    for field in ("owner", "expires", "mitigation", "sign_off"):
+        if not item.get(field):
+            missing.append(field)
+    exp = item.get("expires")
+    if exp:
+        try:
+            exp_date = datetime.date.fromisoformat(str(exp))
+            if exp_date < today:
+                blocked.append(f"{item.get('id', '?')}: expired {exp}")
+        except ValueError:
+            missing.append("expires(invalid)")
+    if missing:
+        blocked.append(f"{item.get('id', '?')}: missing {', '.join(missing)}")
+if blocked:
+    for b in blocked:
+        print(f"exceptions BLOCK: {b}")
+    raise SystemExit(1)
+print(f"exceptions: {len(items)} entries, High/Critical policy OK")
+PY
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ "${RC_GATE_STRICT_EXCEPTIONS:-0}" = "1" ]; then
+      fail=1
+    else
+      warn "exceptions: policy validation failed (non-strict)"
+    fi
+  else
+    note "exceptions: policy OK ($EXCEPTIONS_FILE)"
+  fi
+fi
+
+echo "== RC Tier E: rollback drill record =="
+DRILL_DOC="docs/production-readiness/RollbackDrill-v1.md"
+if [ -f "$DRILL_DOC" ] && grep -q "Last drill" "$DRILL_DOC"; then
+  note "rollback drill doc: present ($DRILL_DOC)"
+else
+  warn "rollback drill: update $DRILL_DOC with Last drill date and operator"
+fi
+
+echo "== RC Tier E: release sign-off =="
+SIGNOFF="docs/production-readiness/ReleaseSignOff-v1.md"
+if [ -f "$SIGNOFF" ]; then
+  if grep -q '\[x\].*Product' "$SIGNOFF" 2>/dev/null || grep -q '\[x\].*Engineering' "$SIGNOFF" 2>/dev/null; then
+    note "sign-off: checked items found"
+  else
+    warn "sign-off: template present but no [x] checkmarks — complete before tag"
+  fi
+else
+  warn "sign-off: missing $SIGNOFF"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "rc-gate-tier-e: FAIL (see $AUDIT)" >&2
+  exit 1
+fi
+
+echo ""
+echo "rc-gate-tier-e: PASS"

--- a/scripts/rc-gate.sh
+++ b/scripts/rc-gate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# RC gate: local readiness + release bundle + evidence + GitHub workflow verification.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== RC gate (release candidate) ==="
+
+if [ "${RC_GATE_SKIP_PRIOR:-1}" != "1" ]; then
+  bash scripts/rc-gate-tier-a.sh
+else
+  echo "== RC Tier A: skipped (RC_GATE_SKIP_PRIOR=1) =="
+fi
+
+bash scripts/rc-gate-tier-b.sh
+bash scripts/rc-gate-tier-c.sh
+bash scripts/rc-gate-tier-d.sh
+
+if [ "${RC_GATE_SKIP_TIER_E:-0}" != "1" ]; then
+  bash scripts/rc-gate-tier-e.sh
+fi
+
+echo ""
+echo "rc-gate: PASS"

--- a/scripts/security-gate-tier-a.sh
+++ b/scripts/security-gate-tier-a.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Security Tier A: trust core (policy packs, peer trust, audit log, access boundary).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Security Tier A: trust core (policy packs + peer trust + audit) =="
+dotnet build "$INFRA" -f net8.0 -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Trust|FullyQualifiedName~NexoPeerBrickExecutorTrustTests" \
+  --blame-hang-timeout 180s --blame-hang-dump-type none
+
+echo ""
+echo "security-gate-tier-a: PASS"

--- a/scripts/security-gate-tier-b.sh
+++ b/scripts/security-gate-tier-b.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Security Tier B: API auth + mesh security middleware + open-internet readiness.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Security Tier B: API security middleware =="
+dotnet build "$INFRA" -f net8.0 -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~NexoApiKeyAuthMiddlewareTests|FullyQualifiedName~MeshSecurityMiddlewareTests|FullyQualifiedName~NexoApiOpenInternetReadinessTests|FullyQualifiedName~SecurityAdvisoryEndpointTests|FullyQualifiedName~SecurityAnalysisRuleTests" \
+  --blame-hang-timeout 180s --blame-hang-dump-type none
+
+echo ""
+echo "security-gate-tier-b: PASS"

--- a/scripts/security-gate-tier-c.sh
+++ b/scripts/security-gate-tier-c.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Security Tier C: trust CLI surfaces (boundary + dashboard + audit JSON).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI="application/src/Nexo.CLI/Nexo.CLI.csproj"
+CLI_TESTS="application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj"
+
+echo "== Security Tier C: TrustCommand unit suite =="
+dotnet build "$CLI_TESTS" -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$CLI_TESTS" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~TrustCommandTests" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+echo "== Security Tier C: trust boundary + dashboard JSON smoke =="
+dotnet build "$CLI" -v minimal
+NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" --no-build -- trust boundary --format-json >/dev/null
+NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" --no-build -- trust dashboard --format-json >/dev/null
+
+echo ""
+echo "security-gate-tier-c: PASS"

--- a/scripts/security-gate-tier-d.sh
+++ b/scripts/security-gate-tier-d.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Security Tier D: supply-chain — vulnerable + deprecated package scan.
+# Scans application + key kernel projects (avoids Nexo.Core YamlDotNet registration bug on some NuGet clients).
+# Strict mode (SECURITY_GATE_STRICT_SUPPLY_CHAIN=1) fails on any vulnerable package or scan failure.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR=".nexo/security-gate"
+mkdir -p "$REPORT_DIR"
+VULN_REPORT="$REPORT_DIR/vulnerable-packages.txt"
+DEPRECATED_REPORT="$REPORT_DIR/deprecated-packages.txt"
+SCAN_FAIL=0
+VULN_FOUND=0
+
+scan_vulnerable() {
+  local target="$1"
+  echo "--- $target ---" | tee -a "$VULN_REPORT"
+  set +e
+  local out
+  out="$(dotnet list "$target" package --vulnerable --include-transitive 2>&1)"
+  local ec=$?
+  set -e
+  echo "$out" | tee -a "$VULN_REPORT"
+  if [ "$ec" -ne 0 ]; then
+    echo "::warning::vulnerable scan failed for $target (exit $ec)" >&2
+    SCAN_FAIL=1
+    return
+  fi
+  if echo "$out" | grep -qiE 'has the following vulnerable|Severity:'; then
+    VULN_FOUND=1
+  fi
+}
+
+scan_deprecated() {
+  local target="$1"
+  echo "--- $target ---" | tee -a "$DEPRECATED_REPORT"
+  set +e
+  local out
+  out="$(dotnet list "$target" package --deprecated 2>&1)"
+  local ec=$?
+  set -e
+  echo "$out" | tee -a "$DEPRECATED_REPORT"
+  if [ "$ec" -ne 0 ]; then
+    echo "::warning::deprecated scan failed for $target (exit $ec)" >&2
+    SCAN_FAIL=1
+  fi
+}
+
+: >"$VULN_REPORT"
+: >"$DEPRECATED_REPORT"
+
+echo "== Security Tier D: restore =="
+dotnet restore application/Nexo.Application.sln >/dev/null
+dotnet restore src/Nexo.Hosting/Nexo.Hosting.csproj >/dev/null
+dotnet restore src/Nexo.Infrastructure/Nexo.Infrastructure.csproj >/dev/null
+
+echo "== Security Tier D: dotnet list package --vulnerable =="
+scan_vulnerable application/Nexo.Application.sln
+scan_vulnerable src/Nexo.Hosting/Nexo.Hosting.csproj
+scan_vulnerable src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+
+echo "== Security Tier D: dotnet list package --deprecated =="
+scan_deprecated application/Nexo.Application.sln
+scan_deprecated src/Nexo.Hosting/Nexo.Hosting.csproj
+scan_deprecated src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+
+if [ "$VULN_FOUND" -eq 1 ]; then
+  if [ "${SECURITY_GATE_STRICT_SUPPLY_CHAIN:-0}" = "1" ]; then
+    echo "Vulnerable packages detected (SECURITY_GATE_STRICT_SUPPLY_CHAIN=1)" >&2
+    exit 1
+  else
+    echo "::warning::Vulnerable packages detected — see $VULN_REPORT (set SECURITY_GATE_STRICT_SUPPLY_CHAIN=1 to fail)"
+  fi
+fi
+
+if [ "$SCAN_FAIL" -eq 1 ] && [ "${SECURITY_GATE_STRICT_SUPPLY_CHAIN:-0}" = "1" ]; then
+  echo "One or more supply-chain scans failed (SECURITY_GATE_STRICT_SUPPLY_CHAIN=1)" >&2
+  exit 1
+fi
+
+if [ "$SCAN_FAIL" -eq 1 ]; then
+  echo "::warning::Some scans failed — see reports in $REPORT_DIR (Nexo.Core/YamlDotNet may need manual audit)"
+fi
+
+echo ""
+echo "security-gate-tier-d: PASS"

--- a/scripts/security-gate-tier-e.sh
+++ b/scripts/security-gate-tier-e.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Security Tier E: air-gapped no-network smoke (kernel/profile + safety probes).
+# Validates that core flows do not require network egress.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Security Tier E: air-gapped + safety in-process tests =="
+dotnet build "$INFRA" -f net8.0 -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~AirGapped|FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Safety" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+if [ "${SECURITY_GATE_AIRGAPPED_CONTAINER:-0}" = "1" ]; then
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    echo "== Security Tier E: --network none container suite =="
+    dotnet run --project application/src/Nexo.CLI/Nexo.CLI.csproj -- \
+      test multi-env --suite framework --env ubuntu-8.0 --no-network
+  else
+    echo "::warning::SECURITY_GATE_AIRGAPPED_CONTAINER=1 but Docker not available — skipping"
+  fi
+fi
+
+echo ""
+echo "security-gate-tier-e: PASS"

--- a/scripts/ship-gate-tier-a.sh
+++ b/scripts/ship-gate-tier-a.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Ship Tier A: Production Readiness Gate v1 (build + pipeline CLI + LiteDB resume).
+# Mirrors .github/workflows/production-readiness-gate-v1.yml operational steps.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI="application/src/Nexo.CLI/Nexo.CLI.csproj"
+INFRA_TESTS="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for JSON assertions in ship-gate-tier-a" >&2
+  exit 1
+fi
+
+echo "== Ship Tier A: build checks =="
+dotnet build src/Nexo.Core.Application/Nexo.Core.Application.csproj -f netstandard2.0 -v minimal
+dotnet build src/Nexo.Infrastructure/Nexo.Infrastructure.csproj -v minimal
+dotnet build "$CLI" -v minimal
+
+echo "== Ship Tier A: host DI smoke =="
+dotnet build "$INFRA_TESTS" -f net8.0 -v minimal
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA_TESTS" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~HostingE2ESmokeTests.AddNexo_RegistersObservationPipeline_ByDefault|FullyQualifiedName~PipelineServiceCollectionExtensionsTests.AddNexo_RegistersPipelineCompositionLayerByDefault" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+TMP="$(mktemp -d)"
+export TMP
+trap 'rm -rf "$TMP"' EXIT
+TEMPLATE_PATH="$TMP/pipeline_gate_demo.json"
+cat > "$TEMPLATE_PATH" <<'JSON'
+{
+  "templateId": "gate-demo",
+  "version": "1.0",
+  "stages": [
+    { "id": "ingest", "name": "Ingest", "mode": "Deterministic" },
+    { "id": "hybrid", "name": "Hybrid", "mode": "Hybrid", "fallbackChain": ["Deterministic", "Agentic"] }
+  ],
+  "edges": [
+    { "fromStageId": "ingest", "toStageId": "hybrid" }
+  ]
+}
+JSON
+
+echo "== Ship Tier A: CLI pipeline validate / run / fallback =="
+NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" --no-build -- \
+  pipeline validate --template "$TEMPLATE_PATH"
+
+SUCCESS_LOG="$TMP/gate-run-success.log"
+FALLBACK_LOG="$TMP/gate-run-fallback.log"
+NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" --no-build -- \
+  pipeline run --template "$TEMPLATE_PATH" --run-id gate-run-success --format-json | tee "$SUCCESS_LOG"
+NEXO_ALLOW_MOCK=1 NEXO_PIPELINE_ENABLE_TEST_HOOKS=1 NEXO_PIPELINE_COMPLETION_POLICY=AllowNonCriticalStageFailures \
+  dotnet run --project "$CLI" --no-build -- \
+  pipeline run --template "$TEMPLATE_PATH" --run-id gate-run-fallback --input "fail:hybrid:deterministic=true" --format-json | tee "$FALLBACK_LOG"
+NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" --no-build -- pipeline diagnostics --format-json >/dev/null
+
+python3 - <<PY
+import json, os, sys
+tmp = os.environ["TMP"]
+def parse_final_json(path):
+    with open(path, encoding="utf-8") as fh:
+        lines = [line.strip() for line in fh if line.strip()]
+    json_lines = [l for l in lines if l.startswith("{") and l.endswith("}")]
+    if not json_lines:
+        sys.exit(f"No JSON in {path}")
+    return json.loads(json_lines[-1])
+success = parse_final_json(os.path.join(tmp, "gate-run-success.log"))
+fallback = parse_final_json(os.path.join(tmp, "gate-run-fallback.log"))
+if not success.get("ok") or success.get("data", {}).get("state") != "Completed":
+    sys.exit("Success pipeline run did not complete")
+hybrid = next((s for s in fallback.get("data", {}).get("stages", []) if s.get("stageId") == "hybrid"), None)
+if hybrid is None or hybrid.get("workerType") != "Agentic":
+    sys.exit(f"Fallback did not use Agentic worker: {hybrid}")
+PY
+
+echo "== Ship Tier A: LiteDB cross-process resume =="
+RESUME_DB="$TMP/nexo_pipeline_gate_resume.db"
+RESUME_SOURCE_LOG="$TMP/gate-resume-source.log"
+RESUME_TARGET_LOG="$TMP/gate-resume-target.log"
+set +e
+NEXO_ALLOW_MOCK=1 NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH="$RESUME_DB" NEXO_PIPELINE_ENABLE_TEST_HOOKS=1 \
+  dotnet run --project "$CLI" --no-build -- \
+  pipeline run --template "$TEMPLATE_PATH" --run-id gate-resume-source --input "fail:ingest:deterministic=true" --format-json | tee "$RESUME_SOURCE_LOG"
+source_exit=$?
+set -e
+if [ "$source_exit" -eq 0 ]; then
+  echo "Expected source run to fail for resume scenario" >&2
+  exit 1
+fi
+NEXO_ALLOW_MOCK=1 NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH="$RESUME_DB" \
+  dotnet run --project "$CLI" --no-build -- \
+  pipeline run --template "$TEMPLATE_PATH" --run-id gate-resume-target --resume-run-id gate-resume-source --resume-failed-stages --format-json | tee "$RESUME_TARGET_LOG"
+
+python3 - <<PY
+import json, os, sys
+tmp = os.environ["TMP"]
+def parse_final_json(path):
+    with open(path, encoding="utf-8") as fh:
+        lines = [line.strip() for line in fh if line.strip()]
+    json_lines = [l for l in lines if l.startswith("{") and l.endswith("}")]
+    return json.loads(json_lines[-1])
+source = parse_final_json(os.path.join(tmp, "gate-resume-source.log"))
+target = parse_final_json(os.path.join(tmp, "gate-resume-target.log"))
+if source.get("data", {}).get("state") != "Failed":
+    sys.exit("Source run should be Failed")
+if not target.get("ok") or target.get("data", {}).get("state") != "Completed":
+    sys.exit("Resume target did not complete")
+PY
+
+echo ""
+echo "ship-gate-tier-a: PASS"

--- a/scripts/ship-gate-tier-b.sh
+++ b/scripts/ship-gate-tier-b.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Ship Tier B: ProdStyle slice + smoke + doctor (lightweight ci-verify stand-in).
+# Full `ci verify` + `nexo validate` run the entire test suite and are opt-in until FluentAssertions binding is fixed repo-wide.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI="application/src/Nexo.CLI/Nexo.CLI.csproj"
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Ship Tier B: build CLI + infrastructure tests =="
+dotnet build "$CLI" -v minimal
+dotnet build "$INFRA" -v minimal
+
+echo "== Ship Tier B: ProdStyle (FluentAssertions-safe filter) =="
+make test-prod-style
+
+echo "== Ship Tier B: framework smoke =="
+NEXO_ALLOW_MOCK=1 dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~BaseFrameworkSmokeTests" \
+  --blame-hang-timeout 60s --blame-hang-dump-type none
+
+echo "== Ship Tier B: doctor --json =="
+set +e
+NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" --no-build -- doctor --json
+doctor_exit=$?
+set -e
+if [ "$doctor_exit" -ne 0 ] && [ "${SHIP_GATE_STRICT_DOCTOR:-0}" = "1" ]; then
+  exit "$doctor_exit"
+fi
+
+if [ "${SHIP_GATE_RUN_CI_VERIFY:-0}" = "1" ]; then
+  echo "== Ship Tier B: full ci verify (opt-in) =="
+  NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" --no-build -- ci verify
+fi
+
+echo ""
+echo "ship-gate-tier-b: PASS"

--- a/scripts/ship-gate-tier-c.sh
+++ b/scripts/ship-gate-tier-c.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ship Tier C: release preflight (pack graph + NuGet consumer sample).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VERSION="${SHIP_GATE_VERSION:-0.0.0-ship-gate-local}"
+echo "== Ship Tier C: release preflight (${VERSION}) =="
+bash scripts/release-preflight-local.sh "$VERSION"
+
+echo ""
+echo "ship-gate-tier-c: PASS"

--- a/scripts/ship-gate-tier-d.sh
+++ b/scripts/ship-gate-tier-d.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Ship Tier D: release bundle or doctor-only (runtime gate is opt-in — can fail without full runtime bench data).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI="application/src/Nexo.CLI/Nexo.CLI.csproj"
+
+if [ "${SHIP_GATE_RUN_RUNTIME_GATE:-0}" = "1" ]; then
+  PROFILE="${SHIP_GATE_BUNDLE_PROFILE:-quick}"
+  echo "== Ship Tier D: ci release-bundle --profile ${PROFILE} =="
+  NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" -- ci release-bundle --profile "$PROFILE"
+else
+  echo "== Ship Tier D: release bundle skipped (SHIP_GATE_RUN_RUNTIME_GATE=1 to enable) =="
+  echo "== Ship Tier D: doctor sign-off =="
+  NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI" -- doctor --json >/dev/null
+fi
+
+echo ""
+echo "ship-gate-tier-d: PASS"

--- a/src/Nexo.Tests.Infrastructure/Tests/Hosting/KernelPhaseResolutionTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Hosting/KernelPhaseResolutionTests.cs
@@ -1,0 +1,192 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.Abstractions;
+using Nexo.Abstractions.Routing;
+using Nexo.BackgroundAgents.Registry;
+using Nexo.BackgroundAgents.Trust;
+using Nexo.Core.Application.Common.Ports;
+using Nexo.Core.Application.Common.Services;
+using Nexo.Core.Application.Configuration.Ports;
+using Nexo.Core.Application.Fleet.Ports;
+using Nexo.Core.Application.Knowledge.Ports;
+using Nexo.Core.Application.Observation.Ports;
+using Nexo.Core.Application.Pipelines.Models;
+using Nexo.Core.Application.Pipelines.Ports;
+using Nexo.Core.Application.Validation.Ports;
+using Nexo.Hosting;
+using Nexo.Infrastructure.Execution;
+using Nexo.Runtime.Routing;
+using Nexo.Tests.Infrastructure.Helpers;
+using Nexo.Transport.Grpc;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Hosting;
+
+/// <summary>
+/// Maps <see cref="NexoKernelRegistrar"/> phases to resolvable services per
+/// <see cref="NexoDeploymentProfile"/>. See docs/architecture/KernelPhaseMatrix.md.
+/// </summary>
+[Trait("Category", "ProdStyle")]
+[Trait("Category", "E2E")]
+[Collection("EnvironmentVariables")]
+public sealed class KernelPhaseResolutionTests
+{
+    public static TheoryData<NexoDeploymentProfile, KernelProfileExpectations> ProfileMatrix =>
+        new()
+        {
+            { NexoDeploymentProfile.Full, KernelProfileExpectations.Full },
+            { NexoDeploymentProfile.Server, KernelProfileExpectations.Full },
+            { NexoDeploymentProfile.Edge, KernelProfileExpectations.Edge },
+            { NexoDeploymentProfile.AirGapped, KernelProfileExpectations.AirGapped },
+            { NexoDeploymentProfile.System, KernelProfileExpectations.System },
+        };
+
+    [Theory(Timeout = TestTimeouts.E2E)]
+    [MemberData(nameof(ProfileMatrix))]
+    public async Task Profile_ResolvesExpectedKernelServices(
+        NexoDeploymentProfile profile,
+        KernelProfileExpectations expected)
+    {
+        await Task.CompletedTask;
+        var sp = BuildProvider(profile);
+
+        AssertPresence(sp, expected.LoopKernel, sp => sp.GetService<ILoopKernel>());
+        AssertPresence(sp, expected.ConfigurationService, sp => sp.GetService<IConfigurationService>());
+        AssertPresence(sp, expected.Model, sp => sp.GetService<IModel>());
+        AssertPresence(sp, expected.ProviderFactory, sp => sp.GetService<IProviderFactory>());
+        AssertPresence(sp, expected.PipelineValidator, sp => sp.GetService<IPipelineTemplateValidator>());
+        AssertPresence(sp, expected.PatternStore, sp => sp.GetService<IPatternStore>());
+        AssertPresence(sp, expected.BackgroundAgents, sp => sp.GetService<IBackgroundAgentRegistry>());
+        AssertPresence(sp, expected.GrpcChannelFactory, sp => sp.GetService<IGrpcChannelFactory>());
+        AssertPresence(sp, expected.FleetRegistry, sp => sp.GetService<IFleetNodeRegistry>());
+        AssertPresence(sp, expected.CloudSanitization, sp => sp.GetService<ICloudSanitizationProxy>());
+
+        if (expected.EndpointRegistryNotInMemory)
+        {
+            sp.GetRequiredService<IEndpointRegistry>().Should().NotBeOfType<InMemoryEndpointRegistry>();
+        }
+    }
+
+    [Fact(Timeout = TestTimeouts.E2E)]
+    public async Task FullProfile_LoopKernel_IsSequentialByDefault()
+    {
+        await Task.CompletedTask;
+        var sp = BuildProvider(NexoDeploymentProfile.Full);
+        var loop = sp.GetRequiredService<ILoopKernel>();
+        loop.Should().BeOfType<SequentialLoopKernel>();
+    }
+
+    [Fact(Timeout = TestTimeouts.E2E)]
+    public async Task EdgeProfile_ValidatesMinimalPipelineTemplate()
+    {
+        await Task.CompletedTask;
+        var sp = BuildProvider(NexoDeploymentProfile.Edge);
+        var validator = sp.GetRequiredService<IPipelineTemplateValidator>();
+        var result = validator.Validate(new PipelineTemplate
+        {
+            TemplateId = "kernel-gate-edge",
+            Version = "1.0",
+            Stages = new[]
+            {
+                new PipelineStageDefinition { Id = "a", Name = "A", Mode = PipelineExecutionMode.Deterministic },
+            },
+        });
+
+        result.IsValid.Should().BeTrue(
+            result.Errors is { Count: > 0 } errors ? string.Join("; ", errors) : "validation failed");
+    }
+
+    [Fact(Timeout = TestTimeouts.E2E)]
+    public async Task FullProfile_ResolvesKnowledgeQuery_whenObservationEnabled()
+    {
+        await Task.CompletedTask;
+        var sp = BuildProvider(NexoDeploymentProfile.Full);
+        sp.GetRequiredService<IKnowledgeQueryService>().Should().NotBeNull();
+    }
+
+    private static ServiceProvider BuildProvider(NexoDeploymentProfile profile)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNexoProfile(profile);
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    private static void AssertPresence<T>(ServiceProvider sp, bool expected, Func<ServiceProvider, T?> resolve)
+        where T : class
+    {
+        if (!expected)
+        {
+            resolve(sp).Should().BeNull(typeof(T).Name);
+            return;
+        }
+
+        resolve(sp).Should().NotBeNull(typeof(T).Name);
+    }
+
+    public sealed record KernelProfileExpectations(
+        bool LoopKernel,
+        bool ConfigurationService,
+        bool Model,
+        bool ProviderFactory,
+        bool PipelineValidator,
+        bool PatternStore,
+        bool BackgroundAgents,
+        bool GrpcChannelFactory,
+        bool FleetRegistry,
+        bool CloudSanitization,
+        bool EndpointRegistryNotInMemory)
+    {
+        public static KernelProfileExpectations Full { get; } = new(
+            LoopKernel: true,
+            ConfigurationService: true,
+            Model: true,
+            ProviderFactory: true,
+            PipelineValidator: true,
+            PatternStore: true,
+            BackgroundAgents: true,
+            GrpcChannelFactory: true,
+            FleetRegistry: true,
+            CloudSanitization: true,
+            EndpointRegistryNotInMemory: false);
+
+        public static KernelProfileExpectations Edge { get; } = new(
+            LoopKernel: true,
+            ConfigurationService: true,
+            Model: true,
+            ProviderFactory: true,
+            PipelineValidator: true,
+            PatternStore: false,
+            BackgroundAgents: false,
+            GrpcChannelFactory: false,
+            FleetRegistry: true,
+            CloudSanitization: false,
+            EndpointRegistryNotInMemory: true);
+
+        public static KernelProfileExpectations AirGapped { get; } = new(
+            LoopKernel: true,
+            ConfigurationService: true,
+            Model: true,
+            ProviderFactory: true,
+            PipelineValidator: true,
+            PatternStore: false,
+            BackgroundAgents: false,
+            GrpcChannelFactory: false,
+            FleetRegistry: true,
+            CloudSanitization: false,
+            EndpointRegistryNotInMemory: true);
+
+        public static KernelProfileExpectations System { get; } = new(
+            LoopKernel: true,
+            ConfigurationService: true,
+            Model: true,
+            ProviderFactory: true,
+            PipelineValidator: false,
+            PatternStore: false,
+            BackgroundAgents: false,
+            GrpcChannelFactory: false,
+            FleetRegistry: true,
+            CloudSanitization: false,
+            EndpointRegistryNotInMemory: true);
+    }
+}


### PR DESCRIPTION
## Summary
- Tiered shell gates from kernel through RC with Makefile targets and GitHub workflows
- Production-readiness docs, `nexo-ready-gate`, and kernel phase resolution tests
- RC gate: release bundle evidence, GitHub workflow verification, policy tier E scaffold

## Test plan
- [ ] `make rc-gate-full` with `RC_GATE_GH_ADVISORY_ONLY=1` locally
- [ ] `make nexo-ready-gate` with `NEXO_READY_SKIP_DOCKER=1`
- [ ] Verify `rc-gate` workflow runs on push

**Stacked:** PR #2 targets this branch for waterproofing gates.

Made with [Cursor](https://cursor.com)