### PR TITLE
Distribution models doc and parallel distribution-matrix CI gate

### DIFF
--- a/.github/workflows/distribution-matrix-gate.yml
+++ b/.github/workflows/distribution-matrix-gate.yml
@@ -1,0 +1,139 @@
+# Validates multiple consumer/distribution channels in parallel.
+# See docs/DistributionModels.md for the mapping.
+name: Distribution Matrix Gate
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly full matrix on default branch (path filters on PRs may skip jobs).
+    - cron: "0 10 * * 1"
+  push:
+    branches:
+      - master
+      - main
+      - "cursor/**"
+    paths:
+      - ".github/workflows/distribution-matrix-gate.yml"
+      - "scripts/ci/distribution-matrix-api-http-smoke.sh"
+      - ".docker/Dockerfile.api"
+      - ".docker/Dockerfile.cli"
+      - "scripts/verify-stable-sdk-host-sample-packages.sh"
+      - "scripts/pack-nexo-hosting-graph.sh"
+      - "scripts/pack-nexo-hosting-graph.ps1"
+      - "scripts/pack-nexo-hosting-graph.allowlist.txt"
+      - "scripts/verify-pack-nexo-hosting-graph-alignment.py"
+      - "application/src/Nexo.API/**"
+      - "application/src/Nexo.CLI/**"
+      - "src/Nexo.Client/**"
+      - "src/Nexo.Hosting/**"
+      - "docs/samples/StableSdkHostSample/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/**"
+      - "src/Nexo.Tests.Infrastructure/Helpers/VirtualProduction/**"
+  pull_request:
+    paths:
+      - ".github/workflows/distribution-matrix-gate.yml"
+      - "scripts/ci/distribution-matrix-api-http-smoke.sh"
+      - ".docker/Dockerfile.api"
+      - ".docker/Dockerfile.cli"
+      - "scripts/verify-stable-sdk-host-sample-packages.sh"
+      - "scripts/pack-nexo-hosting-graph.sh"
+      - "scripts/pack-nexo-hosting-graph.ps1"
+      - "scripts/pack-nexo-hosting-graph.allowlist.txt"
+      - "scripts/verify-pack-nexo-hosting-graph-alignment.py"
+      - "application/src/Nexo.API/**"
+      - "application/src/Nexo.CLI/**"
+      - "src/Nexo.Client/**"
+      - "src/Nexo.Hosting/**"
+      - "docs/samples/StableSdkHostSample/**"
+      - "src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/**"
+      - "src/Nexo.Tests.Infrastructure/Helpers/VirtualProduction/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: distribution-matrix-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nuget-local-pack-consumer:
+    name: NuGet local pack → StableSdkHostSample
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Verify package-consumer build (isolated cache)
+        env:
+          NEXO_SDK_PACKAGE_VERSION: "9.9.9-ci-${{ github.run_id }}"
+        run: bash scripts/verify-stable-sdk-host-sample-packages.sh
+
+  cli-image-smoke:
+    name: CLI image build + smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build CLI image
+        run: |
+          docker build \
+            --file .docker/Dockerfile.cli \
+            --tag nexo-cli:dist-matrix \
+            .
+
+      - name: Smoke (--help)
+        run: docker run --rm nexo-cli:dist-matrix --help
+
+      - name: Smoke (doctor, mock)
+        env:
+          NEXO_ALLOW_MOCK: "1"
+        run: docker run --rm -e NEXO_ALLOW_MOCK=1 nexo-cli:dist-matrix doctor --json
+
+  api-image-http-smoke:
+    name: API image + curl /health + /api/status
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build, run API, curl smoke
+        run: bash scripts/ci/distribution-matrix-api-http-smoke.sh
+
+  nexo-client-inprocess-test:
+    name: Nexo.Client ↔ in-process Nexo.API (net9)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: dotnet test (VirtualProduction INexoClient)
+        env:
+          NEXO_ALLOW_MOCK: "1"
+        run: |
+          dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj \
+            -f net9.0 \
+            --filter "FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.VirtualProduction.FrameworkVirtualProdDemosTests.Virtual_prod_INexoClient_GetStatusAsync_matches_console_and_blazor_demos" \
+            --verbosity minimal
+
+  pack-hosting-graph-alignment:
+    name: Pack script vs Nexo.Hosting graph
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: verify-pack-nexo-hosting-graph-alignment
+        run: python3 scripts/verify-pack-nexo-hosting-graph-alignment.py

--- a/docs/DistributionModels.md
+++ b/docs/DistributionModels.md
@@ -1,0 +1,60 @@
+# Distribution models
+
+This page is for **maintainers and integrators**: how Nexo is shipped, how each channel is **pinned**, and which **automated gates** prove that channel still works.
+
+For day-to-day embedding and extension work, start with **`docs/IntegratorGuide.md`**, **`docs/sdk.md`**, and **`docs/architecture/runtime-vs-application.md`**.
+
+## Version spine
+
+Ship the **same semantic version** across artifacts that belong together:
+
+- **NuGet:** all `Nexo.*` packages for a release share one `PackageVersion`; consumers often reference **`Nexo.Hosting.Bundle`**. See **`docs/PUBLISHING.md`**.
+- **Containers:** GHCR images tagged with the same **`vX.Y.Z`** (and digest pins for production). See **`docs/RELEASE.md`** and **`docs/DEPLOYMENT.md`**.
+
+Release automation is summarized in **`docs/RELEASE.md`** (NuGet + GHCR from one tag when configured).
+
+## Distribution channels
+
+| Channel | Primary artifacts | How consumers pin | First success (manual) |
+|--------|---------------------|-------------------|-------------------------|
+| **NuGet host embed** | `Nexo.Hosting` graph, **`Nexo.Hosting.Bundle`** | Package version on a feed | Build and run **`docs/samples/StableSdkHostSample/`** (see **`docs/SdkIntegrationGuide.md`**) |
+| **NuGet client** | **`Nexo.Client`** / **`Nexo.Sdk`** | Package version | **`docs/sdk.md`** (client quick start) |
+| **HTTP-only** | Running **`Nexo.API`** | Base URL + TLS + API key policy | **`curl`** `GET /health`, `GET /api/status` (see **`docs/SelfHostedAgentServer.md`**) |
+| **CLI** | **`Nexo.CLI`** binary or **GHCR `nexo-cli`** image | Image tag or digest; CLI `--version` / package | **`docs/GettingStarted.md`** (`doctor`, `pipeline`) |
+| **Compose / operators** | Root **`docker-compose*.yml`** + operator docs | Compose file revision + image digests | **`docs/DEPLOYMENT.md`**, stack-specific guides |
+| **Source / monorepo** | `ProjectReference` into **`src/`** | Git commit / branch | **`docs/IntegratorGuide.md`** (project reference example) |
+| **Mesh / federation** | Peer config, director URL, tokens | `instances.json`, env vars | **`docs/IntegratorGuide.md`**, **`docs/FriendMeshPrefab.md`**, mesh phase docs |
+
+## Contract boundaries
+
+- **Host SDK (stable):** `Nexo.Hosting.Sdk` — register bricks/agents before **`AddNexo`**. See **`docs/sdk.md`**.
+- **Client SDK (stable):** `Nexo.Client` / **`INexoClient`** — typed HTTP to a running API; use **`InvokeAsync`** for routes not yet wrapped. See **`docs/sdk.md`** and **`docs/api/index.md`**.
+- **HTTP:** stable routes and behavior for external clients; breaking changes should follow your HTTP/versioning policy (same major concern as mobile clients).
+- **CLI:** treat breaking flags as **consumer-facing** changes; document in release notes.
+
+Breaking-change policy for packages: **`docs/SdkCompatibilityPolicy.md`**.
+
+## Automated gates (CI)
+
+The workflow **`.github/workflows/distribution-matrix-gate.yml`** runs **in parallel** on relevant pull requests, on pushes to the default branch (when touched paths match), on **`workflow_dispatch`**, and on a **weekly schedule** so path-filtered PRs do not miss cross-cutting breaks.
+
+| Matrix job | What it proves |
+|------------|----------------|
+| **nuget-local-pack-consumer** | Local pack → **`scripts/verify-stable-sdk-host-sample-packages.sh`** (isolated NuGet cache, sample restores from folder feed + nuget.org). |
+| **cli-image-smoke** | **`.docker/Dockerfile.cli`** builds; container runs **`--help`** and **`doctor --json`** with **`NEXO_ALLOW_MOCK=1`**. |
+| **api-image-http-smoke** | **`.docker/Dockerfile.api`** builds; container serves **`/health`** and **`/api/status`** (host **`curl`** — HTTP-only consumer path). Script: **`scripts/ci/distribution-matrix-api-http-smoke.sh`**. |
+| **nexo-client-inprocess-test** | **`Nexo.Client`** `GetStatusAsync` against in-process **`Nexo.API`** (same pipeline as production; **`net9.0`** test filter). |
+| **pack-hosting-graph-alignment** | **`scripts/verify-pack-nexo-hosting-graph-alignment.py`** — pack allowlist matches **`Nexo.Hosting`** MSBuild graph. |
+
+**Post-publish NuGet** verification (nuget.org index + retries) stays in **`docs/PUBLISHING.md`**, **`docs/NuGetConsumerVerify.md`**, and the reusable workflow **`reusable-verify-nuget-consumer.yml`** (invoked from release flows).
+
+Other related gates (not duplicated here): **`compose-gate.yml`**, **`devcontainer-gate.yml`**, **`container-image-gate.yml`**, **`pack-hosting-graph-alignment.yml`**, mesh prefab / mesh lab workflows under **`.github/workflows/`**.
+
+## Integrator compatibility matrix
+
+Release owners should keep the **version / runtime table** in **`docs/IntegratorGuide.md`** up to date when you cut a release (single source of truth for “which Nexo version on which .NET”).
+
+## See also
+
+- **`docs/DocsIndex.md`** — documentation hub.
+- **`docs/RELEASE_RUNBOOK.md`** — ship decisions and checks after tag.

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -17,6 +17,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 
 ## Operator / Production Readiness
 
+- **`docs/DistributionModels.md`** — how Nexo is **distributed** (NuGet, HTTP, CLI, compose, source, mesh), **pinning**, and the **distribution matrix** CI workflow that gates each channel.
 - **`docs/production-readiness/README.md`** — **hub** for supporting SMB, enterprise, SaaS, and air-gapped production: release, security, ops, data/compliance, reliability, testing, operator deployment; includes [catalog by deployment type](production-readiness/CatalogByDeploymentType.md) and [runbook template](production-readiness/RunbookTemplate.md).
 - `docs/DEPLOYMENT.md` — **golden paths** (portal stack, CLI image, agent server), **pinning** images vs `latest`, NuGet/CI notes.
 - `docs/RELEASE.md` — **release hub** (preflight, dispatch, tag, deep links).
@@ -37,6 +38,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 - `docs/CiFirstHardwareSecond.md` — **CI first, hardware second**: which workflows to run and what still needs a physical host.
 - `.github/workflows/onboarding-quickstart-gate.yml` — runs first-run onboarding commands in native + container lanes.
 - `.github/workflows/container-image-gate.yml` — container image buildability and smoke-run gate.
+- `.github/workflows/distribution-matrix-gate.yml` — **parallel** gates: NuGet local-pack consumer, CLI image + doctor, API image + `curl` `/health` + `/api/status`, `Nexo.Client` in-process test, pack-graph alignment (plus **weekly** schedule).
 - `.github/workflows/release.yml` — **one entry**: tag `v*.*.*` → GHCR (`nexo-cli`, `nexo-api`) + NuGet; run summary with pin lines.
 - `.github/workflows/container-image-publish.yml` — GHCR on **main** path-filtered pushes + manual (tags use `release.yml` only).
 - `.github/workflows/release-nuget.yml` — **NuGet-only** manual dispatch; after push to nuget.org, **Verify NuGet consumer** (same reusable job as **release.yml**).

--- a/docs/IntegratorGuide.md
+++ b/docs/IntegratorGuide.md
@@ -2,6 +2,8 @@
 
 This guide is for teams embedding Nexo, extending bricks, or hosting custom background agents alongside the core platform.
 
+For **how all distribution channels fit together** (NuGet, HTTP, CLI, compose, source, mesh), **pinning**, and the **CI matrix** that validates each channel, see **`docs/DistributionModels.md`**.
+
 ## Getting started with the Nexo SDK
 
 The slim **HTTP client** package is the `Nexo.Sdk` project (`src/Nexo.Sdk/Nexo.Sdk.csproj`). Register it with **`AddNexoClientSdk(baseUrl, ...)`** (`Nexo.Sdk.Client`). The obsolete **`AddNexoSdk(string baseUrl, ...)`** name remains as a compat shim. For **host-side** brick/agent registration, use **`Nexo.Hosting.Sdk.AddNexoSdk`** (before `AddNexo`). See [`docs/architecture/SdkStructure.md`](architecture/SdkStructure.md).
@@ -59,7 +61,7 @@ Match sensitivity and exfiltration settings to your deployment tier. For mesh-re
 |--------------|--------------|--------|
 | _TBD_        | .NET 8 / 9   | Fill in after your release qualification. |
 
-Update this table when you pin Nexo packages or CLI images for production.
+Update this table when you pin Nexo packages or CLI images for production. Release owners: keep this table aligned with **`docs/DistributionModels.md`** (single place integrators look for “what we support”).
 
 ## Troubleshooting
 

--- a/scripts/ci/distribution-matrix-api-http-smoke.sh
+++ b/scripts/ci/distribution-matrix-api-http-smoke.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Build Nexo.API image from .docker/Dockerfile.api, run with mock provider,
+# and assert /health and /api/status respond (HTTP-only consumer smoke).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+IMAGE_TAG="${DIST_MATRIX_API_IMAGE_TAG:-nexo-api:dist-matrix}"
+HOST_PORT="${DIST_MATRIX_API_PORT:-18080}"
+WAIT_SECS="${DIST_MATRIX_API_WAIT_SECS:-120}"
+
+echo "Building API image ${IMAGE_TAG} ..."
+docker build -f .docker/Dockerfile.api --tag "${IMAGE_TAG}" .
+
+CONTAINER="nexo-api-dist-matrix-${RANDOM}"
+cleanup() {
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Starting container ${CONTAINER} on port ${HOST_PORT} ..."
+docker run -d --name "${CONTAINER}" -p "${HOST_PORT}:8080" \
+  -e NEXO_ALLOW_MOCK=1 \
+  "${IMAGE_TAG}"
+
+start_ts=$(date +%s)
+until curl -fsS "http://127.0.0.1:${HOST_PORT}/health" >/dev/null 2>&1; do
+  now_ts=$(date +%s)
+  if (( now_ts - start_ts > WAIT_SECS )); then
+    echo "Timeout waiting for /health after ${WAIT_SECS}s" >&2
+    docker logs "${CONTAINER}" >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "GET /health OK"
+curl -fsS "http://127.0.0.1:${HOST_PORT}/health" | head -c 256 || true
+echo
+
+echo "GET /api/status OK"
+curl -fsS "http://127.0.0.1:${HOST_PORT}/api/status" | head -c 512 || true
+echo
+
+echo "distribution-matrix-api-http-smoke: OK"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds maintainer-facing documentation for how Nexo is distributed and introduces a GitHub Actions workflow that runs parallel smoke jobs for the main consumption channels.

## Documentation

- New `docs/DistributionModels.md` maps channels (NuGet host, NuGet client, HTTP-only, CLI, compose, source, mesh) to pinning strategies, links to existing release and operator docs, and documents which CI jobs validate each path.
- `docs/DocsIndex.md` links the new page and lists the new workflow.
- `docs/IntegratorGuide.md` points integrators at the distribution hub and ties the compatibility matrix to that doc.

## CI

- New `.github/workflows/distribution-matrix-gate.yml` with five parallel jobs: local NuGet pack consumer verify, CLI Docker image (`--help` + `doctor --json` with mock), API Docker image with host `curl` against `/health` and `/api/status`, a focused `net9.0` `Nexo.Client` integration test (`FrameworkVirtualProdDemosTests`), and the existing Python pack-graph alignment check.
- New `scripts/ci/distribution-matrix-api-http-smoke.sh` implements the API container smoke.
- Triggers: path-filtered `pull_request` and `push`, `workflow_dispatch`, and a weekly cron (Mondays 10:00 UTC) so path filters do not hide drift on the default branch.

## Testing

- Ran `python3 scripts/verify-pack-nexo-hosting-graph-alignment.py` locally (passed).
- Ran the filtered `dotnet test` for the `Nexo.Client` virtual prod test on `net9.0` locally (passed).
- Docker-based jobs were not executed in this environment (no Docker); they will run on GitHub-hosted runners.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-705003ca-aff7-462d-8b22-f42405ae83d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-705003ca-aff7-462d-8b22-f42405ae83d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

