### PR TITLE
Product Fleet: Phase 0.5 observability + Phase 1 Private license

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,6 @@ http://host.docker.internal*
 
 # Public regulatory page blocks CI link-check user agents intermittently.
 https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai
+
+# Vendor blog returns 503 to CI user agents intermittently (see docs/ICPResearchMemo.md).
+https://codebrewtools.com/blogs/ai-native-internal-developer-portals-2026

--- a/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -27,6 +27,7 @@ using Nexo.Infrastructure.Execution;
 using Nexo.API.Security;
 using Nexo.Orchestration.Coordination;
 using Nexo.Orchestration.Models;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
@@ -99,6 +100,11 @@ public static class NexoEndpoints
             .WithSummary("Rolling usage counters for the resolved tenant (Product Fleet Phase 0.3)")
             .Produces<Nexo.Core.Application.Product.Models.TenantUsageSummary>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/support/diagnostics", GetSupportDiagnosticsAsync)
+            .WithName("GetSupportDiagnostics")
+            .WithSummary("Redacted support diagnostics export (Product Fleet Phase 0.5)")
+            .Produces<SupportDiagnosticsResponse>(StatusCodes.Status200OK);
 
         group.MapGet("/status", GetStatusAsync)
             .WithName("GetStatus")
@@ -392,6 +398,7 @@ public static class NexoEndpoints
                 Error = null
             }, cancellationToken);
             usageStore.RecordJobCompleted(tenantId, result.Success);
+            auditLog?.LogCopilotTask(tenantId, taskId, result.Success);
             usageLogger.LogInformation(
                 "NexoUsage metric=copilot_job_completed tenant={TenantId} taskId={TaskId} success={Success}",
                 tenantId,
@@ -420,6 +427,7 @@ public static class NexoEndpoints
                 Error = ex.Message
             }, cancellationToken);
             usageStore.RecordJobCompleted(tenantId, success: false);
+            auditLog?.LogCopilotTask(tenantId, taskId, success: false);
             usageLogger.LogInformation(
                 "NexoUsage metric=copilot_job_completed tenant={TenantId} taskId={TaskId} success={Success}",
                 tenantId,
@@ -429,6 +437,24 @@ public static class NexoEndpoints
                 detail: IsDevelopment() ? ex.Message : "An internal error occurred. Check server logs for details.",
                 statusCode: StatusCodes.Status500InternalServerError);
         }
+    }
+
+    private static Task<IResult> GetSupportDiagnosticsAsync(
+        [FromServices] IConfiguration configuration,
+        [FromServices] IHostEnvironment environment,
+        [FromServices] IOptions<NexoEntitlementsOptions> entitlementsOptions,
+        [FromServices] IOptions<NexoProductOptions> productOptions,
+        [FromServices] IOptions<NexoSecurityOptions> securityOptions,
+        [FromServices] IPrivateLicenseValidator licenseValidator)
+    {
+        var diagnostics = SupportDiagnosticsExporter.Build(
+            configuration,
+            environment,
+            entitlementsOptions.Value,
+            productOptions.Value,
+            securityOptions.Value,
+            licenseValidator.GetStatus());
+        return Task.FromResult<IResult>(Results.Ok(diagnostics));
     }
 
     private static Task<IResult> GetUsageSummaryAsync(

--- a/application/src/Nexo.API/Program.cs
+++ b/application/src/Nexo.API/Program.cs
@@ -91,6 +91,9 @@ builder.Services.Configure<NexoProductOptions>(
     builder.Configuration.GetSection(NexoProductOptions.SectionPath));
 builder.Services.Configure<NexoEntitlementsOptions>(
     builder.Configuration.GetSection(NexoEntitlementsOptions.SectionPath));
+builder.Services.Configure<NexoPrivateLicenseOptions>(
+    builder.Configuration.GetSection(NexoPrivateLicenseOptions.SectionPath));
+builder.Services.AddSingleton<IPrivateLicenseValidator, PrivateLicenseValidator>();
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<ICopilotSubmissionQuota, CopilotSubmissionQuota>();
 builder.Services.AddSingleton<ITenantUsageStore, InMemoryTenantUsageStore>();
@@ -249,6 +252,7 @@ app.UseStaticFiles();
 app.UseNexoMeshCorrelation();
 app.UseNexoMeshSecurity();
 app.UseNexoApiKeyAuth();
+app.UsePrivateLicenseGate();
 app.UseNexoCopilotScopedAuthorization();
 
 app.UseRateLimiter();

--- a/application/src/Nexo.API/Security/IPrivateLicenseValidator.cs
+++ b/application/src/Nexo.API/Security/IPrivateLicenseValidator.cs
@@ -1,0 +1,6 @@
+namespace Nexo.API.Security;
+
+public interface IPrivateLicenseValidator
+{
+    PrivateLicenseStatus GetStatus();
+}

--- a/application/src/Nexo.API/Security/NexoPrivateLicenseOptions.cs
+++ b/application/src/Nexo.API/Security/NexoPrivateLicenseOptions.cs
@@ -1,0 +1,21 @@
+namespace Nexo.API.Security;
+
+/// <summary>
+/// Private deployment license gate (Product Fleet Phase 1.2).
+/// </summary>
+public sealed class NexoPrivateLicenseOptions
+{
+    public const string SectionPath = "Nexo:PrivateLicense";
+
+    /// <summary>When false, license checks are advisory only (logged, not enforced).</summary>
+    public bool EnforceLicense { get; set; }
+
+    /// <summary>Path to signed license JSON. Overridden by <c>NEXO_LICENSE_FILE</c> when set.</summary>
+    public string? LicenseFilePath { get; set; }
+
+    /// <summary>Optional HMAC secret for verifying the <c>signature</c> field in the license file.</summary>
+    public string? HmacSecret { get; set; }
+
+    /// <summary>When license is expired, allow GET/read APIs but block mutating routes.</summary>
+    public bool AllowReadOnlyWhenExpired { get; set; } = true;
+}

--- a/application/src/Nexo.API/Security/PrivateLicenseDocument.cs
+++ b/application/src/Nexo.API/Security/PrivateLicenseDocument.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Nexo.API.Security;
+
+/// <summary>On-disk Private license payload (JSON).</summary>
+public sealed class PrivateLicenseDocument
+{
+    public string CustomerId { get; set; } = "";
+
+    public string TenantId { get; set; } = "";
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    public int Seats { get; set; }
+
+    /// <summary>Base64 HMAC-SHA256 over canonical JSON without this field.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Signature { get; set; }
+}

--- a/application/src/Nexo.API/Security/PrivateLicenseMiddleware.cs
+++ b/application/src/Nexo.API/Security/PrivateLicenseMiddleware.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Nexo.API.Security;
+
+/// <summary>
+/// Blocks mutating API routes when the Private license is expired or invalid.
+/// </summary>
+public sealed class PrivateLicenseMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly NexoPrivateLicenseOptions _options;
+    private readonly IPrivateLicenseValidator _validator;
+
+    public PrivateLicenseMiddleware(
+        RequestDelegate next,
+        IOptions<NexoPrivateLicenseOptions> optionsAccessor,
+        IPrivateLicenseValidator validator)
+    {
+        _next = next;
+        _options = optionsAccessor.Value;
+        _validator = validator;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!_options.EnforceLicense || !ShouldEvaluate(context.Request))
+        {
+            await _next(context);
+            return;
+        }
+
+        var status = _validator.GetStatus();
+        if (!status.BlocksMutatingRequests)
+        {
+            await _next(context);
+            return;
+        }
+
+        if (_options.AllowReadOnlyWhenExpired &&
+            !IsMutatingMethod(context.Request.Method) &&
+            context.Request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase))
+        {
+            await _next(context);
+            return;
+        }
+
+        context.Response.StatusCode = status.State == PrivateLicenseState.Expired
+            ? StatusCodes.Status402PaymentRequired
+            : StatusCodes.Status403Forbidden;
+        context.Response.ContentType = "application/json";
+        var title = status.State == PrivateLicenseState.Expired ? "License expired" : "License invalid";
+        var detail = status.Detail ?? title;
+        await context.Response.WriteAsync(
+            "{\"title\":\"" + EscapeJson(title) + "\",\"detail\":\"" + EscapeJson(detail) + "\"}");
+    }
+
+    private static bool ShouldEvaluate(HttpRequest request)
+    {
+        if (request.Path.StartsWithSegments("/health", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (request.Path.StartsWithSegments("/api/support/diagnostics", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsMutatingMethod(string method) =>
+        HttpMethods.IsPost(method) ||
+        HttpMethods.IsPut(method) ||
+        HttpMethods.IsPatch(method) ||
+        HttpMethods.IsDelete(method);
+
+    private static string EscapeJson(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+}
+
+public static class PrivateLicenseMiddlewareExtensions
+{
+    public static IApplicationBuilder UsePrivateLicenseGate(this IApplicationBuilder app) =>
+        app.UseMiddleware<PrivateLicenseMiddleware>();
+}

--- a/application/src/Nexo.API/Security/PrivateLicenseStatus.cs
+++ b/application/src/Nexo.API/Security/PrivateLicenseStatus.cs
@@ -1,0 +1,27 @@
+namespace Nexo.API.Security;
+
+public enum PrivateLicenseState
+{
+    NotConfigured,
+    Valid,
+    Expired,
+    Invalid,
+}
+
+public sealed class PrivateLicenseStatus
+{
+    public PrivateLicenseState State { get; init; }
+
+    public string? CustomerId { get; init; }
+
+    public string? TenantId { get; init; }
+
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    public int Seats { get; init; }
+
+    public string? Detail { get; init; }
+
+    public bool BlocksMutatingRequests =>
+        State is PrivateLicenseState.Expired or PrivateLicenseState.Invalid;
+}

--- a/application/src/Nexo.API/Security/PrivateLicenseValidator.cs
+++ b/application/src/Nexo.API/Security/PrivateLicenseValidator.cs
@@ -1,0 +1,163 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Nexo.API.Security;
+
+/// <summary>
+/// Loads and validates the on-disk Private license file.
+/// </summary>
+public sealed class PrivateLicenseValidator : IPrivateLicenseValidator
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false,
+    };
+
+    private readonly NexoPrivateLicenseOptions _options;
+    private readonly IHostEnvironment _environment;
+    private readonly ILogger<PrivateLicenseValidator> _logger;
+    private readonly object _sync = new();
+    private PrivateLicenseStatus? _cached;
+
+    public PrivateLicenseValidator(
+        IOptions<NexoPrivateLicenseOptions> optionsAccessor,
+        IHostEnvironment environment,
+        ILogger<PrivateLicenseValidator> logger)
+    {
+        _options = optionsAccessor.Value;
+        _environment = environment;
+        _logger = logger;
+    }
+
+    public PrivateLicenseStatus GetStatus()
+    {
+        lock (_sync)
+        {
+            return _cached ??= Evaluate();
+        }
+    }
+
+    private PrivateLicenseStatus Evaluate()
+    {
+        var path = ResolveLicensePath();
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return new PrivateLicenseStatus
+            {
+                State = PrivateLicenseState.NotConfigured,
+                Detail = "No license file configured.",
+            };
+        }
+
+        if (!File.Exists(path))
+        {
+            _logger.LogWarning("Private license file not found at {Path}", path);
+            return new PrivateLicenseStatus
+            {
+                State = PrivateLicenseState.Invalid,
+                Detail = $"License file not found: {path}",
+            };
+        }
+
+        PrivateLicenseDocument document;
+        try
+        {
+            var json = File.ReadAllText(path);
+            document = JsonSerializer.Deserialize<PrivateLicenseDocument>(json, JsonOptions)
+                       ?? throw new InvalidOperationException("License JSON deserialized to null.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse private license file at {Path}", path);
+            return new PrivateLicenseStatus
+            {
+                State = PrivateLicenseState.Invalid,
+                Detail = "License file could not be parsed.",
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(_options.HmacSecret))
+        {
+            if (string.IsNullOrWhiteSpace(document.Signature))
+            {
+                return Invalid("License signature is required but missing.");
+            }
+
+            if (!VerifySignature(document, _options.HmacSecret.Trim()))
+            {
+                return Invalid("License signature verification failed.");
+            }
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (document.ExpiresAt <= now)
+        {
+            return new PrivateLicenseStatus
+            {
+                State = PrivateLicenseState.Expired,
+                CustomerId = document.CustomerId,
+                TenantId = document.TenantId,
+                ExpiresAt = document.ExpiresAt,
+                Seats = document.Seats,
+                Detail = $"License expired at {document.ExpiresAt:O}.",
+            };
+        }
+
+        return new PrivateLicenseStatus
+        {
+            State = PrivateLicenseState.Valid,
+            CustomerId = document.CustomerId,
+            TenantId = document.TenantId,
+            ExpiresAt = document.ExpiresAt,
+            Seats = document.Seats,
+        };
+    }
+
+    private string? ResolveLicensePath()
+    {
+        var env = Environment.GetEnvironmentVariable("NEXO_LICENSE_FILE");
+        if (!string.IsNullOrWhiteSpace(env))
+            return Path.IsPathRooted(env.Trim())
+                ? env.Trim()
+                : Path.GetFullPath(Path.Combine(_environment.ContentRootPath, env.Trim()));
+
+        var configured = _options.LicenseFilePath;
+        if (string.IsNullOrWhiteSpace(configured))
+            return null;
+
+        return Path.IsPathRooted(configured.Trim())
+            ? configured.Trim()
+            : Path.GetFullPath(Path.Combine(_environment.ContentRootPath, configured.Trim()));
+    }
+
+    private static bool VerifySignature(PrivateLicenseDocument document, string secret)
+    {
+        var canonical = JsonSerializer.Serialize(new
+        {
+            customerId = document.CustomerId,
+            tenantId = document.TenantId,
+            expiresAt = document.ExpiresAt,
+            seats = document.Seats,
+        }, JsonOptions);
+
+        var key = Encoding.UTF8.GetBytes(secret);
+        var payload = Encoding.UTF8.GetBytes(canonical);
+        var computed = Convert.ToBase64String(HMACSHA256.HashData(key, payload));
+        var provided = document.Signature!.Trim();
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(computed),
+            Encoding.UTF8.GetBytes(provided));
+    }
+
+    private static PrivateLicenseStatus Invalid(string detail) =>
+        new()
+        {
+            State = PrivateLicenseState.Invalid,
+            Detail = detail,
+        };
+}

--- a/application/src/Nexo.API/Security/SupportDiagnosticsExporter.cs
+++ b/application/src/Nexo.API/Security/SupportDiagnosticsExporter.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Nexo.API.Security;
+
+/// <summary>
+/// Redacted support bundle for on-call (Product Fleet Phase 0.5).
+/// </summary>
+public static class SupportDiagnosticsExporter
+{
+    private static readonly HashSet<string> SensitiveKeyFragments = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "password",
+        "secret",
+        "token",
+        "apikey",
+        "api_key",
+        "bearer",
+        "hmac",
+        "privatekey",
+        "private_key",
+        "connectionstring",
+        "connection_string",
+    };
+
+    public static SupportDiagnosticsResponse Build(
+        IConfiguration configuration,
+        IHostEnvironment environment,
+        NexoEntitlementsOptions entitlements,
+        NexoProductOptions product,
+        NexoSecurityOptions security,
+        PrivateLicenseStatus licenseStatus)
+    {
+        var version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "unknown";
+
+        return new SupportDiagnosticsResponse
+        {
+            ExportedAt = DateTimeOffset.UtcNow,
+            Application = "Nexo.API",
+            Version = version,
+            Environment = environment.EnvironmentName,
+            DeploymentMode = entitlements.DeploymentMode,
+            Product = new SupportDiagnosticsProductSection
+            {
+                DefaultTenantId = product.DefaultTenantId,
+                AllowedTenantCount = (product.AllowedTenantIds ?? []).Count(x => !string.IsNullOrWhiteSpace(x)),
+            },
+            Entitlements = new SupportDiagnosticsEntitlementsSection
+            {
+                MaxCopilotSubmissionsPerHour = entitlements.MaxCopilotSubmissionsPerHour,
+                Seats = entitlements.Seats,
+                IncludedJobs = entitlements.IncludedJobs,
+                MaxConcurrency = entitlements.MaxConcurrency,
+                RetentionDays = entitlements.RetentionDays,
+                SsoEnabled = entitlements.SsoEnabled,
+                AuditExportEnabled = entitlements.AuditExportEnabled,
+            },
+            Security = new SupportDiagnosticsSecuritySection
+            {
+                ExposureProfile = security.ExposureProfile,
+                AuthorizationMode = security.AuthorizationMode,
+                AuthorizationScope = security.AuthorizationScope,
+                RequireAuthForCopilotReadApis = security.RequireAuthForCopilotReadApis,
+                ApiKeyConfigured = !string.IsNullOrWhiteSpace(security.ApiKey),
+                BearerTokenConfigured = !string.IsNullOrWhiteSpace(security.BearerToken),
+                BasicAuthConfigured = !string.IsNullOrWhiteSpace(security.BasicAuthUsername)
+                                       && !string.IsNullOrWhiteSpace(security.BasicAuthPassword),
+            },
+            License = new SupportDiagnosticsLicenseSection
+            {
+                State = licenseStatus.State.ToString(),
+                CustomerId = licenseStatus.CustomerId,
+                TenantId = licenseStatus.TenantId,
+                ExpiresAt = licenseStatus.ExpiresAt,
+                Seats = licenseStatus.Seats,
+                Detail = licenseStatus.Detail,
+                Enforced = configuration.GetValue<bool>($"{NexoPrivateLicenseOptions.SectionPath}:EnforceLicense"),
+            },
+            RedactedConfiguration = RedactConfiguration(configuration),
+        };
+    }
+
+    private static IReadOnlyDictionary<string, string?> RedactConfiguration(IConfiguration configuration)
+    {
+        var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var child in configuration.AsEnumerable())
+        {
+            if (string.IsNullOrEmpty(child.Key) || child.Value is null)
+                continue;
+
+            if (!child.Key.StartsWith("Nexo:", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            result[child.Key] = IsSensitiveKey(child.Key) ? "***REDACTED***" : child.Value;
+        }
+
+        return result;
+    }
+
+    private static bool IsSensitiveKey(string key)
+    {
+        foreach (var fragment in SensitiveKeyFragments)
+        {
+            if (key.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}
+
+public sealed class SupportDiagnosticsResponse
+{
+    public DateTimeOffset ExportedAt { get; init; }
+
+    public string Application { get; init; } = "";
+
+    public string Version { get; init; } = "";
+
+    public string Environment { get; init; } = "";
+
+    public string DeploymentMode { get; init; } = "";
+
+    public SupportDiagnosticsProductSection Product { get; init; } = new();
+
+    public SupportDiagnosticsEntitlementsSection Entitlements { get; init; } = new();
+
+    public SupportDiagnosticsSecuritySection Security { get; init; } = new();
+
+    public SupportDiagnosticsLicenseSection License { get; init; } = new();
+
+    public IReadOnlyDictionary<string, string?> RedactedConfiguration { get; init; }
+        = new Dictionary<string, string?>();
+}
+
+public sealed class SupportDiagnosticsProductSection
+{
+    public string DefaultTenantId { get; init; } = "";
+
+    public int AllowedTenantCount { get; init; }
+}
+
+public sealed class SupportDiagnosticsEntitlementsSection
+{
+    public int MaxCopilotSubmissionsPerHour { get; init; }
+
+    public int Seats { get; init; }
+
+    public int IncludedJobs { get; init; }
+
+    public int MaxConcurrency { get; init; }
+
+    public int RetentionDays { get; init; }
+
+    public bool SsoEnabled { get; init; }
+
+    public bool AuditExportEnabled { get; init; }
+}
+
+public sealed class SupportDiagnosticsSecuritySection
+{
+    public string ExposureProfile { get; init; } = "";
+
+    public string AuthorizationMode { get; init; } = "";
+
+    public string AuthorizationScope { get; init; } = "";
+
+    public bool RequireAuthForCopilotReadApis { get; init; }
+
+    public bool ApiKeyConfigured { get; init; }
+
+    public bool BearerTokenConfigured { get; init; }
+
+    public bool BasicAuthConfigured { get; init; }
+}
+
+public sealed class SupportDiagnosticsLicenseSection
+{
+    public string State { get; init; } = "";
+
+    public string? CustomerId { get; init; }
+
+    public string? TenantId { get; init; }
+
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    public int Seats { get; init; }
+
+    public string? Detail { get; init; }
+
+    public bool Enforced { get; init; }
+}

--- a/application/src/Nexo.API/appsettings.json
+++ b/application/src/Nexo.API/appsettings.json
@@ -79,6 +79,12 @@
     "Entitlements": {
       "MaxCopilotSubmissionsPerHour": 0
     },
+    "PrivateLicense": {
+      "EnforceLicense": false,
+      "LicenseFilePath": null,
+      "HmacSecret": null,
+      "AllowReadOnlyWhenExpired": true
+    },
     "ForgeSession": {
       "LiteDbPath": null,
       "TenantHeaderName": "X-Forge-Tenant",

--- a/docker-compose.private-single-tenant.yml
+++ b/docker-compose.private-single-tenant.yml
@@ -26,6 +26,9 @@ services:
       Nexo__Entitlements__DeploymentMode: Private
       Nexo__Entitlements__Seats: ${NEXO_SEATS:-5}
       Nexo__Entitlements__MaxConcurrency: ${NEXO_MAX_CONCURRENCY:-2}
+      NEXO_LICENSE_FILE: ${NEXO_LICENSE_FILE:-}
+      Nexo__PrivateLicense__EnforceLicense: ${NEXO_ENFORCE_LICENSE:-false}
+      Nexo__PrivateLicense__AllowReadOnlyWhenExpired: "true"
     ports:
       - "127.0.0.1:8080:8080"
     volumes:

--- a/docs/ProductFleetImplementationRoadmap.md
+++ b/docs/ProductFleetImplementationRoadmap.md
@@ -21,7 +21,7 @@ This is the **engineering, operations, and go-to-market sequence** for turning t
 | 0.2 | **Entitlements configuration** (file or DB) keyed by plan: seats, `included_jobs`, `max_concurrency`, `retention_days`, `sso_enabled`, `audit_export`, `deployment_mode` | Same binary runs with different config profiles (dev/staging/prod) | **Started:** `NexoEntitlementsOptions` fields; copilot hourly quota enforced |
 | 0.3 | **Usage counters** (jobs submitted, jobs succeeded, tokens optional if BYOK proxy) emitted to logs or metrics table | You can answer “how many jobs per tenant last 24h?” | **Started:** `ITenantUsageStore`, `GET /api/usage/summary`, structured `NexoUsage` logs |
 | 0.4 | **Reference deployment** documented: compose (or Helm) for “single-tenant production shape” matching what you sell as Private | New hire reproduces deploy from docs in one session | **Started:** `docker-compose.private-single-tenant.yml` + `docs/product-fleet/private-reference-deployment.md` |
-| 0.5 | **Observability baseline**: structured logs, health checks, redacted config export for support | On-call playbook v0.1 exists |
+| 0.5 | **Observability baseline**: structured logs, health checks, redacted config export for support | On-call playbook v0.1 exists | **Started:** `GET /api/support/diagnostics`, copilot audit `TenantId`, [`on-call-playbook-v0.1.md`](./product-fleet/on-call-playbook-v0.1.md) |
 | 0.6 | **Legal/commercial shell**: entity, basic ToS/Privacy for a website, DPA template if Cloud will hold customer data | Counsel-reviewed drafts (timing varies) |
 
 **Exit:** you can run **one production-shaped tenant** with measurable usage and no ambiguous identity.
@@ -32,12 +32,12 @@ This is the **engineering, operations, and go-to-market sequence** for turning t
 
 Private is usually **less COGS risk** and forces **install, upgrade, and air-gap** clarity early.
 
-| Step | What to implement | Done means |
-|------|-------------------|------------|
-| 1.1 | **Install path**: pinned images, versioned release artifacts, migration notes | Customer upgrades one minor version without data loss |
-| 1.2 | **License or subscription check** (even v0: signed JWT license file or online activation with **air-gap fallback**) | Expired license degrades gracefully (read-only or block execution—your policy, documented) |
-| 1.3 | **Secrets**: BYOK storage for provider keys; document what never leaves host | Security one-pager accurate |
-| 1.4 | **Backup/restore** runbook + tested restore for DB and object stores you use | RPO/RTO stated on support page |
+| Step | What to implement | Done means | Status |
+|------|-------------------|------------|--------|
+| 1.1 | **Install path**: pinned images, versioned release artifacts, migration notes | Customer upgrades one minor version without data loss | **Started:** install/upgrade table in [`private-reference-deployment.md`](./product-fleet/private-reference-deployment.md) |
+| 1.2 | **License or subscription check** (even v0: signed JWT license file or online activation with **air-gap fallback**) | Expired license degrades gracefully (read-only or block execution—your policy, documented) | **Started:** `NexoPrivateLicenseOptions`, `PrivateLicenseMiddleware`, sample [`sample-private-license.json`](./product-fleet/sample-private-license.json) |
+| 1.3 | **Secrets**: BYOK storage for provider keys; document what never leaves host | Security one-pager accurate | **Started:** [`private-byok-security.md`](./product-fleet/private-byok-security.md) |
+| 1.4 | **Backup/restore** runbook + tested restore for DB and object stores you use | RPO/RTO stated on support page | **Started:** [`private-backup-restore.md`](./product-fleet/private-backup-restore.md) (RPO 24h / RTO 4h pilot defaults) |
 | 1.5 | **Private pricing + invoice flow** (Stripe Invoicing, Paddle, or manual) + **order form template** | First paying Private customer can be billed without heroics |
 | 1.6 | **Support boundaries**: severity levels, response-time targets for paid Private | Published on website or contract appendix |
 

--- a/docs/bricks/unknown.md
+++ b/docs/bricks/unknown.md
@@ -2,18 +2,18 @@
 
 ## Behavior
 
-Adapted from promotion 02b2c57f73ed45f688f1928684f47dd5.
+Adapted from promotion d22fc7a6675d4aa9ad12387076fdafd9.
 
-**Last updated:** 2026-06-08
+**Last updated:** 2026-06-10
 
 ## Changelog
 
 ```markdown
 # Changelog
 
-## 2026-06-07 – 2026-06-08
+## 2026-06-09 – 2026-06-10
 
-- **unknown**: Fixed EmptyCatch in EmptyCatch.cs (2026-06-08 15:08)
+- **unknown**: Fixed EmptyCatch in EmptyCatch.cs (2026-06-10 20:00)
 
 
 ```

--- a/docs/product-fleet/on-call-playbook-v0.1.md
+++ b/docs/product-fleet/on-call-playbook-v0.1.md
@@ -1,0 +1,51 @@
+# On-call playbook v0.1 (Product Fleet Phase 0.5)
+
+Minimal first-response guide for a single-tenant **Nexo Private** deployment.
+
+## Severity guide
+
+| Severity | Examples | First response |
+|----------|----------|----------------|
+| S1 | API down, all copilot jobs failing, data loss risk | Page on-call; capture diagnostics within 15 minutes |
+| S2 | Degraded latency, quota mis-fires, one tenant blocked | Triage in business hours unless revenue-critical |
+| S3 | Doc drift, non-blocking warnings in logs | Ticket; fix in next maintenance window |
+
+## First five minutes
+
+1. **Health** — `GET /health` should return `healthy`.
+2. **Status** — `GET /api/status` shows background-agent mode and counts.
+3. **Diagnostics** — `GET /api/support/diagnostics` returns a redacted config bundle (no secrets). Attach this JSON to the incident ticket.
+4. **Usage** — `GET /api/usage/summary?hours=24` with `X-Nexo-Tenant` confirms whether jobs are being recorded.
+5. **Logs** — search for `NexoUsage`, `Nexo.Security`, and `Private license` warnings.
+
+## Common scenarios
+
+### Copilot returns 429
+
+Hourly quota (`Nexo:Entitlements:MaxCopilotSubmissionsPerHour`) is enforced per tenant. Raise the limit in config or wait for the rolling window.
+
+### Copilot returns 402 / license errors
+
+Private license enforcement is on (`Nexo:PrivateLicense:EnforceLicense`). Check `license.state` in diagnostics. Renew the license file and restart the API container. Read-only GET routes remain available when `AllowReadOnlyWhenExpired` is true.
+
+### Cross-tenant data concern
+
+Copilot task history and usage are scoped by `X-Nexo-Tenant`. Verify `Nexo:Product:AllowedTenantIds` matches the customer contract. Run `ProductFleetTenantIsolationTests` in CI after config changes.
+
+### Ollama / model unavailable
+
+Private reference stack depends on `OLLAMA_BASE_URL`. Confirm the Ollama container is healthy and the model tag in `OLLAMA_MODEL` is pulled.
+
+## Escalation data to collect
+
+- Diagnostics JSON (`/api/support/diagnostics`)
+- Last 200 lines of API container logs
+- Compose file version and image digests
+- License expiry (`expiresAt` only — do not paste HMAC secrets)
+- Approximate job volume from usage summary
+
+## Related
+
+- [`private-reference-deployment.md`](./private-reference-deployment.md)
+- [`private-backup-restore.md`](./private-backup-restore.md)
+- [`private-byok-security.md`](./private-byok-security.md)

--- a/docs/product-fleet/private-backup-restore.md
+++ b/docs/product-fleet/private-backup-restore.md
@@ -1,0 +1,52 @@
+# Private backup and restore (Phase 1.4)
+
+Target recovery objectives for pilot Private customers:
+
+| Metric | Pilot default | Notes |
+|--------|---------------|-------|
+| **RPO** | 24 hours | Daily volume snapshots unless contract specifies otherwise |
+| **RTO** | 4 hours | Single-tenant compose stack on comparable hardware |
+
+## What to back up
+
+| Asset | Location (reference compose) | Method |
+|-------|---------------------------|--------|
+| Dailies / run artifacts | Docker volume `nexo-dailies` | `docker run --rm -v nexo-dailies:/data -v $(pwd):/backup alpine tar czf /backup/nexo-dailies.tgz /data` |
+| Copilot persistence | Docker volume `nexo-copilot-data` | Same pattern as dailies |
+| LiteDB audit / pattern stores | Host path from `Nexo:PatternStorePath` or agent config | Filesystem copy while API stopped |
+| License file | `NEXO_LICENSE_FILE` or `Nexo:PrivateLicense:LicenseFilePath` | Secure copy to secrets vault |
+| Configuration | Compose env + `appsettings` overrides | Version in git or sealed customer config repo |
+
+## Backup procedure (reference stack)
+
+```bash
+docker compose -f docker-compose.private-single-tenant.yml stop nexo-api
+docker run --rm \
+  -v nexo-dailies:/data/dailies:ro \
+  -v nexo-copilot-data:/data/copilot:ro \
+  -v "$(pwd)/backups:/backup" \
+  alpine sh -c 'tar czf /backup/nexo-private-$(date -u +%Y%m%dT%H%M%SZ).tgz /data'
+docker compose -f docker-compose.private-single-tenant.yml start nexo-api
+```
+
+Store archives off-host (S3-compatible object storage or customer backup appliance). Encrypt at rest.
+
+## Restore procedure
+
+1. Provision a clean host with Docker.
+2. Load images (`docker load` for air-gap) or pull pinned tags.
+3. Recreate volumes and extract archive:
+
+```bash
+docker volume create nexo-dailies
+docker volume create nexo-copilot-data
+docker run --rm -v nexo-dailies:/data/dailies -v nexo-copilot-data:/data/copilot -v "$(pwd)/backups:/backup" alpine sh -c 'tar xzf /backup/<archive>.tgz -C /'
+```
+
+4. Restore license file and environment variables.
+5. `docker compose -f docker-compose.private-single-tenant.yml up -d`
+6. Verify: `/health`, `/api/support/diagnostics`, and one read-only copilot task list call.
+
+## Test cadence
+
+Run a full restore drill **quarterly** for paying Private customers. Record actual RTO in the ticket and update the support page if it diverges from the stated target.

--- a/docs/product-fleet/private-byok-security.md
+++ b/docs/product-fleet/private-byok-security.md
@@ -1,0 +1,36 @@
+# Private BYOK security one-pager (Phase 1.3)
+
+**Bring your own key (BYOK)** means LLM provider credentials stay on the customer-controlled host. Nexo orchestrates calls; it does not need to custody provider secrets in Nexo-operated cloud infrastructure for Private deployments.
+
+## What stays on the customer host
+
+| Data | Typical storage | Leaves host? |
+|------|-------------------|--------------|
+| OpenAI / Anthropic / Ollama API keys | Env vars, Docker secrets, or host keychain | Only to the configured provider endpoint |
+| Copilot task text and outputs | LiteDB / volumes per deployment profile | No Nexo cloud copy by default |
+| Audit and usage counters | Local LiteDB or in-memory | Export only when customer runs compliance export |
+| Private license file | `NEXO_LICENSE_FILE` mount | Never transmitted automatically |
+
+## What Nexo operators may see (support)
+
+With customer consent, support may receive:
+
+- Redacted diagnostics from `GET /api/support/diagnostics` (secrets stripped)
+- Aggregated usage counts (jobs per 24h)
+- Log excerpts with PII redacted per customer policy
+
+Support must **not** request raw provider API keys.
+
+## Hardening checklist
+
+1. Set `Nexo:Security:AuthorizationMode` to `ApiKey` (or stronger) for production.
+2. Bind API to localhost or private network; use reverse proxy TLS for remote access.
+3. Restrict `Nexo:Product:AllowedTenantIds` to the licensed tenant.
+4. Enable `Nexo:PrivateLicense:EnforceLicense` with HMAC-signed license files for production pilots.
+5. Rotate API keys on the same schedule as other production secrets.
+6. Keep Ollama / model endpoints on the internal Docker network (reference compose does this by default).
+
+## Related
+
+- [`private-reference-deployment.md`](./private-reference-deployment.md)
+- [`sample-private-license.json`](./sample-private-license.json)

--- a/docs/product-fleet/private-reference-deployment.md
+++ b/docs/product-fleet/private-reference-deployment.md
@@ -56,6 +56,36 @@ curl -sS 'http://127.0.0.1:8080/api/usage/summary?hours=24' \
 | `nexo-copilot-data` | `/data/copilot` | Reserved for copilot persistence profiles |
 | `ollama-models` | Ollama | Model weights |
 
+## License (Phase 1.2)
+
+Copy [`sample-private-license.json`](./sample-private-license.json) and set expiry for the pilot:
+
+```bash
+export NEXO_LICENSE_FILE=/path/to/license.json
+export Nexo__PrivateLicense__EnforceLicense=true
+```
+
+When enforcement is on and the license expires, **mutating** `/api/*` routes return `402` while read-only routes (including `/api/support/diagnostics`) remain available if `AllowReadOnlyWhenExpired` is true (default).
+
+## Support diagnostics (Phase 0.5)
+
+```bash
+curl -sS http://127.0.0.1:8080/api/support/diagnostics | jq .
+```
+
+Redacted config export for on-call — see [`on-call-playbook-v0.1.md`](./on-call-playbook-v0.1.md).
+
+## Install and upgrade (Phase 1.1)
+
+| Step | Action |
+|------|--------|
+| Pin version | Use release image digest or tagged `VERSION` from your order form |
+| First install | `docker compose -f docker-compose.private-single-tenant.yml up --build -d` |
+| Minor upgrade | `pull` → `up -d --build`; verify `/health` and one copilot read call |
+| Data safety | Stop API before volume backup — see [`private-backup-restore.md`](./private-backup-restore.md) |
+
+For air-gapped installs, build images on a connected machine, `docker save`, transfer, and `docker load` on the target host.
+
 ## Upgrade / teardown
 
 ```bash
@@ -64,9 +94,9 @@ docker compose -f docker-compose.private-single-tenant.yml up -d --build
 docker compose -f docker-compose.private-single-tenant.yml down
 ```
 
-For air-gapped installs, build images on a connected machine, `docker save`, transfer, and `docker load` on the target host.
-
 ## Related
 
 - [`docs/ProductFleetImplementationRoadmap.md`](../ProductFleetImplementationRoadmap.md) — Phase 0 exit criteria
+- [`private-backup-restore.md`](./private-backup-restore.md) — RPO/RTO and restore drill
+- [`private-byok-security.md`](./private-byok-security.md) — what never leaves the host
 - [`docker-compose.portal.yml`](../../docker-compose.portal.yml) — portal + Ollama without Private entitlements defaults

--- a/docs/product-fleet/sample-private-license.json
+++ b/docs/product-fleet/sample-private-license.json
@@ -1,0 +1,6 @@
+{
+  "customerId": "acme-pilot",
+  "tenantId": "acme-pilot",
+  "expiresAt": "2027-12-31T23:59:59Z",
+  "seats": 5
+}

--- a/src/Nexo.BackgroundAgents/Trust/DataDecisionAuditLog.cs
+++ b/src/Nexo.BackgroundAgents/Trust/DataDecisionAuditLog.cs
@@ -115,6 +115,19 @@ public sealed class DataDecisionAuditLog : IDataDecisionAuditLog, ISanitizationA
     }
 
     /// <inheritdoc />
+    public void LogCopilotTask(string tenantId, string taskId, bool success)
+    {
+        Append(new DataDecisionAuditEntry
+        {
+            EventType = "CopilotTask",
+            Timestamp = DateTimeOffset.UtcNow,
+            TenantId = tenantId,
+            SourceId = taskId,
+            Disposition = success ? "Success" : "Failure",
+        });
+    }
+
+    /// <inheritdoc />
     public IReadOnlyList<DataDecisionAuditEntry> GetRecent(int maxCount, DateTimeOffset? since = null, DateTimeOffset? until = null, string? eventType = null) =>
         GetRecentInternal(maxCount, since, until, eventType);
 
@@ -133,6 +146,7 @@ public sealed class DataDecisionAuditLog : IDataDecisionAuditLog, ISanitizationA
             {
                 e.EventType,
                 e.Timestamp,
+                e.TenantId,
                 e.RuleVersion,
                 e.FieldOrType,
                 e.Disposition,
@@ -207,6 +221,10 @@ public sealed class DataDecisionAuditLog : IDataDecisionAuditLog, ISanitizationA
                 if (!string.IsNullOrEmpty(e.Reason))
                     sb.AppendLine($"- **Summary:** {e.Reason}");
             }
+            else if (e.EventType == "CopilotTask")
+            {
+                sb.AppendLine($"- **Tenant:** {e.TenantId} | **Task:** {e.SourceId} | **Outcome:** {e.Disposition}");
+            }
 
             sb.AppendLine();
         }
@@ -219,12 +237,13 @@ public sealed class DataDecisionAuditLog : IDataDecisionAuditLog, ISanitizationA
     {
         var entries = GetRecentInternal(maxCount, since, until, eventType);
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("Timestamp,EventType,RuleVersion,FieldOrType,Disposition,Reason,ChangeType,Category,SourceId,ProjectPath,PreviousState,NewState,DataType,LevelName");
+        sb.AppendLine("Timestamp,EventType,TenantId,RuleVersion,FieldOrType,Disposition,Reason,ChangeType,Category,SourceId,ProjectPath,PreviousState,NewState,DataType,LevelName");
         foreach (var e in entries)
         {
             var line = string.Join(",",
                 EscapeCsv(e.Timestamp.ToString("o")),
                 EscapeCsv(e.EventType),
+                EscapeCsv(e.TenantId),
                 EscapeCsv(e.RuleVersion),
                 EscapeCsv(e.FieldOrType),
                 EscapeCsv(e.Disposition),

--- a/src/Nexo.BackgroundAgents/Trust/LiteDbDataDecisionAuditLog.cs
+++ b/src/Nexo.BackgroundAgents/Trust/LiteDbDataDecisionAuditLog.cs
@@ -107,6 +107,19 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
     }
 
     /// <inheritdoc />
+    public void LogCopilotTask(string tenantId, string taskId, bool success)
+    {
+        Append(new DataDecisionAuditEntry
+        {
+            EventType = "CopilotTask",
+            Timestamp = DateTimeOffset.UtcNow,
+            TenantId = tenantId,
+            SourceId = taskId,
+            Disposition = success ? "Success" : "Failure",
+        });
+    }
+
+    /// <inheritdoc />
     IReadOnlyList<SanitizationAuditEntry> ISanitizationAuditLog.GetRecent(int maxCount, DateTimeOffset? since)
     {
         var all = GetRecent(maxCount * 3, since, null, "Sanitization");
@@ -155,6 +168,7 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
             {
                 e.EventType,
                 e.Timestamp,
+                e.TenantId,
                 e.RuleVersion,
                 e.FieldOrType,
                 e.Disposition,
@@ -229,6 +243,10 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
                 if (!string.IsNullOrEmpty(e.Reason))
                     sb.AppendLine($"- **Summary:** {e.Reason}");
             }
+            else if (e.EventType == "CopilotTask")
+            {
+                sb.AppendLine($"- **Tenant:** {e.TenantId} | **Task:** {e.SourceId} | **Outcome:** {e.Disposition}");
+            }
 
             sb.AppendLine();
         }
@@ -241,12 +259,13 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
     {
         var entries = GetRecent(maxCount, since, until, eventType);
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("Timestamp,EventType,RuleVersion,FieldOrType,Disposition,Reason,ChangeType,Category,SourceId,ProjectPath,PreviousState,NewState,DataType,LevelName");
+        sb.AppendLine("Timestamp,EventType,TenantId,RuleVersion,FieldOrType,Disposition,Reason,ChangeType,Category,SourceId,ProjectPath,PreviousState,NewState,DataType,LevelName");
         foreach (var e in entries)
         {
             var line = string.Join(",",
                 EscapeCsv(e.Timestamp.ToString("o")),
                 EscapeCsv(e.EventType),
+                EscapeCsv(e.TenantId),
                 EscapeCsv(e.RuleVersion),
                 EscapeCsv(e.FieldOrType),
                 EscapeCsv(e.Disposition),
@@ -299,6 +318,7 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
             Id = ObjectId.NewObjectId().ToString(),
             EventType = e.EventType,
             Timestamp = e.Timestamp,
+            TenantId = e.TenantId,
             RuleVersion = e.RuleVersion,
             FieldOrType = e.FieldOrType,
             Disposition = e.Disposition,
@@ -320,6 +340,7 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
         {
             EventType = d.EventType,
             Timestamp = d.Timestamp,
+            TenantId = d.TenantId,
             RuleVersion = d.RuleVersion,
             FieldOrType = d.FieldOrType,
             Disposition = d.Disposition,
@@ -341,6 +362,7 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
         public string Id { get; set; } = string.Empty;
         public string EventType { get; set; } = string.Empty;
         public DateTimeOffset Timestamp { get; set; }
+        public string? TenantId { get; set; }
         public string? RuleVersion { get; set; }
         public string? FieldOrType { get; set; }
         public string? Disposition { get; set; }

--- a/src/Nexo.Core.Application/Trust/Models/DataDecisionAuditEntry.cs
+++ b/src/Nexo.Core.Application/Trust/Models/DataDecisionAuditEntry.cs
@@ -11,6 +11,9 @@ public sealed class DataDecisionAuditEntry
     /// <summary>When the event occurred.</summary>
     public DateTimeOffset Timestamp { get; init; }
 
+    /// <summary>Product Fleet tenant scope when the event is tenant-bound (e.g. copilot jobs).</summary>
+    public string? TenantId { get; init; }
+
     // Sanitization fields
     public string? RuleVersion { get; init; }
     public string? FieldOrType { get; init; }

--- a/src/Nexo.Core.Application/Trust/Ports/IDataDecisionAuditLog.cs
+++ b/src/Nexo.Core.Application/Trust/Ports/IDataDecisionAuditLog.cs
@@ -30,6 +30,9 @@ public interface IDataDecisionAuditLog
     /// <param name="toolCallsExecuted">Number of tool calls executed.</param>
     void LogAmbientAction(string agentId, string summary, int toolCallsExecuted);
 
+    /// <summary>Log a copilot task completion for tenant-scoped audit trails (Product Fleet Phase 0.5).</summary>
+    void LogCopilotTask(string tenantId, string taskId, bool success);
+
     /// <summary>Get recent audit entries (all types).</summary>
     IReadOnlyList<DataDecisionAuditEntry> GetRecent(int maxCount, DateTimeOffset? since = null, DateTimeOffset? until = null, string? eventType = null);
 

--- a/src/Nexo.Tests.BackgroundAgents/Configuration/AggressivenessModeTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Configuration/AggressivenessModeTests.cs
@@ -510,6 +510,8 @@ public sealed class AggressivenessModeTests
         public void LogAmbientAction(string agentId, string summary, int toolCallsExecuted) =>
             _captured.Add((agentId, summary, toolCallsExecuted));
 
+        public void LogCopilotTask(string tenantId, string taskId, bool success) { }
+
         public void LogSanitization(SanitizationAuditEntryDto entry) { }
         public void LogBoundaryChange(BoundaryChangeEvent evt) { }
         public void LogClassification(string dataType, string levelName, string? reason) { }

--- a/src/Nexo.Tests.BackgroundAgents/Trust/DataDecisionAuditLogTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Trust/DataDecisionAuditLogTests.cs
@@ -148,7 +148,7 @@ public class DataDecisionAuditLogTests
 
         var csv = log.ExportToCsv(10);
 
-        csv.Should().Contain("Timestamp,EventType,RuleVersion,FieldOrType,Disposition");
+        csv.Should().Contain("Timestamp,EventType,TenantId,RuleVersion,FieldOrType,Disposition");
         csv.Should().Contain("Sanitization");
         csv.Should().Contain("Classification");
     }

--- a/src/Nexo.Tests.BackgroundAgents/Trust/LiteDbDataDecisionAuditLogTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Trust/LiteDbDataDecisionAuditLogTests.cs
@@ -81,7 +81,7 @@ public sealed class LiteDbDataDecisionAuditLogTests : IDisposable
 
         var csv = log.ExportToCsv(10);
 
-        csv.Should().Contain("Timestamp,EventType,RuleVersion,FieldOrType,Disposition");
+        csv.Should().Contain("Timestamp,EventType,TenantId,RuleVersion,FieldOrType,Disposition");
         csv.Should().Contain("Sanitization");
     }
 }

--- a/src/Nexo.Tests.Contracts/DataDecisionAuditLogContractTests.cs
+++ b/src/Nexo.Tests.Contracts/DataDecisionAuditLogContractTests.cs
@@ -57,4 +57,17 @@ public abstract class DataDecisionAuditLogContractTests
         json.Should().Contain("ScopeChainRejected");
         json.Should().Contain("AmbientAction");
     }
+
+    [Fact]
+    public void LogCopilotTask_IsTenantScopedAndRetrievable()
+    {
+        var log = CreateInstance();
+        log.LogCopilotTask("tenant-a", "task-123", success: true);
+
+        var recent = log.GetRecent(10, eventType: "CopilotTask");
+        recent.Should().ContainSingle();
+        recent[0].TenantId.Should().Be("tenant-a");
+        recent[0].SourceId.Should().Be("task-123");
+        recent[0].Disposition.Should().Be("Success");
+    }
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/API/PrivateLicenseMiddlewareTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/PrivateLicenseMiddlewareTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Nexo.API.Security;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+public sealed class PrivateLicenseMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_WhenEnforcementDisabled_AllowsMutatingRequest()
+    {
+        var nextCalled = false;
+        var middleware = new PrivateLicenseMiddleware(
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            },
+            Options.Create(new NexoPrivateLicenseOptions { EnforceLicense = false }),
+            new StubValidator(new PrivateLicenseStatus { State = PrivateLicenseState.Expired }));
+
+        var context = CreateContext("/api/copilot/task", "POST");
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenLicenseExpired_BlocksMutatingRequest()
+    {
+        var middleware = new PrivateLicenseMiddleware(
+            _ => Task.CompletedTask,
+            Options.Create(new NexoPrivateLicenseOptions
+            {
+                EnforceLicense = true,
+                AllowReadOnlyWhenExpired = true,
+            }),
+            new StubValidator(new PrivateLicenseStatus
+            {
+                State = PrivateLicenseState.Expired,
+                Detail = "expired",
+            }));
+
+        var context = CreateContext("/api/copilot/task", "POST");
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status402PaymentRequired);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenLicenseExpired_AllowsDiagnosticsRead()
+    {
+        var nextCalled = false;
+        var middleware = new PrivateLicenseMiddleware(
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            },
+            Options.Create(new NexoPrivateLicenseOptions
+            {
+                EnforceLicense = true,
+                AllowReadOnlyWhenExpired = true,
+            }),
+            new StubValidator(new PrivateLicenseStatus { State = PrivateLicenseState.Expired }));
+
+        var context = CreateContext("/api/support/diagnostics", "GET");
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    private static DefaultHttpContext CreateContext(string path, string method)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.Method = method;
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private sealed class StubValidator : IPrivateLicenseValidator
+    {
+        private readonly PrivateLicenseStatus _status;
+
+        public StubValidator(PrivateLicenseStatus status) => _status = status;
+
+        public PrivateLicenseStatus GetStatus() => _status;
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/API/PrivateLicenseValidatorTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/PrivateLicenseValidatorTests.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.API.Security;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+public sealed class PrivateLicenseValidatorTests
+{
+    [Fact]
+    public void GetStatus_WhenNoLicenseConfigured_ReturnsNotConfigured()
+    {
+        var validator = CreateValidator(new NexoPrivateLicenseOptions(), contentRoot: Path.GetTempPath());
+
+        var status = validator.GetStatus();
+
+        status.State.Should().Be(PrivateLicenseState.NotConfigured);
+    }
+
+    [Fact]
+    public void GetStatus_WhenLicenseValid_ReturnsValid()
+    {
+        var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), $"nexo-lic-{Guid.NewGuid():N}")).FullName;
+        var path = Path.Combine(dir, "license.json");
+        var document = new PrivateLicenseDocument
+        {
+            CustomerId = "acme",
+            TenantId = "acme-pilot",
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(30),
+            Seats = 5,
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(document));
+
+        var validator = CreateValidator(
+            new NexoPrivateLicenseOptions { LicenseFilePath = path },
+            contentRoot: dir);
+
+        validator.GetStatus().State.Should().Be(PrivateLicenseState.Valid);
+    }
+
+    [Fact]
+    public void GetStatus_WhenLicenseExpired_ReturnsExpired()
+    {
+        var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), $"nexo-lic-{Guid.NewGuid():N}")).FullName;
+        var path = Path.Combine(dir, "license.json");
+        var document = new PrivateLicenseDocument
+        {
+            CustomerId = "acme",
+            TenantId = "acme-pilot",
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(-1),
+            Seats = 5,
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(document));
+
+        var validator = CreateValidator(
+            new NexoPrivateLicenseOptions { LicenseFilePath = path },
+            contentRoot: dir);
+
+        validator.GetStatus().State.Should().Be(PrivateLicenseState.Expired);
+    }
+
+    private static PrivateLicenseValidator CreateValidator(NexoPrivateLicenseOptions options, string contentRoot) =>
+        new(
+            Options.Create(options),
+            new StubHostEnvironment(contentRoot),
+            NullLogger<PrivateLicenseValidator>.Instance);
+
+    private sealed class StubHostEnvironment : IHostEnvironment
+    {
+        public StubHostEnvironment(string contentRoot) => ContentRootPath = contentRoot;
+
+        public string EnvironmentName { get; set; } = Microsoft.Extensions.Hosting.Environments.Development;
+        public string ApplicationName { get; set; } = "Nexo.Tests";
+        public string ContentRootPath { get; set; }
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Adaptation/AdversarialScopeEscapeTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Adaptation/AdversarialScopeEscapeTests.cs
@@ -206,6 +206,8 @@ public sealed class AdversarialScopeEscapeTests
 
         public void LogAmbientAction(string agentId, string summary, int toolCallsExecuted) { }
 
+        public void LogCopilotTask(string tenantId, string taskId, bool success) { }
+
         public void LogSanitization(SanitizationAuditEntryDto entry) { }
         public void LogBoundaryChange(BoundaryChangeEvent evt) { }
         public void LogClassification(string dataType, string levelName, string? reason) { }

--- a/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
@@ -232,6 +232,7 @@ public sealed class BackgroundAgentLifecycleE2ETests
         public CaptureAmbientAuditLog(ConcurrentBag<(string, string, int)> c) => _captured = c;
         public void LogAmbientAction(string agentId, string summary, int toolCallsExecuted) =>
             _captured.Add((agentId, summary, toolCallsExecuted));
+        public void LogCopilotTask(string tenantId, string taskId, bool success) { }
         public void LogSanitization(SanitizationAuditEntryDto entry) { }
         public void LogBoundaryChange(BoundaryChangeEvent evt) { }
         public void LogClassification(string dataType, string levelName, string? reason) { }

--- a/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetDiagnosticsTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetDiagnosticsTests.cs
@@ -1,0 +1,33 @@
+using System.Net.Http.Json;
+using FluentAssertions;
+using Nexo.API.Security;
+using Nexo.Tests.Infrastructure.Helpers.VirtualProduction;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.VirtualProduction;
+
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
+public sealed class ProductFleetDiagnosticsTests : IClassFixture<NexoApiWebApplicationFactory>
+{
+    private readonly NexoApiWebApplicationFactory _factory;
+
+    public ProductFleetDiagnosticsTests(NexoApiWebApplicationFactory factory) => _factory = factory;
+
+    [Fact(Timeout = 120000)]
+    public async Task GET_support_diagnostics_returns_redacted_bundle()
+    {
+        var client = _factory.CreateClient();
+        using var response = await client.GetAsync("api/support/diagnostics");
+        response.EnsureSuccessStatusCode();
+
+        var diagnostics = await response.Content.ReadFromJsonAsync<SupportDiagnosticsResponse>();
+        diagnostics.Should().NotBeNull();
+        diagnostics!.Application.Should().Be("Nexo.API");
+        diagnostics.Security.ApiKeyConfigured.Should().BeFalse();
+        diagnostics.License.State.Should().Be(nameof(PrivateLicenseState.NotConfigured));
+        diagnostics.RedactedConfiguration.Should().NotBeEmpty();
+        diagnostics.RedactedConfiguration.Values.Should().NotContain("secret-key");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the three post–Phase 0 tracks scoped for this iteration:

### Phase 0.5 — Observability
- `TenantId` on `DataDecisionAuditEntry` and `LogCopilotTask` on `IDataDecisionAuditLog` (wired from copilot submit/complete)
- `GET /api/support/diagnostics` — redacted config export for on-call
- [`docs/product-fleet/on-call-playbook-v0.1.md`](docs/product-fleet/on-call-playbook-v0.1.md)

### Phase 1 Private
- `NexoPrivateLicenseOptions` + `PrivateLicenseValidator` (JSON license file, optional HMAC)
- `PrivateLicenseMiddleware` — blocks mutating `/api/*` when license expired/invalid (read-only fallback when configured)
- Install/upgrade notes, backup/restore runbook, BYOK security one-pager
- Sample license: [`docs/product-fleet/sample-private-license.json`](docs/product-fleet/sample-private-license.json)

### RC validation (local)
- `make dependency-boundary-gate` — PASS
- `make kernel-coverage-gate` — PASS
- `make test-prod-style` — PASS (99 ProdStyle tests)
- `make rc-gate-tier-a` — PASS

`production-readiness-gate-v1` workflow_dispatch requires repo admin token (403 from agent); will run on merge to `master` or can be triggered manually.

## Test plan
- [x] `PrivateLicenseValidatorTests`, `PrivateLicenseMiddlewareTests`
- [x] `ProductFleetDiagnosticsTests`
- [x] `DataDecisionAuditLogContractTests` (incl. `LogCopilotTask`)
- [x] `make test-prod-style`
- [x] `make dependency-boundary-gate` + `make kernel-coverage-gate` + `make rc-gate-tier-a`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

