### PR TITLE
docs(licensing): complete Phase D — metadata and tier alignment

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,8 @@
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <Deterministic>true</Deterministic>
     <RepositoryUrl>https://github.com/IanFrelinger/Nexo</RepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- Open packable projects resolve Apache-2.0 via Directory.Build.targets; commercial clears the expression. -->
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/IanFrelinger/Nexo</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon Condition="Exists('$(MSBuildThisFileDirectory)icon.png')">icon.png</PackageIcon>

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -8,11 +8,11 @@ Nexo uses an open-core boundary:
 
 The repository root license is Apache-2.0. See [`LICENSE`](LICENSE).
 
-For the follow-up project/module extraction sequence, see [`docs/CommercialExtractionPlan.md`](docs/CommercialExtractionPlan.md). For fleet/mesh governance classification, see [`docs/FleetGovernanceExtractionInventory.md`](docs/FleetGovernanceExtractionInventory.md).
+Extraction **Phases A–E** are complete (see [`docs/CommercialExtractionPlan.md`](docs/CommercialExtractionPlan.md)). The open/commercial project graph is enforced in CI by [`scripts/dependency-boundary-gate.sh`](scripts/dependency-boundary-gate.sh). Optional follow-up extractions (for example `src/**/Networking/**`) are classified in [`docs/FleetGovernanceExtractionInventory.md`](docs/FleetGovernanceExtractionInventory.md).
 
 ## Tier 1 — OPEN (Apache-2.0)
 
-Tier 1 is the adoption and trust surface: SDKs, contracts, single-node runtime/hosts, trust primitives, tests, samples, and inspectable extension points. These projects carry Apache-2.0 package metadata either directly in their `.csproj` or through the repository-wide `Directory.Build.props` / `Directory.Build.targets` defaults.
+Tier 1 is the adoption and trust surface: SDKs, contracts, single-node runtime/hosts, trust primitives, tests, samples, and inspectable extension points. These projects carry Apache-2.0 package metadata either directly in their `.csproj` or through the repository-wide `Directory.Build.props` / `Directory.Build.targets` defaults (`PackageLicenseExpression=Apache-2.0` for non-commercial projects).
 
 Rationale: this tier protects two moats at once — an extensible SDK and a single runtime across surfaces. `Nexo.Policies`, `Nexo.Policies.Dev`, and `Nexo.Bricks.Owasp` are open on purpose: trust-by-design fails if the trust primitives are a paywalled black box.
 
@@ -32,7 +32,7 @@ Rationale: this tier protects two moats at once — an extensible SDK and a sing
 | OPEN | `src/Nexo.Lite/Nexo.Lite.csproj` |
 | OPEN | `application/src/Nexo.CLI/Nexo.CLI.csproj` |
 | OPEN | `application/src/Nexo.API/Nexo.API.csproj` |
-| OPEN | `src/Nexo.Infrastructure/Nexo.Infrastructure.csproj` |
+| OPEN | `src/Nexo.Infrastructure/Nexo.Infrastructure.csproj` (includes open `MeshLab` worker executor) |
 | OPEN | `src/Nexo.Orchestration/Nexo.Orchestration.csproj` |
 | OPEN | `src/Nexo.Adapters.Models/Nexo.Adapters.Models.csproj` |
 | OPEN | `src/Nexo.BackgroundAgents/Nexo.BackgroundAgents.csproj` |
@@ -68,61 +68,59 @@ Rationale: this tier protects two moats at once — an extensible SDK and a sing
 | OPEN | `docs/samples/StableSdkHostSample/package-consumer/StableSdkHostSample.Package.csproj` |
 | OPEN | `samples/**` |
 
+Open mesh **primitives** (local discovery, capability advertisement, trust middleware) remain under `src/Nexo.Core.Application/Mesh/**` and `src/Nexo.Infrastructure/Mesh/**`. Mesh-lab **workers** poll the commercial fleet director via open `src/Nexo.Infrastructure/MeshLab/**`.
+
 ## Verify-then-place decisions
 
 These projects were explicitly inspected and placed:
 
 | Project | Decision | Reason |
 |---------|----------|--------|
-| `application/src/Nexo.API/Nexo.API.csproj` | OPEN | Current project is a single-node HTTP/API host over the open kernel. The Forge/GameDomain HTTP surface has been moved to the Game Director application layer, so this host no longer references `Nexo.GameDomain`. |
+| `application/src/Nexo.API/Nexo.API.csproj` | OPEN | Single-node HTTP/API host over the open kernel. Fleet `/api/mesh/*` director endpoints live on `Nexo.Commercial.Fleet.Host`, not open `Nexo.API`. |
 | `src/Nexo.Transport.Grpc.Server/Nexo.Transport.Grpc.Server.csproj` | OPEN | Server implementation exposes the open gRPC transport surface; it is not a fleet-scale director/control-plane project. |
 | `src/Nexo.Transport.Grpc.Server.Host/Nexo.Transport.Grpc.Server.Host.csproj` | OPEN | Standalone gRPC host for the open transport server, not a governance tier. |
-| `application/Nexo.Application.sln` contents | OPEN for current contents | The solution contains `Nexo.API`, `Nexo.CLI`, and `Nexo.Tests.CLI` as open surfaces. `Nexo.GameDomain` and its tests have moved to `commercial/`. |
+| `application/Nexo.Application.sln` contents | OPEN for current contents | The solution contains `Nexo.API`, `Nexo.CLI`, and `Nexo.Tests.CLI` as open surfaces. Game domain and Game Director live under `commercial/`. |
 
 ## Tier 2 — COMMERCIAL (fleet + governance)
 
-Tier 2 is the future commercial layer for fleet-scale and governance capabilities:
+Tier 2 is the commercial layer for fleet-scale and governance capabilities:
 
 - mesh control plane / distributed execution,
-- knowledge sync,
+- knowledge replication on the director,
 - elastic scheduling,
 - leases and checkpoints,
 - data-plane federation,
 - operator hardening,
 - director persistence,
-- centralized policy management,
+- centralized policy management (future `Nexo.Commercial.Governance`),
 - aggregated tamper-evident audit,
 - RBAC/SSO and organization-scale governance.
 
-Current status: fleet contracts, fleet infrastructure, mesh director, fleet API, and fleet host exist under `commercial/`. Mesh-lab director (peer-a) runs `Nexo.Commercial.Fleet.Host`. Open duplicate fleet trees under `src/` have been removed; mesh-lab workers use open `Nexo.Infrastructure/MeshLab` to poll the commercial director HTTP API.
+**Current modules** (each directory has `COMMERCIAL-LICENSE.md` and `NexoCommercialProject=true` in its `.csproj`):
 
-The current classification inventory is [`docs/FleetGovernanceExtractionInventory.md`](docs/FleetGovernanceExtractionInventory.md). Remaining extraction candidates include:
+| Module | Path |
+|--------|------|
+| Fleet contracts | `commercial/src/Nexo.Commercial.Fleet.Contracts/` |
+| Fleet infrastructure | `commercial/src/Nexo.Commercial.Fleet.Infrastructure/` |
+| Fleet API extensions | `commercial/src/Nexo.Commercial.Fleet.Api/` |
+| Fleet operator host | `commercial/src/Nexo.Commercial.Fleet.Host/` |
+| Mesh director CLI | `commercial/src/Nexo.Commercial.MeshDirector/` |
+| Fleet tests | `commercial/tests/Nexo.Commercial.Tests.Fleet/`, `commercial/tests/Nexo.Commercial.Tests.Fleet.Host/` |
+| Mesh director tests | `commercial/tests/Nexo.Commercial.Tests.MeshDirector/` |
 
-- `src/Nexo.Core.Application/Networking/**`
-- `src/Nexo.Infrastructure/Networking/**`
-- fleet-scale portions of `src/Nexo.Core.Application/Mesh/**` and `src/Nexo.Infrastructure/Mesh/**`
-- fleet/director CLI surfaces such as `MeshDirectorCommand` and `MeshHubCommand`
-- API mesh/fleet governance middleware and endpoints under `application/src/Nexo.API/**`
+Mesh-lab **peer-a** runs `Nexo.Commercial.Fleet.Host` (`.docker/Dockerfile.fleet-host`). Open duplicate fleet trees under `src/**/Fleet/**` have been removed.
+
+**Optional follow-up** (not required for the open/commercial boundary): classify and optionally move `src/Nexo.Core.Application/Networking/**` and `src/Nexo.Infrastructure/Networking/**` per [`docs/FleetGovernanceExtractionInventory.md`](docs/FleetGovernanceExtractionInventory.md).
 
 ## Tier 3 — COMMERCIAL (verticals)
 
 Tier 3 is the commercial product/vertical layer.
-
-These app configuration directories are marked with a `COMMERCIAL-LICENSE.md` stub:
 
 | Allocation | Path |
 |------------|------|
 | COMMERCIAL | `commercial/src/Nexo.Commercial.GameDomain/` |
 | COMMERCIAL | `commercial/tests/Nexo.Commercial.Tests.GameDomain/` |
 | COMMERCIAL | `commercial/samples/ForgeMapHostSample/` |
-| COMMERCIAL | `commercial/src/Nexo.Commercial.Fleet.Contracts/` |
-| COMMERCIAL | `commercial/src/Nexo.Commercial.Fleet.Infrastructure/` |
-| COMMERCIAL | `commercial/src/Nexo.Commercial.Fleet.Api/` |
-| COMMERCIAL | `commercial/src/Nexo.Commercial.Fleet.Host/` |
-| COMMERCIAL | `commercial/tests/Nexo.Commercial.Tests.Fleet.Host/` |
-| COMMERCIAL | `commercial/tests/Nexo.Commercial.Tests.Fleet/` |
-| COMMERCIAL | `commercial/src/Nexo.Commercial.MeshDirector/` |
-| COMMERCIAL | `commercial/tests/Nexo.Commercial.Tests.MeshDirector/` |
 | COMMERCIAL | `commercial/src/Nexo.Commercial.GameDirector.Domain/` |
 | COMMERCIAL | `commercial/src/Nexo.Commercial.GameDirector.Agents/` |
 | COMMERCIAL | `commercial/src/Nexo.Commercial.GameDirector.Bricks/` |
@@ -134,11 +132,11 @@ These app configuration directories are marked with a `COMMERCIAL-LICENSE.md` st
 | COMMERCIAL | `apps/release-manager/` |
 | COMMERCIAL | `apps/runtime-studio/` |
 
-Stub text:
+Stub text in each `COMMERCIAL-LICENSE.md`:
 
 > Not licensed under Apache-2.0. Commercial terms TBD. See /LICENSING.md.
 
-The GameDomain module and Game Director code/test projects have been moved into `commercial/`, so they may reference each other and the open core without creating open-to-commercial project references.
+Commercial vertical projects may reference each other and the open core; open projects must not reference commercial projects.
 
 Recommended future open-source candidate: `apps/release-manager` is the best single app to open later as a minimal SDK reference because it demonstrates generic release-readiness automation without making the defense-adjacent Game Director wedge open.
 
@@ -146,16 +144,18 @@ Recommended future open-source candidate: `apps/release-manager` is the best sin
 
 Rule: no Tier 1 OPEN project may reference a Tier 2/3 COMMERCIAL project.
 
-Current result: **passes for committed placement** because no Tier 1 `.csproj` references a commercial project.
-
 Enforced in CI by `scripts/dependency-boundary-gate.sh` (workflow: `.github/workflows/dependency-boundary.yml`). The scanner classifies projects by path and `NexoCommercialProject`, fails on open→commercial `ProjectReference` edges, requires `COMMERCIAL-LICENSE.md` beside commercial `.csproj` files, and verifies open packable projects resolve `PackageLicenseExpression=Apache-2.0`.
 
-Preflight result for the vertical split: **unblocked for GameDomain/GameDirector**. `Nexo.API`, `Nexo.CLI`, and `Nexo.Tests.CLI` no longer reference `Nexo.GameDomain`; `Nexo.GameDomain`, Game Director code, and their tests have moved to commercial paths. Fleet infrastructure extraction from open `src/` is complete; remaining work is networking/governance extraction and further commercial module splits.
+Local verification:
 
-## Open questions
+```bash
+make dependency-boundary-gate
+```
 
-- Which fleet/governance files should be extracted first into commercial projects? Start from [`docs/FleetGovernanceExtractionInventory.md`](docs/FleetGovernanceExtractionInventory.md).
-- Should `Nexo.API` remain a purely open single-node host, or should commercial fleet/governance endpoints move to a separate host?
+## Open questions (post-extraction)
+
+- Should `src/**/Networking/**` move to commercial fleet/governance modules, or remain a smaller open substrate?
+- Should open `MeshHubCommand` split further so only local mesh inspection stays in `Nexo.CLI`?
 - Should `apps/release-manager` become the future minimal open SDK reference app?
 
-See [`docs/CommercialExtractionPlan.md`](docs/CommercialExtractionPlan.md) for the proposed extraction order and validation gates.
+See [`docs/CommercialExtractionPlan.md`](docs/CommercialExtractionPlan.md) for the completed extraction sequence and validation gates.

--- a/README.md
+++ b/README.md
@@ -381,4 +381,4 @@ See [`docs/Configuration.md`](docs/Configuration.md) for security options and [`
 
 ## License
 
-Nexo uses an open-core model: single-node, inspectable runtime/SDK/trust surfaces are Apache-2.0, while fleet-scale governance and vertical app packaging are commercial. See [LICENSE](LICENSE) for Apache-2.0 terms and [LICENSING.md](LICENSING.md) for the authoritative tier allocation, extraction notes, and open questions.
+Nexo uses an open-core model: single-node, inspectable runtime/SDK/trust surfaces are Apache-2.0, while fleet-scale governance and vertical app packaging are commercial. See [LICENSE](LICENSE) for Apache-2.0 terms and [LICENSING.md](LICENSING.md) for the authoritative tier map and CI-enforced project boundary (`make dependency-boundary-gate`).

--- a/docs/CommercialExtractionPlan.md
+++ b/docs/CommercialExtractionPlan.md
@@ -1,6 +1,8 @@
 # Commercial extraction plan
 
-This plan defines the next commercial-boundary work after the open-core licensing sprint. It is a planning document only: do not move code, rename projects, or change CI from this document alone.
+This plan records the commercial-boundary work after the open-core licensing sprint.
+
+**Status (2026-06):** Phases **A–E** are **complete**. GameDomain, Game Director, fleet/mesh governance, licensing metadata (Phase D), and the dependency-boundary CI gate (Phase E) are in place on `master`. Optional follow-ups (Networking extraction, CLI mesh-hub split, `Nexo.Commercial.Governance`) are tracked under [Open questions](#open-questions-post-extraction) in [`LICENSING.md`](../LICENSING.md).
 
 ## Goal
 
@@ -13,9 +15,9 @@ Create a clean project/module boundary where:
 
 ## Current blockers
 
-### Vertical / Game Director graph
+None for the core open/commercial boundary. Phases A–E exit criteria are met.
 
-The vertical code is being separated from the open application surface. The API and CLI seams are now resolved; GameDomain has moved to `commercial/`; Game Director projects are commercially marked in place and can be physically moved in a later cleanup.
+### Vertical / Game Director graph (resolved)
 
 | Current project | Current references that matter for extraction |
 |-----------------|-----------------------------------------------|
@@ -31,21 +33,11 @@ The vertical code is being separated from the open application surface. The API 
 | `commercial/tests/Nexo.Commercial.Tests.GameDomain/Nexo.Commercial.Tests.GameDomain.csproj` | **Resolved:** moved with commercial GameDomain tests. |
 | `commercial/tests/Nexo.Commercial.Tests.GameDirector/Nexo.Tests.GameDirector.csproj` | Moved to commercial layout; references GameDirector projects and commercial GameDomain. |
 
-### Fleet / mesh / governance graph
+### Fleet / mesh / governance graph (resolved)
 
-Fleet-scale mesh and governance behavior is currently woven through open projects:
+Fleet-scale code has moved to `commercial/src/Nexo.Commercial.Fleet.*`, `Nexo.Commercial.MeshDirector`, and `Nexo.Commercial.Fleet.Host`. Open `src/**/Fleet/**` trees are removed. Mesh-lab workers use open `src/Nexo.Infrastructure/MeshLab/**` to call the commercial director HTTP API.
 
-- `src/Nexo.Core.Application/Fleet/**`
-- `src/Nexo.Infrastructure/Fleet/**`
-- `src/Nexo.Core.Application/Networking/**`
-- `src/Nexo.Infrastructure/Networking/**`
-- fleet-scale portions of `src/Nexo.Core.Application/Mesh/**`
-- fleet-scale portions of `src/Nexo.Infrastructure/Mesh/**`
-- `commercial/src/Nexo.Commercial.MeshDirector/MeshDirectorCommand.cs`
-- `application/src/Nexo.CLI/Commands/MeshHubCommand.cs`
-- mesh/fleet governance endpoints and middleware under `application/src/Nexo.API/**`
-
-Those files cannot be marked commercial while they remain inside open projects such as `Nexo.Core.Application`, `Nexo.Infrastructure`, `Nexo.Runtime`, `Nexo.Orchestration`, `Nexo.CLI`, or `Nexo.API`.
+**Optional follow-up:** `src/Nexo.Core.Application/Networking/**`, `src/Nexo.Infrastructure/Networking/**`, and a finer split of open CLI mesh hub vs commercial director commands — see [`FleetGovernanceExtractionInventory.md`](FleetGovernanceExtractionInventory.md).
 
 ## Target boundary
 
@@ -152,33 +144,31 @@ Exit criteria:
 - Commercial fleet modules compile against open contracts.
 - Mesh/fleet tests are split into open primitive tests and commercial fleet tests.
 
-### Phase D — licensing and package metadata
+### Phase D — licensing and package metadata (done)
 
 Purpose: make the legal boundary match the project graph.
 
-1. Add Apache-2.0 package metadata to open projects.
-2. Add commercial stubs to commercial project directories.
-3. Remove any ambiguous “pending extraction” notes once extraction is complete.
-4. Update `LICENSING.md`, `docs/ProjectTiers.md`, `docs/DistributionModels.md`, and package/solution docs.
+1. **Done:** Apache-2.0 package metadata on open projects (`Directory.Build.props` / `Directory.Build.targets`; verified by dependency-boundary gate).
+2. **Done:** `COMMERCIAL-LICENSE.md` stubs beside every commercial `.csproj`.
+3. **Done:** removed ambiguous “pending extraction” notes for extracted modules.
+4. **Done:** updated `LICENSING.md`, `docs/ProjectTiers.md`, `docs/DistributionModels.md`.
 
 Exit criteria:
 
 - `LICENSING.md` has no “pending extraction” entries for extracted modules.
 - Open package graph and commercial module graph are clear.
 
-### Phase E — automate dependency safety
+Validation: `make dependency-boundary-gate`
+
+### Phase E — automate dependency safety (done)
 
 Purpose: prevent boundary regressions.
 
-Recommended check:
-
-1. Maintain an allowlist/map of open project paths and commercial project paths.
-2. Scan every `.csproj` for `<ProjectReference>`.
-3. Fail if an open project references a commercial project.
-4. Warn if a commercial project lacks a `COMMERCIAL-LICENSE.md` stub.
-5. Warn if an open packable project lacks effective `PackageLicenseExpression=Apache-2.0`.
-
-This can start as a script and become a CI gate after the first extraction PR lands.
+1. **Done:** `scripts/verify-open-commercial-dependency-boundary.py` classifies open vs commercial projects.
+2. **Done:** scan every `.csproj` for `<ProjectReference>`; fail on open→commercial edges.
+3. **Done:** require `COMMERCIAL-LICENSE.md` beside commercial projects.
+4. **Done:** verify open packable projects resolve `PackageLicenseExpression=Apache-2.0`.
+5. **Done:** CI workflow `.github/workflows/dependency-boundary.yml` and `make dependency-boundary-gate`.
 
 ## Validation gates by phase
 
@@ -204,5 +194,10 @@ This can start as a script and become a CI gate after the first extraction PR la
 10. **PR 10 — open fleet cleanup:** migrate mesh-lab peer-a to the commercial fleet host and remove open `/api/mesh` fleet/task/knowledge handlers from `Nexo.API`.
 11. **PR 11 — open fleet infrastructure cleanup (done):** removed open fleet trees; mesh-lab worker executor lives in `src/Nexo.Infrastructure/MeshLab/**`; fleet tests moved to `commercial/tests/Nexo.Commercial.Tests.Fleet`.
 12. **PR 12 — dependency-boundary gate (done):** `scripts/dependency-boundary-gate.sh`, `.github/workflows/dependency-boundary.yml`, and `make dependency-boundary-gate`.
+13. **PR 13 — Phase D licensing (done):** align `Directory.Build.props` license default with Apache-2.0; refresh `LICENSING.md`, `ProjectTiers.md`, and `DistributionModels.md` to match the post-extraction graph.
 
-Do not combine these into one large refactor. The dependency graph and licensing boundary should be reviewable at every step.
+Do not combine large refactors retroactively. The dependency graph and licensing boundary should stay reviewable at every step.
+
+## Open questions (post-extraction)
+
+See [`LICENSING.md`](../LICENSING.md) — Networking classification, CLI mesh-hub split, and `apps/release-manager` open-source candidacy.

--- a/docs/DistributionModels.md
+++ b/docs/DistributionModels.md
@@ -23,7 +23,8 @@ Release automation is summarized in **`docs/RELEASE.md`** (NuGet + GHCR from one
 | **CLI** | **`Nexo.CLI`** binary or **GHCR `nexo-cli`** image | Image tag or digest; CLI `--version` / package | **`docs/GettingStarted.md`** (`doctor`, `pipeline`) |
 | **Compose / operators** | Root **`docker-compose*.yml`** + operator docs | Compose file revision + image digests | **`docs/DEPLOYMENT.md`**, stack-specific guides |
 | **Source / monorepo** | `ProjectReference` into **`src/`** | Git commit / branch | **`docs/IntegratorGuide.md`** (project reference example) |
-| **Mesh / federation** | Peer config, director URL, tokens | `instances.json`, env vars | **`docs/IntegratorGuide.md`**, **`docs/FriendMeshPrefab.md`**, mesh phase docs |
+| **Mesh / federation (open peers)** | Peer config, local mesh primitives, worker executor | `instances.json`, env vars | **`docs/IntegratorGuide.md`**, **`docs/FriendMeshPrefab.md`**, **`docs/MeshVirtualLab.md`** |
+| **Mesh fleet director (commercial)** | `Nexo.Commercial.Fleet.Host`, `/api/mesh/*` director APIs | Image tag + API key + peer registration key | **`.docker/Dockerfile.fleet-host`**, **`scripts/commercial-fleet-host-smoke.sh`**, mesh-lab peer-a |
 
 ## Golden reference pins (copy/paste)
 
@@ -37,6 +38,7 @@ Use these as **stable entrypoints** when writing runbooks or samples; replace im
 | **CLI container (public)** | **`ghcr.io/ianfrelinger/nexo-cli:latest`** — smoke with **`--help`** and **`pipeline validate --help`** (not **`doctor`**, see **`docs/GettingStarted.md`**). |
 | **Compose (operator lab)** | **`docker-compose.ephemeral.yml`** (light deps) or **`docker-compose.portal.yml`** (Director stack) — hub **`docs/DEPLOYMENT.md`**. |
 | **Mesh prefab** | **`docker-compose.friend-mesh.yml`** + **`docs/FriendMeshPrefab.md`** |
+| **Mesh lab (heterogeneous)** | **`docker-compose.mesh-lab.yml`** — peer-a = commercial fleet host, peer-b/worker = open `Nexo.API` | **`docs/MeshVirtualLab.md`**, **`scripts/mesh-lab-verify.sh`** |
 
 ## Contract boundaries
 

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -100,7 +100,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 
 ## Planning & Roadmap
 
-- `docs/CommercialExtractionPlan.md` — follow-up extraction plan for Game Director, `Nexo.GameDomain`, and fleet/mesh governance commercial modules.
+- `docs/CommercialExtractionPlan.md` — commercial extraction plan (Phases A–E complete); optional Networking/CLI follow-ups.
 - `docs/FleetGovernanceExtractionInventory.md` — classification inventory for open mesh primitives vs commercial fleet/governance code.
 - `docs/Conventions.md` — current conventions for errors, interfaces, abstract classes, and generics.
 - `docs/MeshPhase0NorthStar.md` — **Phase 0 (executed):** federated mesh north star, capability matrix by profile, trust boundary, SLOs (feeds mesh Phases 1–7).

--- a/docs/ProjectTiers.md
+++ b/docs/ProjectTiers.md
@@ -2,7 +2,7 @@
 
 This is the canonical repository map for contributors and reviewers. Use it with [`README.md`](../README.md) for orientation and [`DistributionModels.md`](DistributionModels.md) for how each surface is consumed or shipped.
 
-The monorepo has **~62** `.csproj` projects. The **runnable product** is roughly **15 projects** (Tiers **0** and **1**): kernel libraries, distribution/SDK packs, and the two deployable hosts. Everything else is packaging, optional transport/mesh, product experiments, demos/samples, and tests.
+The monorepo has **~69** `.csproj` projects (**52** open, **17** commercial; see [`LICENSING.md`](../LICENSING.md) and `make dependency-boundary-gate`). The **runnable open product** is roughly **15 projects** (Tiers **0** and **1**): kernel libraries, distribution/SDK packs, and the two deployable hosts (`Nexo.CLI`, `Nexo.API`). Commercial fleet and vertical hosts live under `commercial/` and `apps/`.
 
 Tiers depend **inward** only (satellites reference the spine, not the reverse). The **`layer-boundary`** CI gate enforces this.
 
@@ -17,7 +17,7 @@ Tiers depend **inward** only (satellites reference the spine, not the reverse). 
 | `Nexo.Contracts` | Cross-cutting contracts |
 | `Nexo.Brick.Contracts` | Brick extension contracts |
 | `Nexo.Policies` | Policy primitives |
-| `Nexo.Infrastructure` | Execution, persistence, adapters |
+| `Nexo.Infrastructure` | Execution, persistence, adapters; open `MeshLab` worker executor (polls commercial fleet director) |
 | `Nexo.Orchestration` | Orchestrator, routing, coordination |
 | `Nexo.BackgroundAgents` | Scheduler, RAG, tools |
 | `Nexo.BackgroundAgents.HostRunners` | Host runner adapters |
@@ -87,6 +87,9 @@ The CLI project also references spine-adjacent packs: **`Nexo.Bricks.Owasp`**, *
 | `application/src/Nexo.Tests.CLI` | CLI tests |
 | `commercial/tests/Nexo.Commercial.Tests.GameDirector` | commercial Game Director tests |
 | `commercial/tests/Nexo.Commercial.Tests.GameDomain` | commercial game domain tests |
+| `commercial/tests/Nexo.Commercial.Tests.Fleet` | commercial fleet/director tests |
+| `commercial/tests/Nexo.Commercial.Tests.Fleet.Host` | commercial fleet host smoke tests |
+| `commercial/tests/Nexo.Commercial.Tests.MeshDirector` | commercial mesh director CLI tests |
 
 ## Minimal clone-to-run core
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **Phase D** of [`docs/CommercialExtractionPlan.md`](docs/CommercialExtractionPlan.md): align legal/package metadata with the post-extraction open/commercial project graph.

## Changes

- **`Directory.Build.props`** — default `PackageLicenseExpression` is `Apache-2.0` (matches repo `LICENSE` and `Directory.Build.targets`; commercial projects still clear the expression via `NexoCommercialProject`)
- **`LICENSING.md`** — documents Phases A–E as complete; lists current commercial fleet/vertical modules; removes stale “pending extraction” / open-fleet-endpoint notes; points optional follow-ups to Networking inventory
- **`docs/ProjectTiers.md`** — ~69 projects (52 open / 17 commercial), MeshLab note, commercial test assemblies
- **`docs/DistributionModels.md`** — commercial fleet director + mesh-lab distribution rows
- **`docs/CommercialExtractionPlan.md`** — Phase D/E marked done; blockers resolved; PR 13 recorded
- **`README.md`**, **`docs/DocsIndex.md`** — updated licensing pointers

## Validation

```bash
make dependency-boundary-gate   # PASS — 69 projects, Apache-2.0 on open packable
```

No source or workflow logic changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

