### PR TITLE
feat(product): Product Fleet Phase 0 foundation (tenant, usage, Private deploy)

### DIFF
--- a/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -8,6 +8,7 @@ using Nexo.BrickContracts.Capabilities;
 using Nexo.Contracts;
 using Nexo.Core.Application.Copilot.Models;
 using Nexo.Core.Application.Copilot.Ports;
+using Nexo.Core.Application.Product.Ports;
 using Nexo.Core.Application.Knowledge.Models;
 using Nexo.Core.Application.Knowledge.Ports;
 using Nexo.Core.Application.Agent.UseCases.RunAgent;
@@ -92,6 +93,12 @@ public static class NexoEndpoints
             .WithName("ListCopilotTasks")
             .WithSummary("List recent copilot tasks (newest first)")
             .Produces<IReadOnlyList<CopilotTaskRecord>>(StatusCodes.Status200OK);
+
+        group.MapGet("/usage/summary", GetUsageSummaryAsync)
+            .WithName("GetUsageSummary")
+            .WithSummary("Rolling usage counters for the resolved tenant (Product Fleet Phase 0.3)")
+            .Produces<Nexo.Core.Application.Product.Models.TenantUsageSummary>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
 
         group.MapGet("/status", GetStatusAsync)
             .WithName("GetStatus")
@@ -337,6 +344,7 @@ public static class NexoEndpoints
         [FromServices] IAccessBoundary? accessBoundary,
         [FromServices] IOptions<NexoProductOptions> productOptions,
         [FromServices] ICopilotSubmissionQuota copilotSubmissionQuota,
+        [FromServices] ITenantUsageStore usageStore,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
@@ -350,6 +358,7 @@ public static class NexoEndpoints
             return Results.Json(new ProblemDetails { Title = "Too Many Requests", Detail = quotaMsg }, statusCode: StatusCodes.Status429TooManyRequests);
 
         var usageLogger = loggerFactory.CreateLogger("Nexo.Usage");
+        usageStore.RecordJobSubmitted(tenantId);
 
         var taskId = Guid.NewGuid().ToString("D");
         var submittedAt = DateTimeOffset.UtcNow;
@@ -382,6 +391,7 @@ public static class NexoEndpoints
                 Summary = summary,
                 Error = null
             }, cancellationToken);
+            usageStore.RecordJobCompleted(tenantId, result.Success);
             usageLogger.LogInformation(
                 "NexoUsage metric=copilot_job_completed tenant={TenantId} taskId={TaskId} success={Success}",
                 tenantId,
@@ -409,6 +419,7 @@ public static class NexoEndpoints
                 Summary = null,
                 Error = ex.Message
             }, cancellationToken);
+            usageStore.RecordJobCompleted(tenantId, success: false);
             usageLogger.LogInformation(
                 "NexoUsage metric=copilot_job_completed tenant={TenantId} taskId={TaskId} success={Success}",
                 tenantId,
@@ -418,6 +429,19 @@ public static class NexoEndpoints
                 detail: IsDevelopment() ? ex.Message : "An internal error occurred. Check server logs for details.",
                 statusCode: StatusCodes.Status500InternalServerError);
         }
+    }
+
+    private static Task<IResult> GetUsageSummaryAsync(
+        HttpContext httpContext,
+        [FromServices] ITenantUsageStore usageStore,
+        [FromServices] IOptions<NexoProductOptions> productOptions,
+        int hours = 24)
+    {
+        if (!NexoHttpTenant.TryResolve(httpContext.Request, productOptions.Value, out var tenantId, out var tenantError))
+            return Task.FromResult<IResult>(Results.BadRequest(new ProblemDetails { Title = "Invalid tenant", Detail = tenantError }));
+
+        var summary = usageStore.GetSummary(tenantId, hours);
+        return Task.FromResult<IResult>(Results.Ok(summary));
     }
 
     private static async Task<IResult> ListCopilotTasksAsync(

--- a/application/src/Nexo.API/Program.cs
+++ b/application/src/Nexo.API/Program.cs
@@ -49,6 +49,8 @@ using Nexo.API.Endpoints;
 using Nexo.API.Middleware.Ingress;
 using Nexo.API.Security;
 using Nexo.Core.Application.Middleware.Ports;
+using Nexo.Core.Application.Product.Ports;
+using Nexo.Infrastructure.Product;
 using Nexo.Contracts;
 using Nexo.BackgroundAgents.Extending;
 using Nexo.BackgroundAgents.HostRunners;
@@ -91,6 +93,7 @@ builder.Services.Configure<NexoEntitlementsOptions>(
     builder.Configuration.GetSection(NexoEntitlementsOptions.SectionPath));
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<ICopilotSubmissionQuota, CopilotSubmissionQuota>();
+builder.Services.AddSingleton<ITenantUsageStore, InMemoryTenantUsageStore>();
 builder.Services.Configure<MeshSecurityOptions>(
     builder.Configuration.GetSection(MeshSecurityOptions.SectionPath));
 builder.Services.Configure<SmsIngressDynamoDbOptions>(

--- a/application/src/Nexo.API/Security/NexoEntitlementsOptions.cs
+++ b/application/src/Nexo.API/Security/NexoEntitlementsOptions.cs
@@ -1,7 +1,8 @@
 namespace Nexo.API.Security;
 
 /// <summary>
-/// Thin quota knobs for multi-tenant shaping (hourly copilot submissions per tenant).
+/// Plan entitlements for multi-tenant shaping (Product Fleet Phase 0).
+/// Enforcement is incremental: copilot hourly quota is active; other fields are config hooks for Phase 0.2+.
 /// </summary>
 public sealed class NexoEntitlementsOptions
 {
@@ -9,4 +10,23 @@ public sealed class NexoEntitlementsOptions
 
     /// <summary>Zero means unlimited.</summary>
     public int MaxCopilotSubmissionsPerHour { get; set; }
+
+    /// <summary>Licensed seat count (0 = not enforced).</summary>
+    public int Seats { get; set; }
+
+    /// <summary>Included copilot/job units per billing period (0 = not enforced).</summary>
+    public int IncludedJobs { get; set; }
+
+    /// <summary>Max concurrent executions per tenant (0 = not enforced).</summary>
+    public int MaxConcurrency { get; set; }
+
+    /// <summary>Artifact/history retention in days (0 = platform default).</summary>
+    public int RetentionDays { get; set; }
+
+    public bool SsoEnabled { get; set; }
+
+    public bool AuditExportEnabled { get; set; }
+
+    /// <summary>e.g. Private, Cloud, Enterprise — documentation / license profile hint.</summary>
+    public string DeploymentMode { get; set; } = "";
 }

--- a/docker-compose.private-single-tenant.yml
+++ b/docker-compose.private-single-tenant.yml
@@ -1,0 +1,39 @@
+# Product Fleet Phase 0.4 — reference single-tenant Private shape (local dev / pilot).
+# See docs/product-fleet/private-reference-deployment.md
+services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama-models:/root/.ollama
+    restart: unless-stopped
+
+  nexo-api:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile.api
+    depends_on:
+      - ollama
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      OLLAMA_BASE_URL: http://ollama:11434
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-llama3.1:latest}
+      NEXO_DAILIES_PATH: /data/dailies
+      Nexo__Product__DefaultTenantId: ${NEXO_DEFAULT_TENANT_ID:-default}
+      Nexo__Product__AllowedTenantIds__0: ${NEXO_DEFAULT_TENANT_ID:-default}
+      Nexo__Entitlements__MaxCopilotSubmissionsPerHour: ${NEXO_MAX_COPILOT_PER_HOUR:-0}
+      Nexo__Entitlements__DeploymentMode: Private
+      Nexo__Entitlements__Seats: ${NEXO_SEATS:-5}
+      Nexo__Entitlements__MaxConcurrency: ${NEXO_MAX_CONCURRENCY:-2}
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - nexo-dailies:/data/dailies
+      - nexo-copilot-data:/data/copilot
+    restart: unless-stopped
+
+volumes:
+  ollama-models:
+  nexo-dailies:
+  nexo-copilot-data:

--- a/docs/ProductFleetImplementationRoadmap.md
+++ b/docs/ProductFleetImplementationRoadmap.md
@@ -15,10 +15,10 @@ This is the **engineering, operations, and go-to-market sequence** for turning t
 
 ## Phase 0 — Foundation (all products depend on this)
 
-| Step | What to implement | Done means |
-|------|-------------------|------------|
-| 0.1 | **Tenant model** end-to-end: stable `tenant_id` (or org id) on every job, audit row, artifact, and API key | Cross-tenant access tests fail in CI |
-| 0.2 | **Entitlements configuration** (file or DB) keyed by plan: seats, `included_jobs`, `max_concurrency`, `retention_days`, `sso_enabled`, `audit_export`, `deployment_mode` | Same binary runs with different config profiles (dev/staging/prod) |
+| Step | What to implement | Done means | Status |
+|------|-------------------|------------|--------|
+| 0.1 | **Tenant model** end-to-end: stable `tenant_id` (or org id) on every job, audit row, artifact, and API key | Cross-tenant access tests fail in CI | **In progress:** `X-Nexo-Tenant` on copilot API; `ProductFleetTenantIsolationTests` + `NexoHttpTenantTests` in CI |
+| 0.2 | **Entitlements configuration** (file or DB) keyed by plan: seats, `included_jobs`, `max_concurrency`, `retention_days`, `sso_enabled`, `audit_export`, `deployment_mode` | Same binary runs with different config profiles (dev/staging/prod) | **Started:** `NexoEntitlementsOptions` fields; copilot hourly quota enforced |
 | 0.3 | **Usage counters** (jobs submitted, jobs succeeded, tokens optional if BYOK proxy) emitted to logs or metrics table | You can answer “how many jobs per tenant last 24h?” |
 | 0.4 | **Reference deployment** documented: compose (or Helm) for “single-tenant production shape” matching what you sell as Private | New hire reproduces deploy from docs in one session |
 | 0.5 | **Observability baseline**: structured logs, health checks, redacted config export for support | On-call playbook v0.1 exists |

--- a/docs/ProductFleetImplementationRoadmap.md
+++ b/docs/ProductFleetImplementationRoadmap.md
@@ -19,8 +19,8 @@ This is the **engineering, operations, and go-to-market sequence** for turning t
 |------|-------------------|------------|--------|
 | 0.1 | **Tenant model** end-to-end: stable `tenant_id` (or org id) on every job, audit row, artifact, and API key | Cross-tenant access tests fail in CI | **In progress:** `X-Nexo-Tenant` on copilot API; `ProductFleetTenantIsolationTests` + `NexoHttpTenantTests` in CI |
 | 0.2 | **Entitlements configuration** (file or DB) keyed by plan: seats, `included_jobs`, `max_concurrency`, `retention_days`, `sso_enabled`, `audit_export`, `deployment_mode` | Same binary runs with different config profiles (dev/staging/prod) | **Started:** `NexoEntitlementsOptions` fields; copilot hourly quota enforced |
-| 0.3 | **Usage counters** (jobs submitted, jobs succeeded, tokens optional if BYOK proxy) emitted to logs or metrics table | You can answer “how many jobs per tenant last 24h?” |
-| 0.4 | **Reference deployment** documented: compose (or Helm) for “single-tenant production shape” matching what you sell as Private | New hire reproduces deploy from docs in one session |
+| 0.3 | **Usage counters** (jobs submitted, jobs succeeded, tokens optional if BYOK proxy) emitted to logs or metrics table | You can answer “how many jobs per tenant last 24h?” | **Started:** `ITenantUsageStore`, `GET /api/usage/summary`, structured `NexoUsage` logs |
+| 0.4 | **Reference deployment** documented: compose (or Helm) for “single-tenant production shape” matching what you sell as Private | New hire reproduces deploy from docs in one session | **Started:** `docker-compose.private-single-tenant.yml` + `docs/product-fleet/private-reference-deployment.md` |
 | 0.5 | **Observability baseline**: structured logs, health checks, redacted config export for support | On-call playbook v0.1 exists |
 | 0.6 | **Legal/commercial shell**: entity, basic ToS/Privacy for a website, DPA template if Cloud will hold customer data | Counsel-reviewed drafts (timing varies) |
 

--- a/docs/product-fleet/private-reference-deployment.md
+++ b/docs/product-fleet/private-reference-deployment.md
@@ -1,0 +1,72 @@
+# Private single-tenant reference deployment (Phase 0.4)
+
+This is the **smallest production-shaped** stack for Nexo Private pilots: one tenant, one API host, local Ollama, and entitlements driven from environment/config (no multi-tenant control plane).
+
+## Prerequisites
+
+- Docker and Docker Compose
+- ~8 GB RAM for Ollama + API (model-dependent)
+
+## Quick start
+
+```bash
+export OLLAMA_MODEL=llama3.1:latest
+export NEXO_DEFAULT_TENANT_ID=acme-pilot
+docker compose -f docker-compose.private-single-tenant.yml up --build -d
+```
+
+Wait for health:
+
+```bash
+curl -sS http://127.0.0.1:8080/health
+curl -sS http://127.0.0.1:8080/api/status
+```
+
+## Tenant and entitlements
+
+| Variable / config | Purpose |
+|-------------------|---------|
+| `NEXO_DEFAULT_TENANT_ID` | Default `X-Nexo-Tenant` when header omitted |
+| `Nexo__Product__AllowedTenantIds__0` | Allow-list (single tenant for Private) |
+| `Nexo__Entitlements__MaxCopilotSubmissionsPerHour` | Hourly copilot quota (`0` = unlimited) |
+| `Nexo__Entitlements__DeploymentMode` | License/profile hint (`Private`) |
+| `Nexo__Entitlements__Seats` / `MaxConcurrency` | Plan hooks (enforcement TBD) |
+
+Example copilot call with explicit tenant:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/api/copilot/task \
+  -H 'Content-Type: application/json' \
+  -H 'X-Nexo-Tenant: acme-pilot' \
+  -d '{"task":"Summarize open PRs"}'
+```
+
+Usage summary (last 24h for resolved tenant):
+
+```bash
+curl -sS 'http://127.0.0.1:8080/api/usage/summary?hours=24' \
+  -H 'X-Nexo-Tenant: acme-pilot'
+```
+
+## Volumes
+
+| Volume | Mount | Data |
+|--------|-------|------|
+| `nexo-dailies` | `/data/dailies` | Director dailies / run artifacts |
+| `nexo-copilot-data` | `/data/copilot` | Reserved for copilot persistence profiles |
+| `ollama-models` | Ollama | Model weights |
+
+## Upgrade / teardown
+
+```bash
+docker compose -f docker-compose.private-single-tenant.yml pull
+docker compose -f docker-compose.private-single-tenant.yml up -d --build
+docker compose -f docker-compose.private-single-tenant.yml down
+```
+
+For air-gapped installs, build images on a connected machine, `docker save`, transfer, and `docker load` on the target host.
+
+## Related
+
+- [`docs/ProductFleetImplementationRoadmap.md`](../ProductFleetImplementationRoadmap.md) — Phase 0 exit criteria
+- [`docker-compose.portal.yml`](../../docker-compose.portal.yml) — portal + Ollama without Private entitlements defaults

--- a/src/Nexo.Core.Application/Product/Models/TenantUsageSummary.cs
+++ b/src/Nexo.Core.Application/Product/Models/TenantUsageSummary.cs
@@ -1,0 +1,9 @@
+namespace Nexo.Core.Application.Product.Models;
+
+/// <summary>Aggregated usage for one tenant over a rolling window (Product Fleet Phase 0.3).</summary>
+public sealed record TenantUsageSummary(
+    string TenantId,
+    int WindowHours,
+    int JobsSubmitted,
+    int JobsSucceeded,
+    int JobsFailed);

--- a/src/Nexo.Core.Application/Product/Ports/ITenantUsageStore.cs
+++ b/src/Nexo.Core.Application/Product/Ports/ITenantUsageStore.cs
@@ -1,0 +1,15 @@
+using Nexo.Core.Application.Product.Models;
+
+namespace Nexo.Core.Application.Product.Ports;
+
+/// <summary>
+/// In-process usage counters per tenant (jobs submitted/succeeded). Phase 0.3 foundation for metering and billing hooks.
+/// </summary>
+public interface ITenantUsageStore
+{
+    void RecordJobSubmitted(string tenantId);
+
+    void RecordJobCompleted(string tenantId, bool success);
+
+    TenantUsageSummary GetSummary(string tenantId, int windowHours);
+}

--- a/src/Nexo.Infrastructure/Product/InMemoryTenantUsageStore.cs
+++ b/src/Nexo.Infrastructure/Product/InMemoryTenantUsageStore.cs
@@ -1,0 +1,58 @@
+using Nexo.Core.Application.Product.Models;
+using Nexo.Core.Application.Product.Ports;
+
+namespace Nexo.Infrastructure.Product;
+
+/// <summary>Thread-safe in-memory tenant usage counters (single-process; replace with durable store for Cloud).</summary>
+public sealed class InMemoryTenantUsageStore : ITenantUsageStore
+{
+    private readonly object _lock = new();
+    private readonly List<UsageEntry> _entries = [];
+
+    public void RecordJobSubmitted(string tenantId)
+        => Append(NormalizeTenant(tenantId), submitted: true, success: null);
+
+    public void RecordJobCompleted(string tenantId, bool success)
+        => Append(NormalizeTenant(tenantId), submitted: false, success: success);
+
+    public TenantUsageSummary GetSummary(string tenantId, int windowHours)
+    {
+        var tid = NormalizeTenant(tenantId);
+        var hours = Math.Clamp(windowHours, 1, 168);
+        var since = DateTimeOffset.UtcNow.AddHours(-hours);
+
+        lock (_lock)
+        {
+            PruneOlderThan(DateTimeOffset.UtcNow.AddDays(-7));
+            var window = _entries.Where(e => e.TenantId == tid && e.At >= since).ToList();
+            var submitted = window.Count(e => e.Submitted);
+            var completed = window.Where(e => e.Success.HasValue).ToList();
+            return new TenantUsageSummary(
+                tid,
+                hours,
+                submitted,
+                completed.Count(e => e.Success == true),
+                completed.Count(e => e.Success == false));
+        }
+    }
+
+    private void Append(string tenantId, bool submitted, bool? success)
+    {
+        lock (_lock)
+        {
+            _entries.Add(new UsageEntry(tenantId, DateTimeOffset.UtcNow, submitted, success));
+            if (_entries.Count > 50_000)
+                _entries.RemoveRange(0, _entries.Count - 40_000);
+        }
+    }
+
+    private void PruneOlderThan(DateTimeOffset cutoff)
+    {
+        _entries.RemoveAll(e => e.At < cutoff);
+    }
+
+    private static string NormalizeTenant(string tenantId)
+        => string.IsNullOrWhiteSpace(tenantId) ? "default" : tenantId.Trim();
+
+    private sealed record UsageEntry(string TenantId, DateTimeOffset At, bool Submitted, bool? Success);
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/API/CopilotSubmissionQuotaTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/CopilotSubmissionQuotaTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Nexo.API.Security;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+public sealed class CopilotSubmissionQuotaTests
+{
+    [Fact]
+    public void TryConsume_enforces_quota_per_tenant_independently()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var quota = new CopilotSubmissionQuota(
+            cache,
+            Options.Create(new NexoEntitlementsOptions { MaxCopilotSubmissionsPerHour = 1 }));
+
+        quota.TryConsume("tenant-a", out _).Should().BeTrue();
+        quota.TryConsume("tenant-a", out var deniedA).Should().BeFalse();
+        deniedA.Should().Contain("tenant-a");
+
+        quota.TryConsume("tenant-b", out _).Should().BeTrue();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/API/NexoHttpTenantTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/NexoHttpTenantTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nexo.API.Security;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+/// <summary>
+/// Product Fleet Phase 0.1 — tenant header resolution and allow-list enforcement.
+/// </summary>
+public sealed class NexoHttpTenantTests
+{
+    [Fact]
+    public void TryResolve_uses_default_when_header_missing()
+    {
+        var ctx = new DefaultHttpContext();
+        var options = new NexoProductOptions { DefaultTenantId = "acme" };
+
+        NexoHttpTenant.TryResolve(ctx.Request, options, out var tenantId, out var error).Should().BeTrue();
+        tenantId.Should().Be("acme");
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_accepts_header_when_allow_list_empty()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers[NexoHttpTenant.TenantHeaderName] = "tenant-b";
+        var options = new NexoProductOptions { DefaultTenantId = "default" };
+
+        NexoHttpTenant.TryResolve(ctx.Request, options, out var tenantId, out _).Should().BeTrue();
+        tenantId.Should().Be("tenant-b");
+    }
+
+    [Fact]
+    public void TryResolve_rejects_tenant_not_in_allow_list()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers[NexoHttpTenant.TenantHeaderName] = "rogue";
+        var options = new NexoProductOptions
+        {
+            DefaultTenantId = "default",
+            AllowedTenantIds = ["tenant-a", "tenant-b"],
+        };
+
+        NexoHttpTenant.TryResolve(ctx.Request, options, out _, out var error).Should().BeFalse();
+        error.Should().Contain("allow-list");
+    }
+
+    [Fact]
+    public void TryResolve_rejects_overlong_tenant_header()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers[NexoHttpTenant.TenantHeaderName] = new string('x', 129);
+        var options = new NexoProductOptions();
+
+        NexoHttpTenant.TryResolve(ctx.Request, options, out _, out var error).Should().BeFalse();
+        error.Should().Contain("128");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Copilot/LiteDbCopilotTaskStoreGapCoverageTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Copilot/LiteDbCopilotTaskStoreGapCoverageTests.cs
@@ -65,6 +65,45 @@ public sealed class LiteDbCopilotTaskStoreGapCoverageTests
     }
 
     [Fact]
+    public async Task QueryAsync_isolates_records_by_tenant()
+    {
+        var path = CreateTempDbPath();
+        try
+        {
+            var store = new LiteDbCopilotTaskStore(path);
+            var now = DateTimeOffset.UtcNow;
+            await store.StoreAsync(new CopilotTaskRecord
+            {
+                TaskId = "a-task",
+                Task = "tenant a",
+                SubmittedAt = now,
+                TenantId = "tenant-a",
+                Success = true,
+            });
+            await store.StoreAsync(new CopilotTaskRecord
+            {
+                TaskId = "b-task",
+                Task = "tenant b",
+                SubmittedAt = now,
+                TenantId = "tenant-b",
+                Success = true,
+            });
+
+            var aResults = await store.QueryAsync(tenantId: "tenant-a");
+            var bResults = await store.QueryAsync(tenantId: "tenant-b");
+
+            aResults.Should().ContainSingle(r => r.TaskId == "a-task");
+            bResults.Should().ContainSingle(r => r.TaskId == "b-task");
+            aResults.Should().NotContain(r => r.TaskId == "b-task");
+            bResults.Should().NotContain(r => r.TaskId == "a-task");
+        }
+        finally
+        {
+            TryDelete(path);
+        }
+    }
+
+    [Fact]
     public async Task QueryAsync_includes_default_tenant_records_with_null_or_empty_tenant()
     {
         var path = CreateTempDbPath();

--- a/src/Nexo.Tests.Infrastructure/Tests/Product/InMemoryTenantUsageStoreTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Product/InMemoryTenantUsageStoreTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Nexo.Infrastructure.Product;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Product;
+
+public sealed class InMemoryTenantUsageStoreTests
+{
+    [Fact]
+    public void GetSummary_isolates_tenants_and_counts_jobs()
+    {
+        var store = new InMemoryTenantUsageStore();
+        store.RecordJobSubmitted("tenant-a");
+        store.RecordJobCompleted("tenant-a", success: true);
+        store.RecordJobSubmitted("tenant-b");
+        store.RecordJobCompleted("tenant-b", success: false);
+
+        var a = store.GetSummary("tenant-a", windowHours: 24);
+        var b = store.GetSummary("tenant-b", windowHours: 24);
+
+        a.JobsSubmitted.Should().Be(1);
+        a.JobsSucceeded.Should().Be(1);
+        a.JobsFailed.Should().Be(0);
+
+        b.JobsSubmitted.Should().Be(1);
+        b.JobsSucceeded.Should().Be(0);
+        b.JobsFailed.Should().Be(1);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetTenantIsolationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetTenantIsolationTests.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Nexo.API.Security;
 using Nexo.Core.Application.Copilot.Models;
 using Nexo.Core.Application.Copilot.Ports;
+using Nexo.Core.Application.Product.Models;
+using Nexo.Core.Application.Product.Ports;
 using Nexo.Tests.Infrastructure.Helpers.VirtualProduction;
 using Xunit;
 
@@ -82,5 +84,30 @@ public sealed class ProductFleetTenantIsolationTests : IClassFixture<NexoApiWebA
         tasks.Should().NotBeNull();
         tasks!.Should().Contain(t => t.TaskId == "list-a");
         tasks.Should().NotContain(t => t.TaskId == "list-b");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GET_usage_summary_returns_counters_for_resolved_tenant_only()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var usage = scope.ServiceProvider.GetRequiredService<ITenantUsageStore>();
+            usage.RecordJobSubmitted("tenant-a");
+            usage.RecordJobCompleted("tenant-a", success: true);
+            usage.RecordJobSubmitted("tenant-b");
+            usage.RecordJobCompleted("tenant-b", success: false);
+        }
+
+        var client = _factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "api/usage/summary?hours=24");
+        request.Headers.TryAddWithoutValidation(NexoHttpTenant.TenantHeaderName, "tenant-a");
+
+        using var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var summary = await response.Content.ReadFromJsonAsync<TenantUsageSummary>();
+        summary.Should().NotBeNull();
+        summary!.TenantId.Should().Be("tenant-a");
+        summary.JobsSubmitted.Should().BeGreaterThanOrEqualTo(1);
+        summary.JobsSucceeded.Should().BeGreaterThanOrEqualTo(1);
     }
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetTenantIsolationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetTenantIsolationTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.API.Security;
+using Nexo.Core.Application.Copilot.Models;
+using Nexo.Core.Application.Copilot.Ports;
+using Nexo.Tests.Infrastructure.Helpers.VirtualProduction;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.VirtualProduction;
+
+/// <summary>
+/// Product Fleet Phase 0.1 — cross-tenant copilot task access must fail at the HTTP layer.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
+public sealed class ProductFleetTenantIsolationTests : IClassFixture<NexoApiWebApplicationFactory>
+{
+    private readonly NexoApiWebApplicationFactory _factory;
+
+    public ProductFleetTenantIsolationTests(NexoApiWebApplicationFactory factory) => _factory = factory;
+
+    [Fact(Timeout = 120000)]
+    public async Task GET_copilot_task_returns_not_found_for_other_tenant()
+    {
+        const string taskId = "phase0-cross-tenant-task";
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var store = scope.ServiceProvider.GetRequiredService<ICopilotTaskStore>();
+            await store.StoreAsync(new CopilotTaskRecord
+            {
+                TaskId = taskId,
+                TenantId = "tenant-a",
+                Task = "secret",
+                SubmittedAt = DateTimeOffset.UtcNow,
+                Success = true,
+            });
+        }
+
+        var client = _factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"api/copilot/tasks/{taskId}");
+        request.Headers.TryAddWithoutValidation(NexoHttpTenant.TenantHeaderName, "tenant-b");
+
+        using var response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GET_copilot_tasks_lists_only_resolved_tenant()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var store = scope.ServiceProvider.GetRequiredService<ICopilotTaskStore>();
+            var now = DateTimeOffset.UtcNow;
+            await store.StoreAsync(new CopilotTaskRecord
+            {
+                TaskId = "list-a",
+                TenantId = "tenant-a",
+                Task = "a",
+                SubmittedAt = now,
+                Success = true,
+            });
+            await store.StoreAsync(new CopilotTaskRecord
+            {
+                TaskId = "list-b",
+                TenantId = "tenant-b",
+                Task = "b",
+                SubmittedAt = now,
+                Success = true,
+            });
+        }
+
+        var client = _factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "api/copilot/tasks?maxCount=50");
+        request.Headers.TryAddWithoutValidation(NexoHttpTenant.TenantHeaderName, "tenant-a");
+
+        using var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var tasks = await response.Content.ReadFromJsonAsync<List<CopilotTaskRecord>>();
+        tasks.Should().NotBeNull();
+        tasks!.Should().Contain(t => t.TaskId == "list-a");
+        tasks.Should().NotContain(t => t.TaskId == "list-b");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product Fleet **Phase 0** foundation after commercial extraction (Phases A–F) and CLI mesh boundary (#155, #156).

## Phase 0.1 — Tenant model (in progress)

- `NexoHttpTenant` unit tests (allow-list, defaults, header length)
- `LiteDbCopilotTaskStore` tenant query isolation
- `ProductFleetTenantIsolationTests` — cross-tenant copilot GET/list (ProdStyle, net9)
- Per-tenant copilot hourly quota independence

## Phase 0.2 — Entitlements config (started)

- `NexoEntitlementsOptions` plan fields (`Seats`, `IncludedJobs`, `MaxConcurrency`, `RetentionDays`, `SsoEnabled`, `AuditExportEnabled`, `DeploymentMode`)
- Copilot hourly quota remains the only enforced limit

## Phase 0.3 — Usage counters (started)

- `ITenantUsageStore` + `InMemoryTenantUsageStore`
- Copilot submit/complete recorded on `/api/copilot/task`
- **`GET /api/usage/summary?hours=24`** per resolved tenant
- Structured `NexoUsage` logs retained

## Phase 0.4 — Reference deployment (started)

- `docker-compose.private-single-tenant.yml` — single-tenant Private pilot shape
- `docs/product-fleet/private-reference-deployment.md` — reproduce-from-docs guide

## Testing

- Phase 0 unit tests (net8) + integration tests (net9) — pass
- `make dependency-boundary-gate` — PASS

## Related

- Roadmap: `docs/ProductFleetImplementationRoadmap.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

