### PR TITLE
Add SelfExtendGenerated composable CLI extensions

### DIFF
--- a/application/src/Nexo.CLI/Commands/SelfExtendGenerated/DomainKnowledgeExtensionCommand.cs
+++ b/application/src/Nexo.CLI/Commands/SelfExtendGenerated/DomainKnowledgeExtensionCommand.cs
@@ -1,0 +1,25 @@
+using System.CommandLine;
+using System.Text.Json;
+
+namespace Nexo.CLI.Commands.SelfExtendGenerated;
+
+public sealed class DomainKnowledgeExtensionCommand : Command, IComposableExtensionCommand
+{
+    public DomainKnowledgeExtensionCommand() : base("ext-domain-knowledge", "Self-extend generated extension command")
+    {
+        this.SetHandler(() =>
+        {
+            Console.Out.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = true,
+                command = Name,
+                extensionId = ExtensionId,
+                dependencies = Dependencies
+            }));
+            Environment.ExitCode = 0;
+        });
+    }
+
+    public string ExtensionId => "domain-knowledge";
+    public IReadOnlyList<string> Dependencies { get; } = Array.Empty<string>();
+}

--- a/application/src/Nexo.CLI/Commands/SelfExtendGenerated/FeatureHotloadExtensionCommand.cs
+++ b/application/src/Nexo.CLI/Commands/SelfExtendGenerated/FeatureHotloadExtensionCommand.cs
@@ -1,0 +1,25 @@
+using System.CommandLine;
+using System.Text.Json;
+
+namespace Nexo.CLI.Commands.SelfExtendGenerated;
+
+public sealed class FeatureHotloadExtensionCommand : Command, IComposableExtensionCommand
+{
+    public FeatureHotloadExtensionCommand() : base("ext-feature-hotload", "Self-extend generated extension command")
+    {
+        this.SetHandler(() =>
+        {
+            Console.Out.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = true,
+                command = Name,
+                extensionId = ExtensionId,
+                dependencies = Dependencies
+            }));
+            Environment.ExitCode = 0;
+        });
+    }
+
+    public string ExtensionId => "feature-hotload";
+    public IReadOnlyList<string> Dependencies { get; } = new[] { "domain-knowledge", "ui-shell", "ui-workflow" };
+}

--- a/application/src/Nexo.CLI/Commands/SelfExtendGenerated/IComposableExtensionCommand.cs
+++ b/application/src/Nexo.CLI/Commands/SelfExtendGenerated/IComposableExtensionCommand.cs
@@ -1,0 +1,7 @@
+namespace Nexo.CLI.Commands.SelfExtendGenerated;
+
+public interface IComposableExtensionCommand
+{
+    string ExtensionId { get; }
+    IReadOnlyList<string> Dependencies { get; }
+}

--- a/application/src/Nexo.CLI/Commands/SelfExtendGenerated/SelfExtendUiDemoBundleCommand.cs
+++ b/application/src/Nexo.CLI/Commands/SelfExtendGenerated/SelfExtendUiDemoBundleCommand.cs
@@ -1,0 +1,14 @@
+using System.CommandLine;
+
+namespace Nexo.CLI.Commands.SelfExtendGenerated;
+
+public sealed class SelfExtendUiDemoBundleCommand : Command
+{
+    public SelfExtendUiDemoBundleCommand() : base("self-extend-ui-demo-bundle", "Composed bundle of generated extension commands")
+    {
+        AddCommand(new DomainKnowledgeExtensionCommand());
+        AddCommand(new UiShellExtensionCommand());
+        AddCommand(new UiWorkflowExtensionCommand());
+        AddCommand(new FeatureHotloadExtensionCommand());
+    }
+}

--- a/application/src/Nexo.CLI/Commands/SelfExtendGenerated/UiShellExtensionCommand.cs
+++ b/application/src/Nexo.CLI/Commands/SelfExtendGenerated/UiShellExtensionCommand.cs
@@ -1,0 +1,25 @@
+using System.CommandLine;
+using System.Text.Json;
+
+namespace Nexo.CLI.Commands.SelfExtendGenerated;
+
+public sealed class UiShellExtensionCommand : Command, IComposableExtensionCommand
+{
+    public UiShellExtensionCommand() : base("ext-ui-shell", "Self-extend generated extension command")
+    {
+        this.SetHandler(() =>
+        {
+            Console.Out.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = true,
+                command = Name,
+                extensionId = ExtensionId,
+                dependencies = Dependencies
+            }));
+            Environment.ExitCode = 0;
+        });
+    }
+
+    public string ExtensionId => "ui-shell";
+    public IReadOnlyList<string> Dependencies { get; } = new[] { "domain-knowledge" };
+}

--- a/application/src/Nexo.CLI/Commands/SelfExtendGenerated/UiWorkflowExtensionCommand.cs
+++ b/application/src/Nexo.CLI/Commands/SelfExtendGenerated/UiWorkflowExtensionCommand.cs
@@ -1,0 +1,25 @@
+using System.CommandLine;
+using System.Text.Json;
+
+namespace Nexo.CLI.Commands.SelfExtendGenerated;
+
+public sealed class UiWorkflowExtensionCommand : Command, IComposableExtensionCommand
+{
+    public UiWorkflowExtensionCommand() : base("ext-ui-workflow", "Self-extend generated extension command")
+    {
+        this.SetHandler(() =>
+        {
+            Console.Out.WriteLine(JsonSerializer.Serialize(new
+            {
+                ok = true,
+                command = Name,
+                extensionId = ExtensionId,
+                dependencies = Dependencies
+            }));
+            Environment.ExitCode = 0;
+        });
+    }
+
+    public string ExtensionId => "ui-workflow";
+    public IReadOnlyList<string> Dependencies { get; } = new[] { "domain-knowledge", "ui-shell" };
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/DomainKnowledgeExtensionCommandStructureTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/DomainKnowledgeExtensionCommandStructureTests.cs
@@ -1,0 +1,53 @@
+using Nexo.CLI.Commands.SelfExtendGenerated;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+
+namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
+
+public sealed class DomainKnowledgeExtensionCommandStructureTests : UnitTestBase
+{
+    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var command = new DomainKnowledgeExtensionCommand();
+            AssertEqual("ext-domain-knowledge", command.Name, "Command name should match scaffold");
+
+            AssertTrue(command is IComposableExtensionCommand, "Command must implement IComposableExtensionCommand");
+            var composable = (IComposableExtensionCommand)command;
+            AssertEqual("domain-knowledge", composable.ExtensionId, "ExtensionId should match scaffold");
+            AssertEqual(0, composable.Dependencies.Count, "Dependency count should match scaffold");
+            AssertEqual(0, composable.Dependencies.Count, "Dependencies should be empty for this extension");
+
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(DomainKnowledgeExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = true,
+                Message = "Generated command structure is valid."
+            });
+        }
+        catch (AssertionException ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(DomainKnowledgeExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(DomainKnowledgeExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/FeatureHotloadExtensionCommandStructureTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/FeatureHotloadExtensionCommandStructureTests.cs
@@ -1,0 +1,55 @@
+using Nexo.CLI.Commands.SelfExtendGenerated;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+
+namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
+
+public sealed class FeatureHotloadExtensionCommandStructureTests : UnitTestBase
+{
+    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var command = new FeatureHotloadExtensionCommand();
+            AssertEqual("ext-feature-hotload", command.Name, "Command name should match scaffold");
+
+            AssertTrue(command is IComposableExtensionCommand, "Command must implement IComposableExtensionCommand");
+            var composable = (IComposableExtensionCommand)command;
+            AssertEqual("feature-hotload", composable.ExtensionId, "ExtensionId should match scaffold");
+            AssertEqual(3, composable.Dependencies.Count, "Dependency count should match scaffold");
+            AssertTrue(composable.Dependencies.Contains("domain-knowledge", StringComparer.Ordinal), "Expected dependency 'domain-knowledge'");
+            AssertTrue(composable.Dependencies.Contains("ui-shell", StringComparer.Ordinal), "Expected dependency 'ui-shell'");
+            AssertTrue(composable.Dependencies.Contains("ui-workflow", StringComparer.Ordinal), "Expected dependency 'ui-workflow'");
+
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(FeatureHotloadExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = true,
+                Message = "Generated command structure is valid."
+            });
+        }
+        catch (AssertionException ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(FeatureHotloadExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(FeatureHotloadExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/SelfExtendUiDemoBundleCommandStructureTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/SelfExtendUiDemoBundleCommandStructureTests.cs
@@ -1,0 +1,51 @@
+using Nexo.CLI.Commands.SelfExtendGenerated;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+
+namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
+
+public sealed class SelfExtendUiDemoBundleCommandStructureTests : UnitTestBase
+{
+    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var command = new SelfExtendUiDemoBundleCommand();
+            AssertEqual("self-extend-ui-demo-bundle", command.Name, "Bundle command name should match scaffold");
+            AssertTrue(command.Subcommands.Any(s => string.Equals(s.Name, "ext-domain-knowledge", StringComparison.Ordinal)), "Expected subcommand 'ext-domain-knowledge'");
+            AssertTrue(command.Subcommands.Any(s => string.Equals(s.Name, "ext-ui-shell", StringComparison.Ordinal)), "Expected subcommand 'ext-ui-shell'");
+            AssertTrue(command.Subcommands.Any(s => string.Equals(s.Name, "ext-ui-workflow", StringComparison.Ordinal)), "Expected subcommand 'ext-ui-workflow'");
+            AssertTrue(command.Subcommands.Any(s => string.Equals(s.Name, "ext-feature-hotload", StringComparison.Ordinal)), "Expected subcommand 'ext-feature-hotload'");
+
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(SelfExtendUiDemoBundleCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = true,
+                Message = "Bundle command composition is valid."
+            });
+        }
+        catch (AssertionException ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(SelfExtendUiDemoBundleCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(SelfExtendUiDemoBundleCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiDomainKnowledgeRetentionTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiDomainKnowledgeRetentionTests.cs
@@ -1,0 +1,103 @@
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+using System.Text.Json;
+
+namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
+
+public sealed class UiDomainKnowledgeRetentionTests : UnitTestBase
+{
+    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            string? repoRoot = null;
+            while (dir != null)
+            {
+                if (Directory.Exists(Path.Combine(dir.FullName, "src")) &&
+                    Directory.Exists(Path.Combine(dir.FullName, "docs")))
+                {
+                    repoRoot = dir.FullName;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+            AssertTrue(!string.IsNullOrWhiteSpace(repoRoot), "Unable to resolve repository root from test context.");
+
+            var uiRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "app");
+            var hostRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "host");
+            var avaloniaRoot = Path.Combine(repoRoot!, "docs", "UiDomainDemoGenerated", "avalonia");
+            var htmlPath = Path.Combine(uiRoot, "index.html");
+            var jsPath = Path.Combine(uiRoot, "app.js");
+            var domainPath = Path.Combine(uiRoot, "domain-knowledge.json");
+            var hostProgramPath = Path.Combine(hostRoot, "Program.cs");
+            var hostProjectPath = Path.Combine(hostRoot, "UiDemoHost.csproj");
+            var smokeProgramPath = Path.Combine(hostRoot, "SmokeProgram.cs");
+            var avaloniaContractsPath = Path.Combine(avaloniaRoot, "Nexo.Ui.Abstractions", "UiContracts.cs");
+            var avaloniaHostProgramPath = Path.Combine(avaloniaRoot, "Nexo.Ui.AvaloniaHost", "Program.cs");
+
+            AssertTrue(File.Exists(htmlPath), "Expected index.html to exist.");
+            AssertTrue(File.Exists(jsPath), "Expected app.js to exist.");
+            AssertTrue(File.Exists(domainPath), "Expected domain-knowledge.json to exist.");
+            AssertTrue(File.Exists(hostProgramPath), "Expected .NET host Program.cs to exist.");
+            AssertTrue(File.Exists(hostProjectPath), "Expected .NET host project file to exist.");
+            AssertTrue(File.Exists(smokeProgramPath), "Expected .NET smoke program to exist.");
+            AssertTrue(File.Exists(avaloniaContractsPath), "Expected Avalonia abstraction contracts to exist.");
+            AssertTrue(File.Exists(avaloniaHostProgramPath), "Expected Avalonia host Program.cs to exist.");
+
+            var html = File.ReadAllText(htmlPath);
+            var js = File.ReadAllText(jsPath);
+            var domainJson = File.ReadAllText(domainPath);
+            var hostProgram = File.ReadAllText(hostProgramPath);
+            var avaloniaContracts = File.ReadAllText(avaloniaContractsPath);
+            var avaloniaHostProgram = File.ReadAllText(avaloniaHostProgramPath);
+
+            AssertTrue(html.Contains("Nexo Chatbot", StringComparison.Ordinal), "UI should render chatbot section.");
+            AssertTrue(html.Contains("Dynamically loaded features", StringComparison.Ordinal), "UI should render dynamic feature host section.");
+            AssertTrue(js.Contains("explainNexo", StringComparison.Ordinal), "JS should implement chatbot explainer behavior.");
+            AssertTrue(js.Contains("/api/scaffold-feature", StringComparison.Ordinal), "JS should call scaffold API endpoint.");
+            AssertTrue(js.Contains("import(moduleUrl)", StringComparison.Ordinal), "JS should dynamically import generated feature modules.");
+            AssertTrue(hostProgram.Contains("MapPost(\"/api/scaffold-feature\"", StringComparison.Ordinal), ".NET host should expose scaffold endpoint.");
+            AssertTrue(hostProgram.Contains("UseStaticFiles", StringComparison.Ordinal), ".NET host should serve static UI.");
+            AssertTrue(avaloniaContracts.Contains("IUiFrameworkAdapter", StringComparison.Ordinal), "Avalonia stack should include cross-framework adapter contract.");
+            AssertTrue(avaloniaContracts.Contains("CrossFrameworkCompatibility", StringComparison.Ordinal), "Avalonia stack should include compatibility contract notes.");
+            AssertTrue(avaloniaHostProgram.Contains("AVALONIA_FEATURE_HOTLOAD", StringComparison.Ordinal), "Avalonia host should scaffold via Avalonia hotload objective.");
+            AssertTrue(avaloniaHostProgram.Contains("AVALONIA_APP_TRANSFORM", StringComparison.Ordinal), "Avalonia host should support full app transformation objective.");
+            AssertTrue(avaloniaHostProgram.Contains("Galactic Operations Console", StringComparison.Ordinal), "Avalonia host should render a distinct transformed application shell.");
+            AssertTrue(avaloniaHostProgram.Contains("AvaloniaUiFrameworkAdapter", StringComparison.Ordinal), "Avalonia host should render nodes through framework adapter.");
+            using var doc = JsonDocument.Parse(domainJson);
+            var capabilities = doc.RootElement.GetProperty("capabilities");
+            AssertTrue(capabilities.GetArrayLength() >= 4, "Expected at least 4 domain capabilities.");
+
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiDomainKnowledgeRetentionTests),
+                Category = "SelfExtendGenerated",
+                Passed = true,
+                Message = "UI demo retains domain knowledge and required artifacts."
+            });
+        }
+        catch (AssertionException ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiDomainKnowledgeRetentionTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiDomainKnowledgeRetentionTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiShellExtensionCommandStructureTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiShellExtensionCommandStructureTests.cs
@@ -1,0 +1,53 @@
+using Nexo.CLI.Commands.SelfExtendGenerated;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+
+namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
+
+public sealed class UiShellExtensionCommandStructureTests : UnitTestBase
+{
+    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var command = new UiShellExtensionCommand();
+            AssertEqual("ext-ui-shell", command.Name, "Command name should match scaffold");
+
+            AssertTrue(command is IComposableExtensionCommand, "Command must implement IComposableExtensionCommand");
+            var composable = (IComposableExtensionCommand)command;
+            AssertEqual("ui-shell", composable.ExtensionId, "ExtensionId should match scaffold");
+            AssertEqual(1, composable.Dependencies.Count, "Dependency count should match scaffold");
+            AssertTrue(composable.Dependencies.Contains("domain-knowledge", StringComparer.Ordinal), "Expected dependency 'domain-knowledge'");
+
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiShellExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = true,
+                Message = "Generated command structure is valid."
+            });
+        }
+        catch (AssertionException ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiShellExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiShellExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiWorkflowExtensionCommandStructureTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/SelfExtendGenerated/UiWorkflowExtensionCommandStructureTests.cs
@@ -1,0 +1,54 @@
+using Nexo.CLI.Commands.SelfExtendGenerated;
+using Nexo.Core.Application.Testing.Abstractions;
+using Nexo.Core.Application.Testing.Models;
+
+namespace Nexo.Tests.CLI.Tests.Commands.SelfExtendGenerated;
+
+public sealed class UiWorkflowExtensionCommandStructureTests : UnitTestBase
+{
+    public override Task<TestResult> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var command = new UiWorkflowExtensionCommand();
+            AssertEqual("ext-ui-workflow", command.Name, "Command name should match scaffold");
+
+            AssertTrue(command is IComposableExtensionCommand, "Command must implement IComposableExtensionCommand");
+            var composable = (IComposableExtensionCommand)command;
+            AssertEqual("ui-workflow", composable.ExtensionId, "ExtensionId should match scaffold");
+            AssertEqual(2, composable.Dependencies.Count, "Dependency count should match scaffold");
+            AssertTrue(composable.Dependencies.Contains("domain-knowledge", StringComparer.Ordinal), "Expected dependency 'domain-knowledge'");
+            AssertTrue(composable.Dependencies.Contains("ui-shell", StringComparer.Ordinal), "Expected dependency 'ui-shell'");
+
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiWorkflowExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = true,
+                Message = "Generated command structure is valid."
+            });
+        }
+        catch (AssertionException ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiWorkflowExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Assertion failed: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new TestResult
+            {
+                Name = nameof(UiWorkflowExtensionCommandStructureTests),
+                Category = "SelfExtendGenerated",
+                Passed = false,
+                ErrorMessage = $"Unexpected exception: {ex.Message}",
+                StackTrace = ex.StackTrace
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds generated composable extension commands (`ui-shell`, `ui-workflow`, `domain-knowledge`, `feature-hotload`, `self-extend-ui-demo-bundle`)
- Structure tests via `UnitTestBridgeTests` for release-core / adaptive runtime paths

## Test plan
- [ ] `dotnet test application/src/Nexo.Tests.CLI --filter "FullyQualifiedName~UnitTestBridgeTests&FullyQualifiedName~SelfExtendGenerated"`
- [ ] `SHIP_GATE_RUN_RUNTIME_GATE=1 make ship-gate-tier-d` (after stack merges)

**Depends on:** #112 (runtime hardening). Merge #110 → #111 → #112 first, or rebase base after those land.

Made with [Cursor](https://cursor.com)