### PR TITLE
test(cli): macOS brew vs curl bootstrap dependency probes

### DIFF
--- a/application/src/Nexo.Tests.CLI/Tests/Commands/BootstrapRuntimeAssessTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/BootstrapRuntimeAssessTests.cs
@@ -60,7 +60,10 @@ public sealed class BootstrapRuntimeAssessTests : UnitTestBase
         AssertTrue(assessment.Supported, "supported");
         var ids = assessment.Dependencies.Select(d => d.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
         AssertTrue(ids.Contains("git"), "expected git dependency probe");
-        AssertTrue(ids.Contains("curl"), "expected curl dependency probe");
         AssertTrue(ids.Contains("dotnet"), "expected dotnet dependency probe");
+        if (OperatingSystem.IsMacOS())
+            AssertTrue(ids.Contains("brew"), "expected Homebrew dependency probe on macOS");
+        else
+            AssertTrue(ids.Contains("curl"), "expected curl dependency probe on Linux and Windows");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `BootstrapRuntimeAssessTests` with `BootstrapRuntime.MacDemoDependencies`, which probes **Homebrew** (`brew`) on macOS instead of `curl`.

## Changes

- `BootstrapRuntimeAssessTests`: assert `brew` on macOS, `curl` on Linux/Windows; `git` and `dotnet` on all supported hosts.

## Merge order

**Merge this PR before** the kernel follow-up ([#136](https://github.com/IanFrelinger/Nexo/pull/136)) that re-enables the test in `nexo validate`. Otherwise macOS `ci verify` will fail again.

## Layer boundary

This PR touches `application/` only. **`layer-boundary` will fail** against `master` by design — merge with repo policy exception (admin merge or temporary rules adjustment), then merge #136.

## Verification

- `dotnet test application/src/Nexo.Tests.CLI --filter DisplayName~BootstrapRuntimeAssessTests`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c7b00c5-8a21-4b3d-aab4-c4552d7cfb08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c7b00c5-8a21-4b3d-aab4-c4552d7cfb08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

