### PR TITLE
fix(ci): re-enable BootstrapRuntimeAssessTests in nexo validate

### DIFF
--- a/src/Nexo.Infrastructure/Testing/UnitTestFrameworkBridge.cs
+++ b/src/Nexo.Infrastructure/Testing/UnitTestFrameworkBridge.cs
@@ -37,9 +37,7 @@ public static class UnitTestFrameworkBridge
 
         if (string.Equals(assembly.GetName().Name, "Nexo.Tests.CLI", StringComparison.Ordinal))
         {
-            types = types.Where(t =>
-                !string.Equals(t.Name, "DoctorCommandTests", StringComparison.Ordinal) &&
-                !string.Equals(t.Name, "BootstrapRuntimeAssessTests", StringComparison.Ordinal));
+            types = types.Where(t => !string.Equals(t.Name, "DoctorCommandTests", StringComparison.Ordinal));
         }
 
         return types.OrderBy(t => t.FullName, StringComparer.Ordinal).ToList();

--- a/src/Nexo.Infrastructure/Validation/Adapters/ValidationServiceAdapter.cs
+++ b/src/Nexo.Infrastructure/Validation/Adapters/ValidationServiceAdapter.cs
@@ -273,7 +273,7 @@ public class ValidationServiceAdapter : IValidationService
         var verbosity = streamOutput ? "normal" : "minimal";
         var args =
             $"test \"{csprojPath}\" --framework net8.0 --no-build " +
-            "--filter \"Category!=DockerOptional&Category!=Stress&FullyQualifiedName!~BootstrapRuntimeAssessTests\" " +
+            "--filter \"Category!=DockerOptional&Category!=Stress\" " +
             "--logger trx --blame-hang-timeout 120s --blame-hang-dump-type none " +
             $"--verbosity {verbosity}";
         var workDir = Path.GetDirectoryName(csprojPath) ?? Directory.GetCurrentDirectory();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the temporary workarounds from #134 that skipped `BootstrapRuntimeAssessTests` during `nexo validate` / `UnitTestBridgeTests`.

## Changes

- `UnitTestFrameworkBridge`: stop skipping `BootstrapRuntimeAssessTests` for `Nexo.Tests.CLI`
- `ValidationServiceAdapter`: drop `FullyQualifiedName!~BootstrapRuntimeAssessTests` validate filter

## Merge order

**Merge after** the application test fix lands on `master` ([#135](https://github.com/IanFrelinger/Nexo/pull/135)). If this merges first, macOS Full Platform Readiness `ci verify` will fail again.

Draft until #135 is merged.

## Verification

- Linux: `dotnet test application/src/Nexo.Tests.CLI --filter DisplayName~BootstrapRuntimeAssessTests`
- Full gate: macOS native readiness after both PRs are on `master`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c7b00c5-8a21-4b3d-aab4-c4552d7cfb08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c7b00c5-8a21-4b3d-aab4-c4552d7cfb08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

