### PR TITLE
Add post-RC waterproofing gates (perf, compat, DR)

### DIFF
--- a/.github/workflows/compat-gate.yml
+++ b/.github/workflows/compat-gate.yml
@@ -1,0 +1,22 @@
+name: compat-gate
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/compat-gate*.sh'
+      - 'scripts/kernel-gate-tier-b.sh'
+
+jobs:
+  compat-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+      - name: Run compat gate
+        run: COMPAT_GATE_SKIP_PRIOR=1 bash scripts/compat-gate.sh

--- a/.github/workflows/dr-gate.yml
+++ b/.github/workflows/dr-gate.yml
@@ -1,0 +1,26 @@
+name: dr-gate
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/dr-gate*.sh'
+
+jobs:
+  dr-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+      - name: Run DR gate
+        run: DR_GATE_SKIP_PRIOR=1 bash scripts/dr-gate.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: dr-gate-${{ github.run_id }}
+          path: .nexo/dr-gate/

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -1,0 +1,28 @@
+name: perf-gate
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/perf-gate*.sh'
+      - 'src/Nexo.Tests.Orchestration/**'
+      - 'src/Nexo.Tests.BackgroundAgents/**'
+
+jobs:
+  perf-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+      - name: Run perf gate
+        run: PERF_GATE_SKIP_PRIOR=1 bash scripts/perf-gate.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: perf-gate-${{ github.run_id }}
+          path: .nexo/perf/

--- a/.github/workflows/waterproofing-gate.yml
+++ b/.github/workflows/waterproofing-gate.yml
@@ -1,0 +1,26 @@
+name: waterproofing-gate
+
+on:
+  workflow_dispatch:
+
+jobs:
+  waterproofing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
+      - name: Run waterproofing gate
+        run: bash scripts/waterproofing-gate.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: waterproofing-gate-${{ github.run_id }}
+          path: |
+            .nexo/perf/
+            .nexo/compat/
+            .nexo/dr-gate/
+            .nexo/rc-gate/

--- a/docs/exceptions.yaml
+++ b/docs/exceptions.yaml
@@ -1,0 +1,4 @@
+# High/Critical vulnerability or policy exceptions.
+# Each entry MUST include: owner, expires (YYYY-MM-DD), mitigation, sign_off.
+# RC gate tier E validates this file when RC_GATE_STRICT_EXCEPTIONS=1.
+exceptions: []

--- a/docs/production-readiness/CompatHardeningPlan-v1.md
+++ b/docs/production-readiness/CompatHardeningPlan-v1.md
@@ -1,0 +1,23 @@
+# Compatibility hardening plan v1
+
+Validates **schema/migration contracts**, **CLI durability across processes**, and **configuration/doctor** surfaces.
+
+**Automation:** `make compat-gate-full`
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Mesh checkpoint migration, LiteDB registration, composition validation | `make compat-gate-tier-a` |
+| B | Cross-process LiteDB pipeline resume (kernel Tier B) | `make compat-gate-tier-b` |
+| C | Configuration binding + kernel phases + doctor smoke | `make compat-gate-tier-c` |
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `COMPAT_GATE_SKIP_PRIOR=1` | Skip perf gate (default in `compat-gate-full`) |
+
+## Related
+
+- [Compat readiness v1](CompatReadiness-v1.md)

--- a/docs/production-readiness/CompatReadiness-v1.md
+++ b/docs/production-readiness/CompatReadiness-v1.md
@@ -1,0 +1,9 @@
+# Compatibility readiness v1
+
+```bash
+make compat-gate-full
+```
+
+Artifacts: `.nexo/compat/`
+
+**Next:** [DR hardening plan v1](DRHardeningPlan-v1.md)

--- a/docs/production-readiness/DRHardeningPlan-v1.md
+++ b/docs/production-readiness/DRHardeningPlan-v1.md
@@ -1,0 +1,25 @@
+# Disaster recovery hardening plan v1
+
+Backup → wipe → restore for **pipeline LiteDB**, **user knowledge log**, and optional **mesh director** persistence.
+
+**Automation:** `make dr-gate-full`
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Pipeline LiteDB backup/restore + resume | `make dr-gate-tier-a` |
+| B | User knowledge LiteDB tests | `make dr-gate-tier-b` |
+| C | Mesh director restart (`.env.mesh-lab`) or advisory skip | `make dr-gate-tier-c` |
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `DR_GATE_SKIP_PRIOR=1` | Skip compat gate (default) |
+| `DR_GATE_SKIP_MESH=1` | Skip mesh persistence even if lab is up |
+
+## Related
+
+- [DR readiness v1](DRReadiness-v1.md)
+- [Rollback drill v1](RollbackDrill-v1.md)

--- a/docs/production-readiness/DRReadiness-v1.md
+++ b/docs/production-readiness/DRReadiness-v1.md
@@ -1,0 +1,9 @@
+# Disaster recovery readiness v1
+
+```bash
+make dr-gate-full
+```
+
+Artifacts: `.nexo/dr-gate/`
+
+**Next:** RC policy tier — `make rc-gate-tier-e` or `make waterproofing-gate-full`

--- a/docs/production-readiness/PerfHardeningPlan-v1.md
+++ b/docs/production-readiness/PerfHardeningPlan-v1.md
@@ -1,0 +1,29 @@
+# Performance hardening plan v1
+
+Regression backstop after **RC gate** — latency/throughput baselines before tag.
+
+**Automation:** `make perf-gate-full`
+
+## Tiers
+
+| Tier | Focus | Command |
+|------|--------|---------|
+| A | Orchestration + background-agent perf tests | `make perf-gate-tier-a` |
+| B | Pipeline throughput (mocked) | `make perf-gate-tier-b` |
+| C | CLI cold-start (`--help`) | `make perf-gate-tier-c` |
+| D | Mini-soak (default) or long soak | `make perf-gate-tier-d` |
+
+## Flags
+
+| Variable | Effect |
+|----------|--------|
+| `PERF_GATE_SKIP_PRIOR=1` | Skip RC prerequisite (default in `perf-gate-full`) |
+| `PERF_GATE_SKIP_TIER_D=1` | Skip soak tier |
+| `PERF_GATE_SOAK_MINUTES=30` | Tier D: run 30-minute soak |
+| `PERF_GATE_STRICT_BASELINE=1` | Fail on regression vs `.nexo/perf/baseline.json` |
+| `PERF_GATE_UPDATE_BASELINE=1` | Refresh baseline after run |
+
+## Related
+
+- `.github/workflows/perf-certification.yml`
+- [Perf readiness v1](PerfReadiness-v1.md)

--- a/docs/production-readiness/PerfReadiness-v1.md
+++ b/docs/production-readiness/PerfReadiness-v1.md
@@ -1,0 +1,9 @@
+# Performance readiness v1
+
+```bash
+make perf-gate-full
+```
+
+Artifacts: `.nexo/perf/` (`baseline.json`, `last-run.json`, throughput/cold-start/soak reports).
+
+**Next:** [Compat hardening plan v1](CompatHardeningPlan-v1.md)

--- a/docs/production-readiness/ReleaseSignOff-v1.md
+++ b/docs/production-readiness/ReleaseSignOff-v1.md
@@ -1,0 +1,19 @@
+# Release sign-off v1
+
+Complete before tagging a release candidate.
+
+## Checklist
+
+- [ ] Product: scope and known limitations accepted
+- [ ] Engineering: all automated gates green for target SHA
+- [ ] Security: exceptions file reviewed (`docs/exceptions.yaml`)
+- [ ] Operations: rollback drill recorded ([Rollback drill v1](RollbackDrill-v1.md))
+
+## Sign-off record
+
+| Role | Name | Date | SHA |
+|------|------|------|-----|
+| Product | | | |
+| Engineering | | | |
+| Security | | | |
+| Operations | | | |

--- a/docs/production-readiness/RollbackDrill-v1.md
+++ b/docs/production-readiness/RollbackDrill-v1.md
@@ -1,0 +1,27 @@
+# Rollback drill v1
+
+## Procedure
+
+1. Record current deploy: image tag/digest or package version, git SHA.
+2. Deploy previous known-good artifact to staging (or local mesh-lab stack).
+3. Run smoke: `dotnet run --project application/src/Nexo.CLI -- doctor`, pipeline validate, API `/health`.
+4. If stateful: restore LiteDB/volume from backup taken before step 1.
+5. Document elapsed time and data loss window.
+
+## Last drill
+
+| Field | Value |
+|-------|-------|
+| Date | _not yet recorded_ |
+| Operator | |
+| Environment | staging / mesh-lab / local |
+| From version | |
+| To version | |
+| RPO observed | |
+| RTO observed | |
+| Result | |
+
+## References
+
+- [Release and promotion](ReleaseAndPromotion.md)
+- `make dr-gate-full`

--- a/scripts/compat-gate-tier-a.sh
+++ b/scripts/compat-gate-tier-a.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Compat Tier A: schema / migration / composition compatibility tests.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== Compat Tier A: mesh checkpoint migration =="
+dotnet build "$INFRA" -v minimal
+dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~MeshTaskExecutionServiceTests.MigrateForCheckpointAsync" \
+  --blame-hang-timeout 60s --blame-hang-dump-type none
+
+echo "== Compat Tier A: LiteDB persistence registration =="
+dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~PipelineServiceCollectionExtensionsTests.AddPipelineCompositionLayer_WithLiteDbPersistence" \
+  --blame-hang-timeout 60s --blame-hang-dump-type none
+
+echo "== Compat Tier A: composition registry validation =="
+dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~CompositionRegistryValidationTests" \
+  --blame-hang-timeout 60s --blame-hang-dump-type none
+
+echo ""
+echo "compat-gate-tier-a: PASS"

--- a/scripts/compat-gate-tier-b.sh
+++ b/scripts/compat-gate-tier-b.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Compat Tier B: cross-version CLI durability (LiteDB resume across processes).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Reuse kernel Tier B resume scenario (same CLI + store contract).
+bash scripts/kernel-gate-tier-b.sh | tee /tmp/compat-gate-tier-b.log
+
+REPORT_DIR=".nexo/compat"
+mkdir -p "$REPORT_DIR"
+cp /tmp/compat-gate-tier-b.log "$REPORT_DIR/cli-resume.log" 2>/dev/null || true
+
+echo ""
+echo "compat-gate-tier-b: PASS"

--- a/scripts/compat-gate-tier-c.sh
+++ b/scripts/compat-gate-tier-c.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Compat Tier C: configuration binding + doctor smoke.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+CLI="application/src/Nexo.CLI/Nexo.CLI.csproj"
+
+echo "== Compat Tier C: configuration override tests =="
+dotnet build "$INFRA" -v minimal
+dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~PipelineServiceCollectionExtensionsTests.AddPipelineCompositionLayer_WithConfiguration" \
+  --blame-hang-timeout 60s --blame-hang-dump-type none
+
+echo "== Compat Tier C: hosting profile resolution =="
+dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~KernelPhaseResolutionTests" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+echo "== Compat Tier C: doctor smoke =="
+dotnet build "$CLI" -v minimal >/dev/null
+OUT=$(dotnet run --project "$CLI" --no-build -- doctor --json 2>&1)
+echo "$OUT" | python3 -c '
+import json, sys
+text = sys.stdin.read()
+start = text.find("{")
+if start < 0:
+    if "overall: PASS" in text:
+        print("doctor smoke: PASS (text report)")
+        raise SystemExit(0)
+    raise SystemExit("doctor: no JSON output")
+doc = json.loads(text[start:])
+if not doc.get("ok", False):
+    raise SystemExit(f"doctor failed: {doc}")
+print("doctor smoke: PASS")
+'
+
+REPORT_DIR=".nexo/compat"
+mkdir -p "$REPORT_DIR"
+echo "$OUT" >"$REPORT_DIR/doctor.json"
+
+echo ""
+echo "compat-gate-tier-c: PASS"

--- a/scripts/compat-gate.sh
+++ b/scripts/compat-gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== Compat gate ==="
+
+if [ "${COMPAT_GATE_SKIP_PRIOR:-1}" != "1" ]; then
+  PERF_GATE_SKIP_PRIOR=1 bash scripts/perf-gate.sh
+fi
+
+bash scripts/compat-gate-tier-a.sh
+bash scripts/compat-gate-tier-b.sh
+bash scripts/compat-gate-tier-c.sh
+
+echo ""
+echo "compat-gate: PASS"

--- a/scripts/dr-gate-tier-a.sh
+++ b/scripts/dr-gate-tier-a.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# DR Tier A: LiteDB pipeline store backup → wipe → restore → resume.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI_PROJECT="application/src/Nexo.CLI/Nexo.CLI.csproj"
+TMP_ROOT="${TMPDIR:-/tmp}/nexo-dr-gate-$$"
+mkdir -p "$TMP_ROOT"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+DB="$TMP_ROOT/pipeline_dr.db"
+BACKUP="$TMP_ROOT/pipeline_dr.backup.db"
+TEMPLATE="$TMP_ROOT/pipeline_dr.json"
+
+cat >"$TEMPLATE" <<'JSON'
+{
+  "templateId": "dr-gate",
+  "version": "1.0",
+  "stages": [
+    { "id": "ingest", "name": "Ingest", "mode": "Deterministic" },
+    { "id": "hybrid", "name": "Hybrid", "mode": "Hybrid", "fallbackChain": ["Deterministic", "Agentic"] }
+  ],
+  "edges": [{ "fromStageId": "ingest", "toStageId": "hybrid" }]
+}
+JSON
+
+dotnet build "$CLI_PROJECT" -v minimal >/dev/null
+
+echo "== DR Tier A: seed failed run in LiteDB =="
+rm -f "$DB" "$BACKUP"
+set +e
+NEXO_ALLOW_MOCK=1 NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH="$DB" NEXO_PIPELINE_ENABLE_TEST_HOOKS=1 \
+  dotnet run --project "$CLI_PROJECT" --no-build -- pipeline run --template "$TEMPLATE" \
+  --run-id dr-source --input "fail:ingest:deterministic=true" --format-json >/dev/null
+set -e
+
+if [ ! -f "$DB" ]; then
+  echo "DR Tier A: LiteDB file not created" >&2
+  exit 1
+fi
+
+cp "$DB" "$BACKUP"
+rm -f "$DB"
+
+echo "== DR Tier A: restore backup and resume =="
+cp "$BACKUP" "$DB"
+NEXO_ALLOW_MOCK=1 NEXO_PIPELINE_STORE_PROVIDER=LiteDb NEXO_PIPELINE_STORE_PATH="$DB" \
+  dotnet run --project "$CLI_PROJECT" --no-build -- pipeline run --template "$TEMPLATE" \
+  --run-id dr-target --resume-run-id dr-source --resume-failed-stages --format-json \
+  >"$TMP_ROOT/dr-resume.json"
+
+python3 - <<PY
+import json
+with open("$TMP_ROOT/dr-resume.json", encoding="utf-8") as fh:
+    lines = [l.strip() for l in fh if l.strip().startswith("{")]
+payload = json.loads(lines[-1])
+if not payload.get("ok") or payload.get("data", {}).get("state") != "Completed":
+    raise SystemExit(f"resume after restore failed: {payload}")
+print("pipeline DR restore+resume: PASS")
+PY
+
+REPORT_DIR=".nexo/dr-gate"
+mkdir -p "$REPORT_DIR"
+cat >"$REPORT_DIR/pipeline-restore.json" <<EOF
+{"ok": true, "store": "LiteDb", "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+EOF
+
+echo ""
+echo "dr-gate-tier-a: PASS"

--- a/scripts/dr-gate-tier-b.sh
+++ b/scripts/dr-gate-tier-b.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# DR Tier B: user knowledge log store durability tests.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INFRA="src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj"
+
+echo "== DR Tier B: LiteDB user knowledge log store =="
+dotnet build "$INFRA" -v minimal
+dotnet test "$INFRA" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~LiteDbUserKnowledgeLogStoreTests" \
+  --blame-hang-timeout 60s --blame-hang-dump-type none
+
+REPORT_DIR=".nexo/dr-gate"
+mkdir -p "$REPORT_DIR"
+echo '{"ok": true, "component": "user-knowledge-log", "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' \
+  >"$REPORT_DIR/knowledge-store.json"
+
+echo ""
+echo "dr-gate-tier-b: PASS"

--- a/scripts/dr-gate-tier-c.sh
+++ b/scripts/dr-gate-tier-c.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# DR Tier C: mesh director persistence (Docker mesh-lab) or file-level LiteDB copy check.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR=".nexo/dr-gate"
+mkdir -p "$REPORT_DIR"
+
+if [ -f ".env.mesh-lab" ] && command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  if [ "${DR_GATE_SKIP_MESH:-0}" = "1" ]; then
+    echo "== DR Tier C: mesh persistence skipped (DR_GATE_SKIP_MESH=1) =="
+  else
+    echo "== DR Tier C: mesh director persistence (restart peer-a) =="
+    make mesh-lab-up 2>/dev/null || true
+    PEER_HOST="${MESH_LAB_PEER_A_HOST:-127.0.0.1:18081}"
+    echo "waiting for peer-a health at http://${PEER_HOST}/health ..."
+    for i in $(seq 1 120); do
+      if curl -fsS -m 3 "http://${PEER_HOST}/health" >/dev/null 2>&1; then
+        break
+      fi
+      if [ "$i" -eq 120 ]; then
+        echo "peer-a not healthy after mesh-lab-up" >&2
+        exit 1
+      fi
+      sleep 2
+    done
+    bash scripts/mesh-lab-verify-persistence.sh .env.mesh-lab | tee "$REPORT_DIR/mesh-persistence.log"
+    echo '{"ok": true, "component": "mesh-director", "verified": "restart"}' >"$REPORT_DIR/mesh-persistence.json"
+    echo ""
+    echo "dr-gate-tier-c: PASS"
+    exit 0
+  fi
+fi
+
+echo "== DR Tier C: advisory — mesh lab not available; file-copy LiteDB sanity =="
+TMP="${TMPDIR:-/tmp}/nexo-dr-tier-c-$$"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+FAKE="$TMP/fake.litedb"
+echo "nexo-dr-placeholder" >"$FAKE"
+cp "$FAKE" "$TMP/backup.litedb"
+rm -f "$FAKE"
+cp "$TMP/backup.litedb" "$FAKE"
+test -f "$FAKE"
+
+echo '{"ok": true, "component": "mesh-director", "verified": "skipped-advisory"}' >"$REPORT_DIR/mesh-persistence.json"
+echo "::warning::mesh DR: run with .env.mesh-lab + Docker for full director persistence verify"
+
+echo ""
+echo "dr-gate-tier-c: PASS (advisory)"

--- a/scripts/dr-gate.sh
+++ b/scripts/dr-gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== DR gate ==="
+
+if [ "${DR_GATE_SKIP_PRIOR:-1}" != "1" ]; then
+  COMPAT_GATE_SKIP_PRIOR=1 bash scripts/compat-gate.sh
+fi
+
+bash scripts/dr-gate-tier-a.sh
+bash scripts/dr-gate-tier-b.sh
+bash scripts/dr-gate-tier-c.sh
+
+echo ""
+echo "dr-gate: PASS"

--- a/scripts/perf-gate-baseline.sh
+++ b/scripts/perf-gate-baseline.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Record/compare perf metrics under .nexo/perf/baseline.json
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR=".nexo/perf"
+BASELINE="$REPORT_DIR/baseline.json"
+LAST="$REPORT_DIR/last-run.json"
+mkdir -p "$REPORT_DIR"
+
+python3 - <<'PY'
+import json, os, glob
+from datetime import datetime, timezone
+
+report_dir = ".nexo/perf"
+metrics = {"timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), "metrics": {}}
+
+for name in ("pipeline-throughput.json", "cold-start.json", "soak.json"):
+    path = os.path.join(report_dir, name)
+    if os.path.isfile(path):
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        key = name.replace(".json", "").replace("-", "_")
+        if "totalMs" in data:
+            metrics["metrics"][f"{key}_total_ms"] = data["totalMs"]
+            metrics["metrics"][f"{key}_avg_ms"] = data.get("avgMsPerRun", data["totalMs"])
+        if "elapsedMs" in data:
+            metrics["metrics"][f"{key}_ms"] = data["elapsedMs"]
+        if "runs" in data and "failures" in data:
+            metrics["metrics"][f"{key}_failures"] = data["failures"]
+
+# TRX pass counts
+for trx in glob.glob(os.path.join(report_dir, "perf-*.trx")):
+    try:
+        with open(trx, encoding="utf-8", errors="ignore") as fh:
+            content = fh.read()
+        passed = content.count('outcome="Passed"')
+        failed = content.count('outcome="Failed"')
+        metrics["metrics"][os.path.basename(trx) + "_passed"] = passed
+        metrics["metrics"][os.path.basename(trx) + "_failed"] = failed
+    except OSError:
+        pass
+
+with open(os.path.join(report_dir, "last-run.json"), "w", encoding="utf-8") as fh:
+    json.dump(metrics, fh, indent=2)
+
+baseline_path = os.path.join(report_dir, "baseline.json")
+update = os.environ.get("PERF_GATE_UPDATE_BASELINE", "0") == "1"
+regression_pct = float(os.environ.get("PERF_GATE_REGRESSION_PCT", "25"))
+
+if not os.path.isfile(baseline_path):
+    if update or os.environ.get("PERF_GATE_INIT_BASELINE", "1") == "1":
+        with open(baseline_path, "w", encoding="utf-8") as fh:
+            json.dump(metrics, fh, indent=2)
+        print(f"perf baseline: initialized {baseline_path}")
+    else:
+        print("perf baseline: no baseline.json (set PERF_GATE_UPDATE_BASELINE=1)")
+    raise SystemExit(0)
+
+with open(baseline_path, encoding="utf-8") as fh:
+    baseline = json.load(fh)
+
+failures = []
+for key, value in metrics["metrics"].items():
+    if not key.endswith("_ms") and not key.endswith("_total_ms") and not key.endswith("_avg_ms"):
+        continue
+    if key not in baseline.get("metrics", {}):
+        continue
+    base = baseline["metrics"][key]
+    if base <= 0:
+        continue
+    delta_pct = ((value - base) / base) * 100.0
+    if delta_pct > regression_pct:
+        failures.append(f"{key}: {value} vs baseline {base} (+{delta_pct:.1f}%)")
+
+if failures and os.environ.get("PERF_GATE_STRICT_BASELINE", "0") == "1":
+    for f in failures:
+        print(f"perf regression: {f}")
+    raise SystemExit(1)
+
+for f in failures:
+    print(f"::warning::perf regression (advisory): {f}")
+
+if update:
+    with open(baseline_path, "w", encoding="utf-8") as fh:
+        json.dump(metrics, fh, indent=2)
+    print(f"perf baseline: updated {baseline_path}")
+
+print("perf-gate-baseline: PASS")
+PY

--- a/scripts/perf-gate-tier-a.sh
+++ b/scripts/perf-gate-tier-a.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Perf Tier A: micro-benchmark / performance-scoped unit tests.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR=".nexo/perf"
+mkdir -p "$REPORT_DIR"
+
+ORCH="src/Nexo.Tests.Orchestration/Nexo.Tests.Orchestration.csproj"
+BG="src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj"
+
+echo "== Perf Tier A: orchestration performance tests =="
+dotnet build "$ORCH" -v minimal
+dotnet test "$ORCH" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~Nexo.Tests.Orchestration.Performance" \
+  --logger "trx;LogFileName=perf-orchestration.trx" \
+  --results-directory "$REPORT_DIR" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+echo "== Perf Tier A: background agent performance tests =="
+dotnet build "$BG" -v minimal
+dotnet test "$BG" -f net8.0 --no-build \
+  --filter "FullyQualifiedName~Nexo.Tests.BackgroundAgents.Performance" \
+  --logger "trx;LogFileName=perf-background-agents.trx" \
+  --results-directory "$REPORT_DIR" \
+  --blame-hang-timeout 120s --blame-hang-dump-type none
+
+echo ""
+echo "perf-gate-tier-a: PASS"

--- a/scripts/perf-gate-tier-b.sh
+++ b/scripts/perf-gate-tier-b.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Perf Tier B: pipeline throughput (mocked deterministic stages).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI_PROJECT="application/src/Nexo.CLI/Nexo.CLI.csproj"
+TMP_ROOT="${TMPDIR:-/tmp}/nexo-perf-gate-$$"
+mkdir -p "$TMP_ROOT"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+TEMPLATE="$TMP_ROOT/pipeline_perf.json"
+ITERATIONS="${PERF_GATE_PIPELINE_ITERATIONS:-5}"
+MAX_TOTAL_MS="${PERF_GATE_PIPELINE_MAX_MS:-180000}"
+
+cat >"$TEMPLATE" <<'JSON'
+{
+  "templateId": "perf-gate",
+  "version": "1.0",
+  "stages": [
+    { "id": "ingest", "name": "Ingest", "mode": "Deterministic" },
+    { "id": "process", "name": "Process", "mode": "Deterministic" }
+  ],
+  "edges": [{ "fromStageId": "ingest", "toStageId": "process" }]
+}
+JSON
+
+echo "== Perf Tier B: pipeline throughput ($ITERATIONS runs, max ${MAX_TOTAL_MS}ms total) =="
+dotnet build "$CLI_PROJECT" -v minimal >/dev/null
+
+START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')
+for i in $(seq 1 "$ITERATIONS"); do
+  NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI_PROJECT" --no-build -- \
+    pipeline run --template "$TEMPLATE" --run-id "perf-gate-$i" --format-json >/dev/null
+done
+END_MS=$(python3 -c 'import time; print(int(time.time()*1000))')
+ELAPSED=$((END_MS - START_MS))
+AVG=$((ELAPSED / ITERATIONS))
+
+REPORT_DIR=".nexo/perf"
+mkdir -p "$REPORT_DIR"
+cat >"$REPORT_DIR/pipeline-throughput.json" <<EOF
+{
+  "iterations": $ITERATIONS,
+  "totalMs": $ELAPSED,
+  "avgMsPerRun": $AVG,
+  "maxTotalMs": $MAX_TOTAL_MS,
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "pipeline throughput: ${ELAPSED}ms total, ${AVG}ms avg/run"
+
+if [ "$ELAPSED" -gt "$MAX_TOTAL_MS" ]; then
+  echo "perf-gate-tier-b: FAIL (exceeded ${MAX_TOTAL_MS}ms)" >&2
+  exit 1
+fi
+
+echo ""
+echo "perf-gate-tier-b: PASS"

--- a/scripts/perf-gate-tier-c.sh
+++ b/scripts/perf-gate-tier-c.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Perf Tier C: CLI cold-start / help smoke timing.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI_PROJECT="application/src/Nexo.CLI/Nexo.CLI.csproj"
+MAX_MS="${PERF_GATE_COLD_START_MAX_MS:-45000}"
+
+echo "== Perf Tier C: CLI cold-start (--help) =="
+dotnet build "$CLI_PROJECT" -v minimal >/dev/null
+
+START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')
+dotnet run --project "$CLI_PROJECT" --no-build -- --help >/dev/null
+END_MS=$(python3 -c 'import time; print(int(time.time()*1000))')
+ELAPSED=$((END_MS - START_MS))
+
+REPORT_DIR=".nexo/perf"
+mkdir -p "$REPORT_DIR"
+cat >"$REPORT_DIR/cold-start.json" <<EOF
+{
+  "command": "dotnet run -- --help",
+  "elapsedMs": $ELAPSED,
+  "maxMs": $MAX_MS,
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "cold-start: ${ELAPSED}ms (max ${MAX_MS}ms)"
+
+if [ "$ELAPSED" -gt "$MAX_MS" ]; then
+  echo "perf-gate-tier-c: FAIL" >&2
+  exit 1
+fi
+
+echo ""
+echo "perf-gate-tier-c: PASS"

--- a/scripts/perf-gate-tier-d.sh
+++ b/scripts/perf-gate-tier-d.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Perf Tier D: mini-soak (repeated pipeline runs). Set PERF_GATE_SOAK_MINUTES for long soak.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CLI_PROJECT="application/src/Nexo.CLI/Nexo.CLI.csproj"
+TMP_ROOT="${TMPDIR:-/tmp}/nexo-perf-soak-$$"
+mkdir -p "$TMP_ROOT"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+TEMPLATE="$TMP_ROOT/pipeline_soak.json"
+SOAK_MINUTES="${PERF_GATE_SOAK_MINUTES:-0}"
+ITERATIONS="${PERF_GATE_SOAK_ITERATIONS:-15}"
+
+cat >"$TEMPLATE" <<'JSON'
+{
+  "templateId": "perf-soak",
+  "version": "1.0",
+  "stages": [{ "id": "work", "name": "Work", "mode": "Deterministic" }],
+  "edges": []
+}
+JSON
+
+dotnet build "$CLI_PROJECT" -v minimal >/dev/null
+
+if [ "$SOAK_MINUTES" -gt 0 ]; then
+  echo "== Perf Tier D: soak ${SOAK_MINUTES} minutes =="
+  END=$(( $(date +%s) + SOAK_MINUTES * 60 ))
+  RUNS=0
+  FAILS=0
+  while [ "$(date +%s)" -lt "$END" ]; do
+    RUNS=$((RUNS + 1))
+    if ! NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI_PROJECT" --no-build -- \
+      pipeline run --template "$TEMPLATE" --run-id "soak-$RUNS" --format-json >/dev/null 2>&1; then
+      FAILS=$((FAILS + 1))
+    fi
+  done
+else
+  echo "== Perf Tier D: mini-soak ($ITERATIONS iterations) =="
+  RUNS=$ITERATIONS
+  FAILS=0
+  for i in $(seq 1 "$ITERATIONS"); do
+    if ! NEXO_ALLOW_MOCK=1 dotnet run --project "$CLI_PROJECT" --no-build -- \
+      pipeline run --template "$TEMPLATE" --run-id "soak-$i" --format-json >/dev/null 2>&1; then
+      FAILS=$((FAILS + 1))
+    fi
+  done
+fi
+
+REPORT_DIR=".nexo/perf"
+mkdir -p "$REPORT_DIR"
+cat >"$REPORT_DIR/soak.json" <<EOF
+{
+  "runs": $RUNS,
+  "failures": $FAILS,
+  "soakMinutes": $SOAK_MINUTES,
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "soak: runs=$RUNS failures=$FAILS"
+
+if [ "$FAILS" -gt 0 ]; then
+  echo "perf-gate-tier-d: FAIL" >&2
+  exit 1
+fi
+
+echo ""
+echo "perf-gate-tier-d: PASS"

--- a/scripts/perf-gate.sh
+++ b/scripts/perf-gate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== Perf gate ==="
+
+if [ "${PERF_GATE_SKIP_PRIOR:-1}" != "1" ]; then
+  RC_GATE_SKIP_PRIOR=1 RC_GATE_GH_ADVISORY_ONLY=1 bash scripts/rc-gate.sh
+fi
+
+bash scripts/perf-gate-tier-a.sh
+bash scripts/perf-gate-tier-b.sh
+bash scripts/perf-gate-tier-c.sh
+if [ "${PERF_GATE_SKIP_TIER_D:-0}" != "1" ]; then
+  bash scripts/perf-gate-tier-d.sh
+fi
+bash scripts/perf-gate-baseline.sh
+
+echo ""
+echo "perf-gate: PASS"

--- a/scripts/waterproofing-gate.sh
+++ b/scripts/waterproofing-gate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Post-RC waterproofing: perf → compat → DR → RC policy tiers.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== Waterproofing gate (perf → compat → DR → RC policy) ==="
+
+PERF_GATE_SKIP_PRIOR=1 bash scripts/perf-gate.sh
+COMPAT_GATE_SKIP_PRIOR=1 bash scripts/compat-gate.sh
+DR_GATE_SKIP_PRIOR=1 bash scripts/dr-gate.sh
+
+if [ "${WATERPROOFING_SKIP_RC_POLICY:-0}" != "1" ]; then
+  bash scripts/rc-gate-tier-e.sh
+fi
+
+echo ""
+echo "waterproofing-gate: PASS"


### PR DESCRIPTION
## Summary
- `perf-gate`, `compat-gate`, `dr-gate`, and `waterproofing-gate-full` automation
- Baseline perf metrics, LiteDB DR drills, mesh persistence verify
- `docs/exceptions.yaml`, rollback drill and release sign-off templates

## Test plan
- [ ] `make waterproofing-gate-full`
- [ ] `PERF_GATE_STRICT_BASELINE=1 make perf-gate-full` (after baseline exists)

**Depends on:** production readiness gates PR (base branch).

Made with [Cursor](https://cursor.com)