### PR TITLE
docs: align GameDomain references with commercial extraction

### DIFF
--- a/application/README.md
+++ b/application/README.md
@@ -4,11 +4,13 @@ Deployable and product-facing projects that consume the runtime under `src/`.
 
 | Project | Role |
 |---------|------|
-| `Nexo.API` | HTTP host |
+| `Nexo.API` | Open HTTP host (kernel status, mesh worker, etc.) |
 | `Nexo.CLI` | `nexo` global tool |
-| `Nexo.GameDomain` | Forge / game descriptors |
+| `Nexo.Commercial.GameDomain` | Forge / game descriptors (commercial; under `commercial/src/`) |
 
-Tests: `Nexo.Tests.CLI`, `Nexo.Tests.GameDomain`.
+Forge HTTP (`/api/forge/*`) is served by **`Nexo.Commercial.GameDirector.Host`** in `commercial/`, not `Nexo.API`.
+
+Tests: `Nexo.Tests.CLI`, `Nexo.Commercial.Tests.GameDomain` (commercial).
 
 Build:
 

--- a/commercial/samples/ForgeMapHostSample/Program.cs
+++ b/commercial/samples/ForgeMapHostSample/Program.cs
@@ -2,7 +2,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Nexo.GameDomain.Mapping;
 
-var baseUrl = (Environment.GetEnvironmentVariable("NEXO_API_BASE_URL") ?? "http://localhost:5000").TrimEnd('/');
+var baseUrl = (Environment.GetEnvironmentVariable("NEXO_API_BASE_URL") ?? "http://127.0.0.1:8080").TrimEnd('/');
 var engineId = Environment.GetEnvironmentVariable("FORGE_ENGINE_ID") ?? "unity";
 var mapboxToken = Environment.GetEnvironmentVariable("MAPBOX_ACCESS_TOKEN");
 var tileset = Environment.GetEnvironmentVariable("MAPBOX_TILESET_ID") ?? "mapbox.mapbox-streets-v8";

--- a/commercial/samples/ForgeMapHostSample/README.md
+++ b/commercial/samples/ForgeMapHostSample/README.md
@@ -5,15 +5,15 @@ Runnable **.NET 8** console app that walks through **M1–M5**, **phases A–C**
 1. **M1 — Manifest consumption:** `GET /api/forge/engine/{engineId}/aesthetic-manifest`, unwraps the JSON envelope, prints pack id / profile / binding count.
 2. **M4 — LOD pyramid:** `GET /api/forge/map/tile-pyramid` — prints zoom tier(s) from **`LodLevels`** vs **`PYRAMID_FINEST_ZOOM`** (runs early so you see pyramid without Mapbox).
 3. **Phase A / M6 — Material hints:** `GET /api/forge/map/material-hints` — procedural surface hints for the active aesthetic.
-4. **M2 — Tile orchestration:** Uses **`WebMercatorTileMath`** + **`VectorTileUrlBuilder`** (from `Nexo.GameDomain`) to build a Mapbox vector tile URL from lon/lat/zoom + **`MAPBOX_ACCESS_TOKEN`**.
+4. **M2 — Tile orchestration:** Uses **`WebMercatorTileMath`** + **`VectorTileUrlBuilder`** (from `Nexo.Commercial.GameDomain`) to build a Mapbox vector tile URL from lon/lat/zoom + **`MAPBOX_ACCESS_TOKEN`**.
 5. **Phase B — Tile disk cache:** When **`NEXO_TILE_CACHE_DIR`** is set, writes raw MVT bytes under **`MapTileDiskCache`** keyed by **`MapTileCacheKey`** (aesthetic + provider + **`z/x/y`**).
 6. **M3 + terrain parity:** `POST /api/forge/map/pipeline/run` with **vector** and **Terrain-RGB** URLs (`TerrainTileUrlBuilder` / **`terrainDataUrl`**); prints vector parse/verify plus **`fetch_terrain`** PNG summary from the API.
 7. **Engine bridge:** **`docs/engine-bridge/`** — **`unity-package`**, **`godot-addon`**, and **`snippets/`**.
 
 ## Prerequisites
 
-- **Nexo.API** running locally (or set **`NEXO_API_BASE_URL`** to your deployment).
-- Optional: **Mapbox access token** for live tile fetch — must match **`Nexo:ForgeSession:AllowedMapFetchHosts`** on the API (include `api.mapbox.com`).
+- **Nexo.Commercial.GameDirector.Host** running locally (or set **`NEXO_API_BASE_URL`** to your Forge deployment).
+- Optional: **Mapbox access token** for live tile fetch — must match **`Nexo:ForgeSession:AllowedMapFetchHosts`** on the Game Director host (include `api.mapbox.com`).
 
 ## Run
 
@@ -26,7 +26,7 @@ With Mapbox:
 
 ```bash
 export MAPBOX_ACCESS_TOKEN="pk...."
-export NEXO_API_BASE_URL="http://localhost:5000"
+export NEXO_API_BASE_URL="http://127.0.0.1:8080"
 export SAMPLE_LAT="37.7749"
 export SAMPLE_LON="-122.4194"
 export SAMPLE_ZOOM="14"
@@ -37,7 +37,7 @@ dotnet run
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `NEXO_API_BASE_URL` | `http://localhost:5000` | Nexo.API base URL |
+| `NEXO_API_BASE_URL` | `http://127.0.0.1:8080` | Game Director host base URL (Forge `/api/forge/*`) |
 | `FORGE_ENGINE_ID` | `unity` | Path segment for manifest endpoint |
 | `MAPBOX_ACCESS_TOKEN` | _(empty)_ | Enables M2/M3 Mapbox URL + pipeline fetch |
 | `MAPBOX_TILESET_ID` | `mapbox.mapbox-streets-v8` | Mapbox tileset path |

--- a/docs/NexoForge.md
+++ b/docs/NexoForge.md
@@ -10,7 +10,9 @@ Nexo Forge maps to Nexo's layered architecture:
 ┌──────────────────────────────────────────────────────┐
 │  Forge Bar UX (CLI / future Unity editor panel)      │
 ├──────────────────────────────────────────────────────┤
-│  Nexo.GameDomain (Session, Macros, Descriptors)      │
+│  Nexo.Commercial.GameDomain (Session, Macros, etc.)  │
+├──────────────────────────────────────────────────────┤
+│  Nexo.Commercial.GameDirector.Host (/api/forge)    │
 ├──────────────────────────────────────────────────────┤
 │  Background Agents (balance, map, perf, content, macro)│
 ├──────────────────────────────────────────────────────┤
@@ -20,7 +22,7 @@ Nexo Forge maps to Nexo's layered architecture:
 └──────────────────────────────────────────────────────┘
 ```
 
-- **Nexo.GameDomain** — domain models (`SessionState`, `MacroDefinition`, weapon/map/ability descriptors) and exporter utilities for JSON round-tripping.
+- **Nexo.Commercial.GameDomain** — domain models (`SessionState`, `MacroDefinition`, weapon/map/ability descriptors) and exporter utilities for JSON round-tripping. Types retain the `Nexo.GameDomain` namespace.
 - **Background Agents** — the `agent_set.forge.json` configuration drives five deterministic agents that run on a schedule.
 - **Core.Application / Orchestration** — MediatR use cases, the orchestrator, and the agent scheduler from the base Nexo platform.
 - **Infrastructure** — LLM providers (used by the content-suggester when wired to a real model), persistence, and mesh networking.
@@ -203,4 +205,4 @@ Nexo Forge is designed to integrate with the Unity game engine via the **Unity s
 4. **LOD control** — the performance-monitor agent's LOD suggestions are applied to Unity's `LODGroup` components via the sidecar bridge.
 5. **Macro playback** — macros can script sequences of Unity editor actions (place spawn points, adjust lighting, swap materials) through the sidecar command channel.
 
-The `Nexo.GameDomain` library targets `netstandard2.0` alongside `net8.0` so it can be referenced directly from Unity 2019+ projects.
+`Nexo.Commercial.GameDomain` targets `netstandard2.0` alongside `net8.0` so it can be referenced directly from Unity 2019+ projects.

--- a/docs/architecture/TestingModel.md
+++ b/docs/architecture/TestingModel.md
@@ -16,7 +16,7 @@ Some suites inherit **`UnitTestBase`** (which extends **`TestBase`**) and implem
 
 ## Production-like tests (`Category=ProdStyle`)
 
-Use **`[Trait("Category", "ProdStyle")]`** on xUnit classes that mirror production wiring: **`AddNexo`**, **`AddRunPodCapabilityRouting`**, adaptation/composition stacks, Forge HTTP surfaces, capability routing, barriers, etc. **`UnitTestBridgeTests`** in Application / Domain / Infrastructure / CLI is tagged so every **`UnitTestBase`** suite participates. **`Nexo.Tests.GameDomain`** and **`Nexo.Tests.Transport`** use **`[assembly: AssemblyTrait("Category", "ProdStyle")]`** so the full assembly runs under **`Category=ProdStyle`**.
+Use **`[Trait("Category", "ProdStyle")]`** on xUnit classes that mirror production wiring: **`AddNexo`**, **`AddRunPodCapabilityRouting`**, adaptation/composition stacks, Forge HTTP surfaces, capability routing, barriers, etc. **`UnitTestBridgeTests`** in Application / Domain / Infrastructure / CLI is tagged so every **`UnitTestBase`** suite participates. **`Nexo.Commercial.Tests.GameDomain`** and **`Nexo.Tests.Transport`** use **`[assembly: AssemblyTrait("Category", "ProdStyle")]`** so the full assembly runs under **`Category=ProdStyle`**.
 
 **NCR virtual routing (`VirtualProductionNcrRoutingHost`):** production **`RunPodHttpClient`** against an in-process **`RunPodLoopbackApiServer`** (REST-compatible shim), **`ProviderFactory`** local execution, **`EnvironmentHardwareProfiler`**, **`FileBasedInstanceDiscovery`** — see **`docs/NcrReleaseSLOs.md`**.
 

--- a/docs/architecture/aesthetic-engine-adaptation.md
+++ b/docs/architecture/aesthetic-engine-adaptation.md
@@ -26,7 +26,7 @@ Nexo carries **portable visual intent** in `AestheticPack`. Game engines (Unity,
 
 ## Mapbox tiles (shared kernel)
 
-`Nexo.GameDomain.Maps` provides **`MapboxTileUrls`**, **`MapboxWebMercatorTileMath`**, and **`MapboxTileResponseValidators`** for host-agnostic URL construction and HTTP response checks. **Never** embed access tokens in source; use environment variables or secret stores.
+`Nexo.Commercial.GameDomain` (`Nexo.GameDomain.Maps`) provides **`MapboxTileUrls`**, **`MapboxWebMercatorTileMath`**, and **`MapboxTileResponseValidators`** for host-agnostic URL construction and HTTP response checks. **Never** embed access tokens in source; use environment variables or secret stores.
 
 ## Precedence (recommended)
 
@@ -35,4 +35,4 @@ Nexo carries **portable visual intent** in `AestheticPack`. Game engines (Unity,
 
 ## Unity-specific descriptors
 
-Types under `Nexo.GameDomain.Assets` and many `Descriptors` still mention Unity in comments. Treat them as **legacy host projections**; new cross-engine work should prefer `AestheticPack` + neutral descriptors or parallel DTOs in a consuming repo.
+Types under `Nexo.Commercial.GameDomain` (`Nexo.GameDomain.Assets`, `Descriptors`, etc.) still mention Unity in comments. Treat them as **legacy host projections**; new cross-engine work should prefer `AestheticPack` + neutral descriptors or parallel DTOs in a consuming repo.

--- a/docs/architecture/forge-map-adaptation.md
+++ b/docs/architecture/forge-map-adaptation.md
@@ -1,6 +1,6 @@
 # Forge map adaptation and engine manifests
 
-Runtime types live in **`Nexo.GameDomain`**; HTTP surface in **`Nexo.API`** (`ForgeEndpoints`).
+Runtime types live in **`Nexo.Commercial.GameDomain`** (`Nexo.GameDomain` namespace); HTTP surface in **`Nexo.Commercial.GameDirector.Host`** (`ForgeEndpoints` in `Nexo.Commercial.GameDirector.Mcp`).
 
 ## Map adaptation plan
 

--- a/docs/architecture/forge-map-host-integration.md
+++ b/docs/architecture/forge-map-host-integration.md
@@ -1,6 +1,6 @@
 # Forge map host integration (milestones)
 
-This document tracks **host-side** work that sits next to runtime types in **`Nexo.GameDomain`** and HTTP endpoints in **`Nexo.API`**.
+This document tracks **host-side** work that sits next to runtime types in **`Nexo.Commercial.GameDomain`** (`Nexo.GameDomain` namespace) and HTTP endpoints in **`Nexo.Commercial.GameDirector.Host`** (`ForgeEndpoints` in `Nexo.Commercial.GameDirector.Mcp`).
 
 ## M1 — Engine aesthetic manifest
 
@@ -55,7 +55,7 @@ This document tracks **host-side** work that sits next to runtime types in **`Ne
 
 ## M6 — Material / aesthetic assist (implemented)
 
-**Goal:** Surface procedural colours and shader-parameter hints aligned with **`EngineSurfaceBinding`** roles without requiring tessellation in Nexo.API.
+**Goal:** Surface procedural colours and shader-parameter hints aligned with **`EngineSurfaceBinding`** roles without requiring tessellation in the Game Director host.
 
 **Implemented in-repo:**
 

--- a/docs/architecture/runtime-vs-application.md
+++ b/docs/architecture/runtime-vs-application.md
@@ -1,13 +1,14 @@
 # Runtime vs application boundary
 
-This monorepo keeps **kernel/runtime libraries** under `src/` and **application surfaces** under `application/src/` (CLI, HTTP API, Forge/game descriptors). The same split matters when you consume Nexo as **NuGet packages** from another repository.
+This monorepo keeps **kernel/runtime libraries** under `src/` and **open application surfaces** under `application/src/` (CLI, HTTP API). Forge/game descriptors and the Game Director host live under **`commercial/`**. The same split matters when you consume Nexo as **NuGet packages** from another repository.
 
 ## Layout in this repository
 
 | Location | Role |
 |----------|------|
 | `src/` | Execution kernel: abstractions, core, hosting library, infrastructure, orchestration, runtime, agents, ingress adapters, and tests for the kernel graph |
-| `application/src/` | Product hosts: `Nexo.API`, `Nexo.CLI`, `Nexo.GameDomain`, plus tests such as `Nexo.Tests.GameDomain` |
+| `application/src/` | Open product hosts: `Nexo.API`, `Nexo.CLI`, plus `Nexo.Tests.CLI` |
+| `commercial/` | Commercial vertical: `Nexo.Commercial.GameDomain`, Game Director host/MCP, and `Nexo.Commercial.Tests.GameDomain` |
 
 ## Runtime layer (NuGet / embeddable graph)
 
@@ -51,7 +52,7 @@ Product-specific deployables and descriptors stay under **`application/src/`** i
 | File | Purpose |
 |------|---------|
 | `Nexo.Runtime.sln` | Runtime kernel graph for CI and publishing libraries (and `Nexo.Runtime.Bundle`). |
-| `application/Nexo.Application.sln` | `application/src/*` projects (CLI, API, GameDomain, application tests). |
+| `application/Nexo.Application.sln` | Open `application/src/*` plus commercial GameDomain projects referenced for local dev. |
 | `Nexo.sln` | Full monorepo: kernel, clients, infrastructure tests, `Nexo.Runtime.Bundle`, ingress projects, etc. Application code is built via **`dotnet build application/Nexo.Application.sln`** when you only need product surfaces. |
 
 Build application layer:

--- a/src/Nexo.Core.Application/Environments/MaterialIntelligenceModels.cs
+++ b/src/Nexo.Core.Application/Environments/MaterialIntelligenceModels.cs
@@ -2,7 +2,7 @@ namespace Nexo.Core.Application.Environments;
 
 /// <summary>
 /// Suggested material parameters and texture-generation hints for the engine adaptation layer.
-/// Maps naturally to <c>Nexo.GameDomain.Assets.MaterialDescriptor</c> (paths filled after image bake).
+/// Maps naturally to <c>Nexo.Commercial.GameDomain</c> <c>MaterialDescriptor</c> (paths filled after image bake).
 /// </summary>
 /// <param name="Id">Stable material id.</param>
 /// <param name="Name">Display name.</param>

--- a/src/Nexo.Runtime.Bundle/README.md
+++ b/src/Nexo.Runtime.Bundle/README.md
@@ -9,7 +9,7 @@ See `docs/architecture/runtime-vs-application.md` in this repository for the bou
 ## What is not included
 
 - **`Nexo.Hosting`** — composition root (`AddNexo`). Reference it separately when you want the stock DI graph, or register services yourself in your application repo.
-- **`Nexo.API`**, **`Nexo.CLI`**, **`Nexo.GameDomain`** — product / application surfaces stay out of this bundle by design.
+- **`Nexo.API`**, **`Nexo.CLI`**, and commercial Forge/GameDirector projects — product / application surfaces stay out of this bundle by design.
 
 ## Related
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-extraction doc hygiene: update stale references that still described Forge/GameDomain as living under open `application/src/` and `Nexo.API`.

## Changes

- Point architecture and application docs at `commercial/src/Nexo.Commercial.GameDomain` and `Nexo.Commercial.GameDirector.Host` for Forge HTTP.
- Update `NexoForge.md`, forge-map docs, `runtime-vs-application.md`, `TestingModel.md`, and bundle README.
- Refresh `ForgeMapHostSample` default base URL to Game Director host (`http://127.0.0.1:8080`).
- Clarify XML doc on `MaterialIntelligenceModels` (commercial GameDomain path).

## Validation

- Doc-only change; no runtime logic changes beyond sample default URL.
- RC gates to run on `master` separately.

## Related

- Follows commercial extraction merge (#151), Phase D licensing (#152), and orphaned GameDomain removal (#153).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

