### PR TITLE
Product Fleet Phase 2: Cloud org control plane + Private commercial finish

### DIFF
--- a/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -8,6 +8,7 @@ using Nexo.BrickContracts.Capabilities;
 using Nexo.Contracts;
 using Nexo.Core.Application.Copilot.Models;
 using Nexo.Core.Application.Copilot.Ports;
+using Nexo.Core.Application.Product.Models;
 using Nexo.Core.Application.Product.Ports;
 using Nexo.Core.Application.Knowledge.Models;
 using Nexo.Core.Application.Knowledge.Ports;
@@ -28,6 +29,7 @@ using Nexo.API.Security;
 using Nexo.Orchestration.Coordination;
 using Nexo.Orchestration.Models;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
@@ -105,6 +107,32 @@ public static class NexoEndpoints
             .WithName("GetSupportDiagnostics")
             .WithSummary("Redacted support diagnostics export (Product Fleet Phase 0.5)")
             .Produces<SupportDiagnosticsResponse>(StatusCodes.Status200OK);
+
+        group.MapPost("/orgs", CreateOrganizationAsync)
+            .WithName("CreateOrganization")
+            .WithSummary("Create a cloud organization (Product Fleet Phase 2.3)")
+            .Produces<Organization>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/orgs/{orgId}", GetOrganizationAsync)
+            .WithName("GetOrganization")
+            .WithSummary("Get organization metadata for a member")
+            .Produces<Organization>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapGet("/orgs/{orgId}/members", ListOrganizationMembersAsync)
+            .WithName("ListOrganizationMembers")
+            .WithSummary("List organization members")
+            .Produces<IReadOnlyList<OrganizationMember>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        group.MapPost("/orgs/{orgId}/members", AddOrganizationMemberAsync)
+            .WithName("AddOrganizationMember")
+            .WithSummary("Invite or add a member (admin only)")
+            .Produces<OrganizationMember>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
 
         group.MapGet("/status", GetStatusAsync)
             .WithName("GetStatus")
@@ -357,7 +385,7 @@ public static class NexoEndpoints
         if (string.IsNullOrWhiteSpace(request?.Task))
             return Results.BadRequest(new ProblemDetails { Title = "Task is required" });
 
-        if (!NexoHttpTenant.TryResolve(httpContext.Request, productOptions.Value, out var tenantId, out var tenantError))
+        if (!TryResolveProductTenant(httpContext, productOptions.Value, out var tenantId, out var tenantError))
             return Results.BadRequest(new ProblemDetails { Title = "Invalid tenant", Detail = tenantError });
 
         if (!copilotSubmissionQuota.TryConsume(tenantId, out var quotaMsg))
@@ -463,7 +491,7 @@ public static class NexoEndpoints
         [FromServices] IOptions<NexoProductOptions> productOptions,
         int hours = 24)
     {
-        if (!NexoHttpTenant.TryResolve(httpContext.Request, productOptions.Value, out var tenantId, out var tenantError))
+        if (!TryResolveProductTenant(httpContext, productOptions.Value, out var tenantId, out var tenantError))
             return Task.FromResult<IResult>(Results.BadRequest(new ProblemDetails { Title = "Invalid tenant", Detail = tenantError }));
 
         var summary = usageStore.GetSummary(tenantId, hours);
@@ -478,7 +506,7 @@ public static class NexoEndpoints
         [FromQuery] DateTimeOffset? since = null,
         CancellationToken cancellationToken = default)
     {
-        if (!NexoHttpTenant.TryResolve(httpContext.Request, productOptions.Value, out var tenantId, out var tenantError))
+        if (!TryResolveProductTenant(httpContext, productOptions.Value, out var tenantId, out var tenantError))
             return Results.BadRequest(new ProblemDetails { Title = "Invalid tenant", Detail = tenantError });
 
         maxCount = Math.Clamp(maxCount <= 0 ? 50 : maxCount, 1, 500);
@@ -496,7 +524,7 @@ public static class NexoEndpoints
         if (string.IsNullOrWhiteSpace(taskId))
             return Results.BadRequest(new ProblemDetails { Title = "taskId is required" });
 
-        if (!NexoHttpTenant.TryResolve(httpContext.Request, productOptions.Value, out var tenantId, out var tenantError))
+        if (!TryResolveProductTenant(httpContext, productOptions.Value, out var tenantId, out var tenantError))
             return Results.BadRequest(new ProblemDetails { Title = "Invalid tenant", Detail = tenantError });
 
         var task = await copilotTaskStore.GetByIdAsync(taskId.Trim(), cancellationToken);
@@ -1106,6 +1134,164 @@ public static class NexoEndpoints
             activePack?.Version));
     }
 
+    private static Task<IResult> CreateOrganizationAsync(
+        HttpContext httpContext,
+        [FromBody] CreateOrganizationRequest request,
+        [FromServices] IOrganizationStore orgStore,
+        [FromServices] IOptions<NexoProductOptions> productOptions)
+    {
+        if (string.IsNullOrWhiteSpace(request?.Name))
+            return Task.FromResult<IResult>(Results.BadRequest(new ProblemDetails { Title = "Name is required" }));
+
+        Organization organization;
+        try
+        {
+            organization = orgStore.CreateOrganization(request.Name, request.TenantId);
+        }
+        catch (ArgumentException ex)
+        {
+            return Task.FromResult<IResult>(Results.BadRequest(new ProblemDetails { Title = "Invalid organization", Detail = ex.Message }));
+        }
+
+        if (NexoHttpOrg.TryResolveUser(httpContext.Request, productOptions.Value, out var creatorId, out _))
+            orgStore.AddMember(organization.OrgId, creatorId, OrganizationRole.Admin);
+
+        return Task.FromResult<IResult>(Results.Ok(organization));
+    }
+
+    private static Task<IResult> GetOrganizationAsync(
+        HttpContext httpContext,
+        string orgId,
+        [FromServices] IOrganizationStore orgStore,
+        [FromServices] IOptions<NexoProductOptions> productOptions)
+    {
+        if (!NexoHttpOrg.TryResolveOrgContext(
+                httpContext.Request,
+                productOptions.Value,
+                orgStore,
+                out var organization,
+                out _,
+                out _,
+                out var error) ||
+            !string.Equals(organization.OrgId, orgId.Trim(), StringComparison.Ordinal))
+        {
+            return Task.FromResult<IResult>(Results.Json(
+                new ProblemDetails { Title = "Forbidden", Detail = error ?? "Organization access denied." },
+                statusCode: StatusCodes.Status403Forbidden));
+        }
+
+        return Task.FromResult<IResult>(Results.Ok(organization));
+    }
+
+    private static Task<IResult> ListOrganizationMembersAsync(
+        HttpContext httpContext,
+        string orgId,
+        [FromServices] IOrganizationStore orgStore,
+        [FromServices] IOptions<NexoProductOptions> productOptions)
+    {
+        if (!NexoHttpOrg.TryResolveOrgContext(
+                httpContext.Request,
+                productOptions.Value,
+                orgStore,
+                out var organization,
+                out _,
+                out _,
+                out var error) ||
+            !string.Equals(organization.OrgId, orgId.Trim(), StringComparison.Ordinal))
+        {
+            return Task.FromResult<IResult>(Results.Json(
+                new ProblemDetails { Title = "Forbidden", Detail = error ?? "Organization access denied." },
+                statusCode: StatusCodes.Status403Forbidden));
+        }
+
+        return Task.FromResult<IResult>(Results.Ok(orgStore.GetMembers(orgId.Trim())));
+    }
+
+    private static Task<IResult> AddOrganizationMemberAsync(
+        HttpContext httpContext,
+        string orgId,
+        [FromBody] AddOrganizationMemberRequest request,
+        [FromServices] IOrganizationStore orgStore,
+        [FromServices] IOptions<NexoProductOptions> productOptions)
+    {
+        if (string.IsNullOrWhiteSpace(request?.UserId))
+            return Task.FromResult<IResult>(Results.BadRequest(new ProblemDetails { Title = "UserId is required" }));
+
+        if (!NexoHttpOrg.TryResolveOrgContext(
+                httpContext.Request,
+                productOptions.Value,
+                orgStore,
+                out var organization,
+                out _,
+                out var actorRole,
+                out var error) ||
+            !string.Equals(organization.OrgId, orgId.Trim(), StringComparison.Ordinal))
+        {
+            return Task.FromResult<IResult>(Results.Json(
+                new ProblemDetails { Title = "Forbidden", Detail = error ?? "Organization access denied." },
+                statusCode: StatusCodes.Status403Forbidden));
+        }
+
+        if (actorRole != OrganizationRole.Admin)
+        {
+            return Task.FromResult<IResult>(Results.Json(
+                new ProblemDetails { Title = "Forbidden", Detail = "Only organization admins can add members." },
+                statusCode: StatusCodes.Status403Forbidden));
+        }
+
+        if (!Enum.TryParse<OrganizationRole>(request.Role, ignoreCase: true, out var role))
+            role = OrganizationRole.Member;
+
+        try
+        {
+            var member = orgStore.AddMember(orgId.Trim(), request.UserId, role);
+            return Task.FromResult<IResult>(Results.Ok(member));
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return Task.FromResult<IResult>(Results.BadRequest(new ProblemDetails { Title = "Invalid member", Detail = ex.Message }));
+        }
+    }
+
+    private static bool TryResolveProductTenant(
+        HttpContext httpContext,
+        NexoProductOptions options,
+        out string tenantId,
+        out string? errorDetail)
+    {
+        if (!NexoHttpTenant.TryResolve(httpContext.Request, options, out tenantId, out errorDetail))
+            return false;
+
+        if (!options.RequireOrgMembership)
+            return true;
+
+        var orgStore = httpContext.RequestServices.GetService<IOrganizationStore>();
+        if (orgStore is null)
+        {
+            errorDetail = "Organization store is not configured.";
+            return false;
+        }
+
+        if (!NexoHttpOrg.TryResolveOrgContext(
+                httpContext.Request,
+                options,
+                orgStore,
+                out var organization,
+                out _,
+                out _,
+                out errorDetail))
+            return false;
+
+        if (!NexoHttpOrg.TenantMatchesOrg(tenantId, organization))
+        {
+            errorDetail = $"Tenant '{tenantId}' does not match organization scope '{organization.TenantId}'.";
+            return false;
+        }
+
+        tenantId = organization.TenantId;
+        return true;
+    }
+
     // Preferences file lives next to the config file so it survives Docker
     // container restarts when the config directory is on a volume mount.
     private static bool IsDevelopment() =>
@@ -1300,7 +1486,7 @@ public static class NexoEndpoints
             providers.Add(new ProviderStatus(name, available, reason));
         }
 
-        if (!NexoHttpTenant.TryResolve(httpContext.Request, productOptions.Value, out var tenantId, out var tenantError))
+        if (!TryResolveProductTenant(httpContext, productOptions.Value, out var tenantId, out var tenantError))
             return Results.BadRequest(new ProblemDetails { Title = "Invalid tenant", Detail = tenantError });
 
         var tasks = await copilotTaskStore.QueryAsync(1, null, tenantId, cancellationToken);
@@ -1486,3 +1672,9 @@ public sealed record OnboardingStatusResponse(
     string ResolvedTenantId);
 
 public sealed record ProviderStatus(string Name, bool Available, string? Reason);
+
+// ── Cloud control plane (Phase 2.3) ─────────────────────────────────
+
+public sealed record CreateOrganizationRequest(string Name, string? TenantId);
+
+public sealed record AddOrganizationMemberRequest(string UserId, string Role = "Member");

--- a/application/src/Nexo.API/Program.cs
+++ b/application/src/Nexo.API/Program.cs
@@ -97,6 +97,7 @@ builder.Services.AddSingleton<IPrivateLicenseValidator, PrivateLicenseValidator>
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<ICopilotSubmissionQuota, CopilotSubmissionQuota>();
 builder.Services.AddSingleton<ITenantUsageStore, InMemoryTenantUsageStore>();
+builder.Services.AddSingleton<IOrganizationStore, InMemoryOrganizationStore>();
 builder.Services.Configure<MeshSecurityOptions>(
     builder.Configuration.GetSection(MeshSecurityOptions.SectionPath));
 builder.Services.Configure<SmsIngressDynamoDbOptions>(

--- a/application/src/Nexo.API/Security/NexoHttpOrg.cs
+++ b/application/src/Nexo.API/Security/NexoHttpOrg.cs
@@ -1,0 +1,87 @@
+using Nexo.Core.Application.Product.Models;
+using Nexo.Core.Application.Product.Ports;
+
+namespace Nexo.API.Security;
+
+/// <summary>
+/// Resolves cloud org membership and tenant scope from staging headers (Phase 2.3).
+/// </summary>
+public static class NexoHttpOrg
+{
+    public const string UserHeaderName = "X-Nexo-User";
+    public const string OrgHeaderName = "X-Nexo-Org";
+
+    public static bool TryResolveUser(HttpRequest request, NexoProductOptions options, out string userId, out string? errorDetail)
+    {
+        userId = "";
+        errorDetail = null;
+        var header = string.IsNullOrWhiteSpace(options.UserHeaderName)
+            ? UserHeaderName
+            : options.UserHeaderName.Trim();
+
+        var raw = request.Headers[header].ToString().Trim();
+        if (string.IsNullOrEmpty(raw))
+        {
+            errorDetail = $"User header '{header}' is required when org membership is enforced.";
+            return false;
+        }
+
+        if (raw.Length > 256)
+        {
+            errorDetail = $"User header '{header}' exceeds maximum length (256).";
+            return false;
+        }
+
+        userId = raw;
+        return true;
+    }
+
+    public static bool TryResolveOrgContext(
+        HttpRequest request,
+        NexoProductOptions options,
+        IOrganizationStore orgStore,
+        out Organization organization,
+        out string userId,
+        out OrganizationRole role,
+        out string? errorDetail)
+    {
+        organization = null!;
+        userId = "";
+        role = OrganizationRole.Member;
+        errorDetail = null;
+
+        if (!TryResolveUser(request, options, out userId, out errorDetail))
+            return false;
+
+        var orgHeader = string.IsNullOrWhiteSpace(options.OrgHeaderName)
+            ? OrgHeaderName
+            : options.OrgHeaderName.Trim();
+        var orgId = request.Headers[orgHeader].ToString().Trim();
+        if (string.IsNullOrEmpty(orgId))
+        {
+            errorDetail = $"Org header '{orgHeader}' is required when org membership is enforced.";
+            return false;
+        }
+
+        var org = orgStore.GetOrganization(orgId);
+        if (org is null)
+        {
+            errorDetail = $"Organization '{orgId}' was not found.";
+            return false;
+        }
+
+        var memberRole = orgStore.GetMemberRole(orgId, userId);
+        if (memberRole is null)
+        {
+            errorDetail = $"User is not a member of organization '{orgId}'.";
+            return false;
+        }
+
+        organization = org;
+        role = memberRole.Value;
+        return true;
+    }
+
+    public static bool TenantMatchesOrg(string tenantId, Organization organization) =>
+        string.Equals(tenantId, organization.TenantId, StringComparison.Ordinal);
+}

--- a/application/src/Nexo.API/Security/NexoProductOptions.cs
+++ b/application/src/Nexo.API/Security/NexoProductOptions.cs
@@ -15,4 +15,11 @@ public sealed class NexoProductOptions
     /// When empty, any non-empty tenant header up to 128 chars is accepted after trimming.
     /// </summary>
     public string[] AllowedTenantIds { get; set; } = [];
+
+    /// <summary>Cloud mode: copilot/usage routes require <c>X-Nexo-User</c> + <c>X-Nexo-Org</c> membership.</summary>
+    public bool RequireOrgMembership { get; set; }
+
+    public string UserHeaderName { get; set; } = NexoHttpOrg.UserHeaderName;
+
+    public string OrgHeaderName { get; set; } = NexoHttpOrg.OrgHeaderName;
 }

--- a/docker-compose.cloud-multi-tenant.yml
+++ b/docker-compose.cloud-multi-tenant.yml
@@ -1,0 +1,38 @@
+# Product Fleet Phase 2 — multi-tenant Cloud staging shape (local dev).
+# See docs/product-fleet/cloud-reference-deployment.md
+services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama-models:/root/.ollama
+    restart: unless-stopped
+
+  nexo-api:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile.api
+    depends_on:
+      - ollama
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      OLLAMA_BASE_URL: http://ollama:11434
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-llama3.1:latest}
+      NEXO_DAILIES_PATH: /data/dailies
+      Nexo__Product__RequireOrgMembership: "true"
+      Nexo__Entitlements__DeploymentMode: Cloud
+      Nexo__Entitlements__MaxCopilotSubmissionsPerHour: ${NEXO_MAX_COPILOT_PER_HOUR:-120}
+      Nexo__Entitlements__Seats: ${NEXO_SEATS:-25}
+      Nexo__Entitlements__MaxConcurrency: ${NEXO_MAX_CONCURRENCY:-3}
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - nexo-cloud-dailies:/data/dailies
+      - nexo-cloud-data:/data/copilot
+    restart: unless-stopped
+
+volumes:
+  ollama-models:
+  nexo-cloud-dailies:
+  nexo-cloud-data:

--- a/docs/ProductFleetImplementationRoadmap.md
+++ b/docs/ProductFleetImplementationRoadmap.md
@@ -17,11 +17,11 @@ This is the **engineering, operations, and go-to-market sequence** for turning t
 
 | Step | What to implement | Done means | Status |
 |------|-------------------|------------|--------|
-| 0.1 | **Tenant model** end-to-end: stable `tenant_id` (or org id) on every job, audit row, artifact, and API key | Cross-tenant access tests fail in CI | **In progress:** `X-Nexo-Tenant` on copilot API; `ProductFleetTenantIsolationTests` + `NexoHttpTenantTests` in CI |
-| 0.2 | **Entitlements configuration** (file or DB) keyed by plan: seats, `included_jobs`, `max_concurrency`, `retention_days`, `sso_enabled`, `audit_export`, `deployment_mode` | Same binary runs with different config profiles (dev/staging/prod) | **Started:** `NexoEntitlementsOptions` fields; copilot hourly quota enforced |
-| 0.3 | **Usage counters** (jobs submitted, jobs succeeded, tokens optional if BYOK proxy) emitted to logs or metrics table | You can answer “how many jobs per tenant last 24h?” | **Started:** `ITenantUsageStore`, `GET /api/usage/summary`, structured `NexoUsage` logs |
-| 0.4 | **Reference deployment** documented: compose (or Helm) for “single-tenant production shape” matching what you sell as Private | New hire reproduces deploy from docs in one session | **Started:** `docker-compose.private-single-tenant.yml` + `docs/product-fleet/private-reference-deployment.md` |
-| 0.5 | **Observability baseline**: structured logs, health checks, redacted config export for support | On-call playbook v0.1 exists | **Started:** `GET /api/support/diagnostics`, copilot audit `TenantId`, [`on-call-playbook-v0.1.md`](./product-fleet/on-call-playbook-v0.1.md) |
+| 0.1 | **Tenant model** end-to-end: stable `tenant_id` (or org id) on every job, audit row, artifact, and API key | Cross-tenant access tests fail in CI | **Done:** `X-Nexo-Tenant`; `ProductFleetTenantIsolationTests` + `NexoHttpTenantTests` |
+| 0.2 | **Entitlements configuration** (file or DB) keyed by plan: seats, `included_jobs`, `max_concurrency`, `retention_days`, `sso_enabled`, `audit_export`, `deployment_mode` | Same binary runs with different config profiles (dev/staging/prod) | **Done:** `NexoEntitlementsOptions`; copilot hourly quota enforced |
+| 0.3 | **Usage counters** (jobs submitted, jobs succeeded, tokens optional if BYOK proxy) emitted to logs or metrics table | You can answer “how many jobs per tenant last 24h?” | **Done:** `ITenantUsageStore`, `GET /api/usage/summary`, `NexoUsage` logs |
+| 0.4 | **Reference deployment** documented: compose (or Helm) for “single-tenant production shape” matching what you sell as Private | New hire reproduces deploy from docs in one session | **Done:** `docker-compose.private-single-tenant.yml` + [`private-reference-deployment.md`](./product-fleet/private-reference-deployment.md) |
+| 0.5 | **Observability baseline**: structured logs, health checks, redacted config export for support | On-call playbook v0.1 exists | **Done:** `GET /api/support/diagnostics`, copilot audit `TenantId`, [`on-call-playbook-v0.1.md`](./product-fleet/on-call-playbook-v0.1.md) |
 | 0.6 | **Legal/commercial shell**: entity, basic ToS/Privacy for a website, DPA template if Cloud will hold customer data | Counsel-reviewed drafts (timing varies) |
 
 **Exit:** you can run **one production-shaped tenant** with measurable usage and no ambiguous identity.
@@ -38,8 +38,8 @@ Private is usually **less COGS risk** and forces **install, upgrade, and air-gap
 | 1.2 | **License or subscription check** (even v0: signed JWT license file or online activation with **air-gap fallback**) | Expired license degrades gracefully (read-only or block execution—your policy, documented) | **Started:** `NexoPrivateLicenseOptions`, `PrivateLicenseMiddleware`, sample [`sample-private-license.json`](./product-fleet/sample-private-license.json) |
 | 1.3 | **Secrets**: BYOK storage for provider keys; document what never leaves host | Security one-pager accurate | **Started:** [`private-byok-security.md`](./product-fleet/private-byok-security.md) |
 | 1.4 | **Backup/restore** runbook + tested restore for DB and object stores you use | RPO/RTO stated on support page | **Started:** [`private-backup-restore.md`](./product-fleet/private-backup-restore.md) (RPO 24h / RTO 4h pilot defaults) |
-| 1.5 | **Private pricing + invoice flow** (Stripe Invoicing, Paddle, or manual) + **order form template** | First paying Private customer can be billed without heroics |
-| 1.6 | **Support boundaries**: severity levels, response-time targets for paid Private | Published on website or contract appendix |
+| 1.5 | **Private pricing + invoice flow** (Stripe Invoicing, Paddle, or manual) + **order form template** | First paying Private customer can be billed without heroics | **Started:** [`private-order-form-template.md`](./product-fleet/private-order-form-template.md) |
+| 1.6 | **Support boundaries**: severity levels, response-time targets for paid Private | Published on website or contract appendix | **Started:** [`private-support-boundaries.md`](./product-fleet/private-support-boundaries.md) |
 
 **Exit:** **first annual Private customer** or equivalent pilot revenue with a repeatable deploy story.
 
@@ -49,11 +49,11 @@ Private is usually **less COGS risk** and forces **install, upgrade, and air-gap
 
 Only start when Phase 0 is solid; overlap Phase 1 if you have capacity.
 
-| Step | What to implement | Done means |
-|------|-------------------|------------|
-| 2.1 | **AWS account structure**: prod/stage, IAM boundaries, secrets manager, VPC | No secrets in git; least-privilege roles |
-| 2.2 | **Isolation**: per-tenant DB schema or DB, or strict row-level security + proven tests; network policies between services | Third-party or internal pen test of **tenant escape** path |
-| 2.3 | **Control plane**: signup, org creation, invite flow, role model (admin vs member) | Non-admin cannot read other org’s jobs |
+| Step | What to implement | Done means | Status |
+|------|-------------------|------------|--------|
+| 2.1 | **AWS account structure**: prod/stage, IAM boundaries, secrets manager, VPC | No secrets in git; least-privilege roles | **Started:** [`cloud-aws-account-structure.md`](./product-fleet/cloud-aws-account-structure.md) |
+| 2.2 | **Isolation**: per-tenant DB schema or DB, or strict row-level security + proven tests; network policies between services | Third-party or internal pen test of **tenant escape** path | **Started:** `RequireOrgMembership` + `ProductFleetOrgControlPlaneTests`; [`docker-compose.cloud-multi-tenant.yml`](../docker-compose.cloud-multi-tenant.yml) |
+| 2.3 | **Control plane**: signup, org creation, invite flow, role model (admin vs member) | Non-admin cannot read other org’s jobs | **Started:** `IOrganizationStore`, `/api/orgs/*`, admin-only invites |
 | 2.4 | **Stripe Billing**: products/prices for seats; optional metered usage for jobs/storage | Test subscription + upgrade + cancel in staging |
 | 2.5 | **Metering pipeline**: usage events → aggregation job → Stripe usage records (or internal ledger if invoiced) | Overage bill matches product-defined job definition |
 | 2.6 | **Abuse controls**: rate limits, CAPTCHA or email domain rules, plan caps | Cost cannot spike unbounded from one free account |

--- a/docs/product-fleet/cloud-aws-account-structure.md
+++ b/docs/product-fleet/cloud-aws-account-structure.md
@@ -1,0 +1,46 @@
+# Cloud AWS account structure (Phase 2.1)
+
+Reference layout for **Nexo Cloud** staging and production. Adapt account IDs and region to your org.
+
+## Account topology
+
+| Account | Purpose | Network |
+|---------|---------|---------|
+| **management** | AWS Organizations, billing, SSO | No workloads |
+| **shared-services** | ECR, CI artifacts, Route53 public zones | Private connectivity to workload accounts |
+| **nexo-cloud-staging** | Multi-tenant staging | VPC per env; no prod data |
+| **nexo-cloud-prod** | Paying customers | Isolated subnets; WAF on ingress |
+
+## IAM boundaries (least privilege)
+
+| Role | Scope | Notes |
+|------|-------|-------|
+| `nexo-deploy-staging` | EKS/ECS deploy in staging only | OIDC from GitHub Actions |
+| `nexo-runtime-prod` | Read secrets, write CloudWatch logs | No `*` on `s3:*` |
+| `nexo-support-readonly` | CloudWatch + diagnostics export bucket | Break-glass via SSO |
+
+**Rule:** no long-lived access keys in git. Use **Secrets Manager** or **SSM Parameter Store** for:
+
+- Stripe webhook signing secret
+- Per-tenant BYOK vault references (not raw keys in shared config)
+
+## VPC sketch (prod)
+
+```
+Internet → ALB (TLS) → Nexo.API (private subnets)
+                      → Ollama gateway / BYOK proxy (optional)
+RDS or DynamoDB (tenant metadata) — private subnets only
+S3 (artifacts) — bucket policies per tenant prefix (future)
+```
+
+## Secrets checklist
+
+- [ ] `Nexo__Security__ApiKey` in Secrets Manager, not compose files
+- [ ] Stripe keys in management account billing integration only
+- [ ] Separate KMS keys for staging vs prod
+- [ ] CloudTrail enabled on all workload accounts
+
+## Related
+
+- [`cloud-reference-deployment.md`](./cloud-reference-deployment.md) — local multi-tenant compose shape
+- [`MonetizationProductDesign.md`](../MonetizationProductDesign.md) — Cloud tier entitlements

--- a/docs/product-fleet/cloud-reference-deployment.md
+++ b/docs/product-fleet/cloud-reference-deployment.md
@@ -1,0 +1,71 @@
+# Cloud multi-tenant reference deployment (Phase 2)
+
+Local **staging shape** for Nexo Cloud: multiple orgs, membership enforcement, shared API process.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Same base requirements as Private reference stack
+
+## Quick start
+
+```bash
+export OLLAMA_MODEL=llama3.1:latest
+docker compose -f docker-compose.cloud-multi-tenant.yml up --build -d
+curl -sS http://127.0.0.1:8080/health
+```
+
+## Control plane flow (Phase 2.3)
+
+1. **Create org** (creator becomes admin when `X-Nexo-User` is set):
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/api/orgs \
+  -H 'Content-Type: application/json' \
+  -H 'X-Nexo-User: alice@acme.example' \
+  -d '{"name":"Acme Cloud"}'
+```
+
+2. **Add a member** (admin only):
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8080/api/orgs/<orgId>/members" \
+  -H 'Content-Type: application/json' \
+  -H 'X-Nexo-User: alice@acme.example' \
+  -H 'X-Nexo-Org: <orgId>' \
+  -d '{"userId":"bob@acme.example","role":"Member"}'
+```
+
+3. **Copilot job** (requires org membership; tenant must match org scope):
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/api/copilot/task \
+  -H 'Content-Type: application/json' \
+  -H 'X-Nexo-User: bob@acme.example' \
+  -H 'X-Nexo-Org: <orgId>' \
+  -H 'X-Nexo-Tenant: <tenantId from org response>' \
+  -d '{"task":"Summarize usage"}'
+```
+
+## Cloud vs Private headers
+
+| Header | Private (default) | Cloud (`RequireOrgMembership=true`) |
+|--------|-------------------|-------------------------------------|
+| `X-Nexo-Tenant` | Required for isolation | Must match org `tenantId` |
+| `X-Nexo-User` | Optional | Required on copilot/usage |
+| `X-Nexo-Org` | N/A | Required on copilot/usage |
+
+Staging headers are **not** production auth — replace with SSO (Phase 3.1) before GA.
+
+## Configuration
+
+| Setting | Cloud reference value |
+|---------|----------------------|
+| `Nexo__Product__RequireOrgMembership` | `true` |
+| `Nexo__Entitlements__DeploymentMode` | `Cloud` |
+| `Nexo__Entitlements__MaxCopilotSubmissionsPerHour` | per tier |
+
+## Related
+
+- [`cloud-aws-account-structure.md`](./cloud-aws-account-structure.md)
+- [`private-reference-deployment.md`](./private-reference-deployment.md)

--- a/docs/product-fleet/private-order-form-template.md
+++ b/docs/product-fleet/private-order-form-template.md
@@ -1,0 +1,50 @@
+# Private order form template (Phase 1.5)
+
+Use this skeleton for the first annual **Nexo Private** pilot. Adapt with counsel before signature.
+
+## Order summary
+
+| Field | Value |
+|-------|-------|
+| Customer legal name | |
+| Billing contact | |
+| Technical contact | |
+| Deployment mode | **Nexo Private** (single-tenant, customer-controlled host) |
+| Contract term | 12 months |
+| Renewal | Auto-renew annual unless 60-day written notice |
+| Currency | USD |
+
+## SKU line items
+
+| Line | Qty | Unit | Annual price | Notes |
+|------|-----|------|--------------|-------|
+| Nexo Private — Team Self-Host seats | | seat | per [`MonetizationProductDesign.md`](../MonetizationProductDesign.md) | Includes copilot + audit baseline |
+| Priority support add-on (optional) | 1 | org | | Next-business-day email |
+| Professional services — production readiness (optional) | | fixed SOW | | Deploy + policy workshop |
+
+## Entitlements (attach as exhibit)
+
+| Entitlement | Pilot value |
+|-------------|-------------|
+| Licensed tenant id | |
+| Seats | |
+| `MaxCopilotSubmissionsPerHour` | 0 = unlimited unless capped |
+| License file expiry | |
+| BYOK required | Yes (recommended) |
+
+## Billing mechanics
+
+1. **Invoice** — Net 30 from order form execution (Stripe Invoicing, Paddle, or manual wire).
+2. **True-up** — Quarterly seat reconciliation against license `seats` field.
+3. **Overage** — Not applicable for Private v1 unless PS hours exceed SOW.
+
+## Customer obligations
+
+- Maintain supported Docker / host OS per [`private-reference-deployment.md`](./private-reference-deployment.md)
+- Store provider API keys on-host per [`private-byok-security.md`](./private-byok-security.md)
+- Execute quarterly backup/restore drill per [`private-backup-restore.md`](./private-backup-restore.md)
+
+## Vendor obligations
+
+- Deliver pinned release artifacts and license file
+- Support per [`private-support-boundaries.md`](./private-support-boundaries.md)

--- a/docs/product-fleet/private-support-boundaries.md
+++ b/docs/product-fleet/private-support-boundaries.md
@@ -1,0 +1,41 @@
+# Private support boundaries (Phase 1.6)
+
+Published severity levels and response targets for **paid Nexo Private** pilots. Adjust in contract exhibits as needed.
+
+## Severity definitions
+
+| Severity | Definition | Examples |
+|----------|------------|----------|
+| **S1 — Critical** | Production API unavailable or all copilot jobs failing | `/health` down, license gate mis-config blocks all work |
+| **S2 — Major** | Degraded service; workaround exists | Elevated 429s, single integration failure, Ollama unreachable |
+| **S3 — Minor** | Question, doc gap, non-blocking defect | UI copy, log noise, feature request |
+
+## Response targets (business hours)
+
+| Severity | First response | Update cadence | Resolution target |
+|----------|----------------|----------------|-------------------|
+| S1 | 4 hours | Every 4 hours | 1 business day (mitigation) |
+| S2 | 1 business day | Daily | 5 business days |
+| S3 | 2 business days | Weekly | Best effort / next release |
+
+Business hours: **09:00–17:00 customer local time**, Mon–Fri, excluding published holidays.
+
+## In scope
+
+- Nexo API, CLI, and reference compose stack from order form version
+- License validation and tenant-scoped copilot/usage APIs
+- Diagnostics bundle review (`GET /api/support/diagnostics`)
+- Upgrade guidance for **one minor** version jump
+
+## Out of scope (unless separate SOW)
+
+- Customer cloud account administration
+- LLM provider outages or quota on customer keys
+- Custom agent/brick development
+- 24×7 coverage (Enterprise SKU)
+
+## How to open a ticket
+
+Include: severity, diagnostics JSON, license `expiresAt`, compose/image digest, steps to reproduce, and approximate job volume from `/api/usage/summary`.
+
+See also [`on-call-playbook-v0.1.md`](./on-call-playbook-v0.1.md).

--- a/src/Nexo.Core.Application/Product/Models/Organization.cs
+++ b/src/Nexo.Core.Application/Product/Models/Organization.cs
@@ -1,0 +1,14 @@
+namespace Nexo.Core.Application.Product.Models;
+
+/// <summary>Cloud control-plane organization (maps 1:1 to a copilot tenant scope).</summary>
+public sealed class Organization
+{
+    public required string OrgId { get; init; }
+
+    public required string Name { get; init; }
+
+    /// <summary>Stable tenant id used by copilot, usage, and audit APIs.</summary>
+    public required string TenantId { get; init; }
+
+    public DateTimeOffset CreatedAt { get; init; }
+}

--- a/src/Nexo.Core.Application/Product/Models/OrganizationMember.cs
+++ b/src/Nexo.Core.Application/Product/Models/OrganizationMember.cs
@@ -1,0 +1,12 @@
+namespace Nexo.Core.Application.Product.Models;
+
+public sealed class OrganizationMember
+{
+    public required string OrgId { get; init; }
+
+    public required string UserId { get; init; }
+
+    public OrganizationRole Role { get; init; }
+
+    public DateTimeOffset JoinedAt { get; init; }
+}

--- a/src/Nexo.Core.Application/Product/Models/OrganizationRole.cs
+++ b/src/Nexo.Core.Application/Product/Models/OrganizationRole.cs
@@ -1,0 +1,7 @@
+namespace Nexo.Core.Application.Product.Models;
+
+public enum OrganizationRole
+{
+    Member = 0,
+    Admin = 1,
+}

--- a/src/Nexo.Core.Application/Product/Ports/IOrganizationStore.cs
+++ b/src/Nexo.Core.Application/Product/Ports/IOrganizationStore.cs
@@ -1,0 +1,17 @@
+using Nexo.Core.Application.Product.Models;
+
+namespace Nexo.Core.Application.Product.Ports;
+
+/// <summary>Minimal org control plane (Product Fleet Phase 2.3).</summary>
+public interface IOrganizationStore
+{
+    Organization CreateOrganization(string name, string? tenantId = null);
+
+    Organization? GetOrganization(string orgId);
+
+    OrganizationMember AddMember(string orgId, string userId, OrganizationRole role);
+
+    IReadOnlyList<OrganizationMember> GetMembers(string orgId);
+
+    OrganizationRole? GetMemberRole(string orgId, string userId);
+}

--- a/src/Nexo.Infrastructure/Product/InMemoryOrganizationStore.cs
+++ b/src/Nexo.Infrastructure/Product/InMemoryOrganizationStore.cs
@@ -1,0 +1,109 @@
+using Nexo.Core.Application.Product.Models;
+using Nexo.Core.Application.Product.Ports;
+
+namespace Nexo.Infrastructure.Product;
+
+/// <summary>In-memory org registry for Cloud staging; replace with durable store for production.</summary>
+public sealed class InMemoryOrganizationStore : IOrganizationStore
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<string, Organization> _orgs = new(StringComparer.Ordinal);
+    private readonly List<OrganizationMember> _members = [];
+
+    public Organization CreateOrganization(string name, string? tenantId = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Organization name is required.", nameof(name));
+
+        var orgId = Guid.NewGuid().ToString("D");
+        var tid = string.IsNullOrWhiteSpace(tenantId)
+            ? $"org-{orgId[..8]}"
+            : tenantId.Trim();
+        var org = new Organization
+        {
+            OrgId = orgId,
+            Name = name.Trim(),
+            TenantId = tid,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        lock (_lock)
+        {
+            _orgs[orgId] = org;
+        }
+
+        return org;
+    }
+
+    public Organization? GetOrganization(string orgId)
+    {
+        if (string.IsNullOrWhiteSpace(orgId))
+            return null;
+
+        lock (_lock)
+        {
+            return _orgs.TryGetValue(orgId.Trim(), out var org) ? org : null;
+        }
+    }
+
+    public OrganizationMember AddMember(string orgId, string userId, OrganizationRole role)
+    {
+        if (GetOrganization(orgId) is null)
+            throw new InvalidOperationException($"Organization '{orgId}' was not found.");
+
+        var normalizedUser = NormalizeUser(userId);
+        var member = new OrganizationMember
+        {
+            OrgId = orgId.Trim(),
+            UserId = normalizedUser,
+            Role = role,
+            JoinedAt = DateTimeOffset.UtcNow,
+        };
+
+        lock (_lock)
+        {
+            _members.RemoveAll(m =>
+                string.Equals(m.OrgId, member.OrgId, StringComparison.Ordinal) &&
+                string.Equals(m.UserId, member.UserId, StringComparison.Ordinal));
+            _members.Add(member);
+        }
+
+        return member;
+    }
+
+    public IReadOnlyList<OrganizationMember> GetMembers(string orgId)
+    {
+        if (string.IsNullOrWhiteSpace(orgId))
+            return [];
+
+        lock (_lock)
+        {
+            return _members
+                .Where(m => string.Equals(m.OrgId, orgId.Trim(), StringComparison.Ordinal))
+                .OrderBy(m => m.JoinedAt)
+                .ToList();
+        }
+    }
+
+    public OrganizationRole? GetMemberRole(string orgId, string userId)
+    {
+        if (string.IsNullOrWhiteSpace(orgId) || string.IsNullOrWhiteSpace(userId))
+            return null;
+
+        lock (_lock)
+        {
+            var member = _members.FirstOrDefault(m =>
+                string.Equals(m.OrgId, orgId.Trim(), StringComparison.Ordinal) &&
+                string.Equals(m.UserId, NormalizeUser(userId), StringComparison.Ordinal));
+            return member?.Role;
+        }
+    }
+
+    private static string NormalizeUser(string userId)
+    {
+        var trimmed = userId.Trim();
+        if (trimmed.Length > 256)
+            throw new ArgumentException("User id exceeds maximum length (256).", nameof(userId));
+        return trimmed;
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Helpers/VirtualProduction/NexoCloudApiWebApplicationFactory.cs
+++ b/src/Nexo.Tests.Infrastructure/Helpers/VirtualProduction/NexoCloudApiWebApplicationFactory.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace Nexo.Tests.Infrastructure.Helpers.VirtualProduction;
+
+/// <summary>API host with <see cref="Nexo.API.Security.NexoProductOptions.RequireOrgMembership"/> enabled.</summary>
+public sealed class NexoCloudApiWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nexo:Product:RequireOrgMembership"] = "true",
+            });
+        });
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/API/NexoHttpOrgTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/API/NexoHttpOrgTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nexo.API.Security;
+using Nexo.Core.Application.Product.Models;
+using Nexo.Infrastructure.Product;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.API;
+
+public sealed class NexoHttpOrgTests
+{
+    [Fact]
+    public void TryResolveOrgContext_requires_membership()
+    {
+        var store = new InMemoryOrganizationStore();
+        var org = store.CreateOrganization("Acme");
+        store.AddMember(org.OrgId, "alice@example.com", OrganizationRole.Admin);
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers[NexoHttpOrg.UserHeaderName] = "bob@example.com";
+        context.Request.Headers[NexoHttpOrg.OrgHeaderName] = org.OrgId;
+
+        var ok = NexoHttpOrg.TryResolveOrgContext(
+            context.Request,
+            new NexoProductOptions(),
+            store,
+            out _,
+            out _,
+            out _,
+            out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Contain("not a member");
+    }
+
+    [Fact]
+    public void TryResolveOrgContext_succeeds_for_member()
+    {
+        var store = new InMemoryOrganizationStore();
+        var org = store.CreateOrganization("Acme");
+        store.AddMember(org.OrgId, "alice@example.com", OrganizationRole.Member);
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers[NexoHttpOrg.UserHeaderName] = "alice@example.com";
+        context.Request.Headers[NexoHttpOrg.OrgHeaderName] = org.OrgId;
+
+        var ok = NexoHttpOrg.TryResolveOrgContext(
+            context.Request,
+            new NexoProductOptions(),
+            store,
+            out var resolvedOrg,
+            out var userId,
+            out var role,
+            out _);
+
+        ok.Should().BeTrue();
+        resolvedOrg.OrgId.Should().Be(org.OrgId);
+        userId.Should().Be("alice@example.com");
+        role.Should().Be(OrganizationRole.Member);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Product/InMemoryOrganizationStoreTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Product/InMemoryOrganizationStoreTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Nexo.Core.Application.Product.Models;
+using Nexo.Infrastructure.Product;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Product;
+
+public sealed class InMemoryOrganizationStoreTests
+{
+    [Fact]
+    public void CreateOrganization_assigns_tenant_scope()
+    {
+        var store = new InMemoryOrganizationStore();
+        var org = store.CreateOrganization("Acme");
+
+        org.TenantId.Should().StartWith("org-");
+        store.GetOrganization(org.OrgId).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddMember_and_GetMemberRole_round_trip()
+    {
+        var store = new InMemoryOrganizationStore();
+        var org = store.CreateOrganization("Acme");
+        store.AddMember(org.OrgId, "alice@example.com", OrganizationRole.Admin);
+
+        store.GetMemberRole(org.OrgId, "alice@example.com").Should().Be(OrganizationRole.Admin);
+        store.GetMembers(org.OrgId).Should().ContainSingle();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetOrgControlPlaneTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/ProductFleetOrgControlPlaneTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Nexo.API.Endpoints;
+using Nexo.API.Security;
+using Nexo.Core.Application.Product.Models;
+using Nexo.Tests.Infrastructure.Helpers.VirtualProduction;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.VirtualProduction;
+
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+[Trait("Category", "ProdStyle")]
+public sealed class ProductFleetOrgControlPlaneTests : IClassFixture<NexoCloudApiWebApplicationFactory>
+{
+    private readonly NexoCloudApiWebApplicationFactory _factory;
+
+    public ProductFleetOrgControlPlaneTests(NexoCloudApiWebApplicationFactory factory) => _factory = factory;
+
+    [Fact(Timeout = 120000)]
+    public async Task Member_cannot_add_other_members()
+    {
+        var client = _factory.CreateClient();
+        var org = await CreateOrgAsync(client, "alice@acme.example", "Acme");
+        await AddMemberAsync(client, org.OrgId, "alice@acme.example", "bob@acme.example", OrganizationRole.Member);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"api/orgs/{org.OrgId}/members");
+        request.Headers.TryAddWithoutValidation(NexoHttpOrg.UserHeaderName, "bob@acme.example");
+        request.Headers.TryAddWithoutValidation(NexoHttpOrg.OrgHeaderName, org.OrgId);
+        request.Content = JsonContent.Create(new AddOrganizationMemberRequest("eve@acme.example", "Member"));
+
+        using var response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Copilot_usage_requires_org_membership_when_cloud_mode_enabled()
+    {
+        var client = _factory.CreateClient();
+        var org = await CreateOrgAsync(client, "alice@acme.example", "Acme");
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "api/usage/summary?hours=24");
+        request.Headers.TryAddWithoutValidation(NexoHttpTenant.TenantHeaderName, org.TenantId);
+        request.Headers.TryAddWithoutValidation(NexoHttpOrg.UserHeaderName, "stranger@example.com");
+        request.Headers.TryAddWithoutValidation(NexoHttpOrg.OrgHeaderName, org.OrgId);
+
+        using var response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private static async Task<Organization> CreateOrgAsync(HttpClient client, string creator, string name)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/orgs");
+        request.Headers.TryAddWithoutValidation(NexoHttpOrg.UserHeaderName, creator);
+        request.Content = JsonContent.Create(new CreateOrganizationRequest(name, null));
+        using var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var org = await response.Content.ReadFromJsonAsync<Organization>();
+        org.Should().NotBeNull();
+        return org!;
+    }
+
+    private static async Task AddMemberAsync(
+        HttpClient client,
+        string orgId,
+        string adminUser,
+        string newUser,
+        OrganizationRole role)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"api/orgs/{orgId}/members");
+        request.Headers.TryAddWithoutValidation(NexoHttpOrg.UserHeaderName, adminUser);
+        request.Headers.TryAddWithoutValidation(NexoHttpOrg.OrgHeaderName, orgId);
+        request.Content = JsonContent.Create(new AddOrganizationMemberRequest(newUser, role.ToString()));
+        using var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues Product Fleet after merge of #158 (Phase 0.5 + Phase 1 foundation).

### Phase 1 finish (commercial)
- [`private-order-form-template.md`](docs/product-fleet/private-order-form-template.md) — order form / billing skeleton (1.5)
- [`private-support-boundaries.md`](docs/product-fleet/private-support-boundaries.md) — severity + response targets (1.6)

### Phase 2 Cloud foundation
- **`IOrganizationStore`** + in-memory implementation
- **Control plane API:** `POST /api/orgs`, `GET /api/orgs/{id}`, members list/add (admin-only invites)
- **`RequireOrgMembership`** on `NexoProductOptions` — copilot/usage routes validate `X-Nexo-User` + `X-Nexo-Org` and tenant scope
- [`docker-compose.cloud-multi-tenant.yml`](docker-compose.cloud-multi-tenant.yml) + cloud deployment/AWS structure docs
- **`ProductFleetOrgControlPlaneTests`** (net9 ProdStyle)

### Roadmap
- Phase 0 steps marked **Done**
- Phase 2.1–2.3 marked **Started**

## Test plan
- [x] `InMemoryOrganizationStoreTests`, `NexoHttpOrgTests`
- [x] `ProductFleetOrgControlPlaneTests` (net9.0)
- [x] `dotnet build Nexo.LocalDevCore.slnf`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fcae8ef-3efc-45ca-a399-9c33bffbc9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

