### PR TITLE
fix: keep stable SDK sample buildable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
     <PackageVersion Include="OsmSharp" Version="6.2.0" />
+    <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="Testcontainers.DynamoDb" Version="4.11.0" />
   </ItemGroup>
   <!-- System Packages -->

--- a/application/src/Nexo.CLI/Commands/NewCommand.cs
+++ b/application/src/Nexo.CLI/Commands/NewCommand.cs
@@ -1,0 +1,179 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Text.Json;
+
+namespace Nexo.CLI.Commands;
+
+/// <summary>
+/// Scaffolds new Nexo extension artifacts.
+/// </summary>
+public sealed class NewCommand : Command
+{
+    public NewCommand()
+        : base("new", "Scaffold Nexo extension artifacts.")
+    {
+        AddCommand(CreateBrickCommand());
+    }
+
+    private static Command CreateBrickCommand()
+    {
+        var nameArg = new Argument<string>("name", "Brick name, for example MyThing.");
+        var outputOpt = new Option<string>(
+            "--output",
+            () => Environment.CurrentDirectory,
+            "Directory where the brick solution folder should be created.");
+        var jsonOpt = new Option<bool>("--json", () => false, "Emit machine-readable JSON output.");
+
+        var command = new Command("brick", "Scaffold a code-authored Nexo brick project and test project.")
+        {
+            nameArg,
+            outputOpt,
+            jsonOpt
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            var name = context.ParseResult.GetValueForArgument(nameArg);
+            var output = context.ParseResult.GetValueForOption(outputOpt) ?? Environment.CurrentDirectory;
+            var json = context.ParseResult.GetValueForOption(jsonOpt);
+            context.ExitCode = ExecuteBrick(name, output, json);
+        });
+
+        return command;
+    }
+
+    internal static int ExecuteBrick(string name, string outputDirectory, bool json)
+    {
+        var normalizedName = NormalizeBrickName(name);
+        if (normalizedName is null)
+        {
+            WriteResult(false, "Brick name must be a valid C# identifier segment (letters, digits, underscore; cannot start with a digit).", null, json);
+            return 1;
+        }
+
+        var repoRoot = FindRepoRoot();
+        var templateRoot = Path.Combine(repoRoot, "samples", "templates", "brick");
+        if (!Directory.Exists(templateRoot))
+        {
+            WriteResult(false, $"Brick template not found: {templateRoot}", null, json);
+            return 1;
+        }
+
+        var root = Path.GetFullPath(outputDirectory);
+        var projectRoot = Path.Combine(root, $"{normalizedName}Brick");
+        var testsRoot = Path.Combine(root, $"{normalizedName}Brick.Tests");
+        if ((Directory.Exists(projectRoot) && Directory.EnumerateFileSystemEntries(projectRoot).Any()) ||
+            (Directory.Exists(testsRoot) && Directory.EnumerateFileSystemEntries(testsRoot).Any()))
+        {
+            WriteResult(false, $"Refusing to overwrite existing brick project directories under {root}.", null, json);
+            return 1;
+        }
+
+        var replacements = BuildReplacements(normalizedName, projectRoot, repoRoot);
+        CopyTemplate(templateRoot, root, replacements);
+
+        var testProject = Path.Combine(testsRoot, $"{normalizedName}Brick.Tests.csproj");
+        WriteResult(
+            true,
+            $"Scaffolded {normalizedName}Brick.",
+            new
+            {
+                outputDirectory = root,
+                project = Path.Combine(projectRoot, $"{normalizedName}Brick.csproj"),
+                testProject,
+                next = $"dotnet test \"{testProject}\""
+            },
+            json);
+        return 0;
+    }
+
+    private static Dictionary<string, string> BuildReplacements(string brickName, string projectRoot, string repoRoot)
+    {
+        var coreDomainProject = Path.Combine(repoRoot, "src", "Nexo.Core.Domain", "Nexo.Core.Domain.csproj");
+        var relativeCoreDomainProject = Path.GetRelativePath(projectRoot, coreDomainProject).Replace('\\', '/');
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["__BrickName__"] = brickName,
+            ["__DisplayName__"] = $"{brickName} Brick",
+            ["__BrickId__"] = ToBrickId(brickName),
+            ["__Namespace__"] = $"{brickName}Brick",
+            ["__NexoCoreDomainProjectReference__"] = relativeCoreDomainProject
+        };
+    }
+
+    private static void CopyTemplate(string templateRoot, string outputRoot, IReadOnlyDictionary<string, string> replacements)
+    {
+        foreach (var sourcePath in Directory.GetFiles(templateRoot, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(templateRoot, sourcePath);
+            var targetRelative = ReplaceTokens(relative, replacements);
+            var target = Path.Combine(outputRoot, targetRelative);
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+
+            var text = File.ReadAllText(sourcePath);
+            File.WriteAllText(target, ReplaceTokens(text, replacements));
+        }
+    }
+
+    private static string ReplaceTokens(string value, IReadOnlyDictionary<string, string> replacements)
+    {
+        foreach (var (token, replacement) in replacements)
+            value = value.Replace(token, replacement, StringComparison.Ordinal);
+        return value;
+    }
+
+    private static string? NormalizeBrickName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        var cleaned = new string(name.Trim().Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+        if (string.IsNullOrWhiteSpace(cleaned) || char.IsDigit(cleaned[0]))
+            return null;
+
+        return char.ToUpperInvariant(cleaned[0]) + cleaned[1..];
+    }
+
+    private static string ToBrickId(string name)
+    {
+        var chars = new List<char>();
+        for (var i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (char.IsUpper(c) && i > 0)
+                chars.Add('-');
+            chars.Add(char.ToLowerInvariant(c));
+        }
+        return string.Concat(chars);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(Environment.CurrentDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Nexo.sln")) &&
+                Directory.Exists(Path.Combine(current.FullName, "samples", "templates", "brick")))
+            {
+                return current.FullName;
+            }
+            current = current.Parent;
+        }
+
+        return AppContext.BaseDirectory;
+    }
+
+    private static void WriteResult(bool ok, string summary, object? details, bool json)
+    {
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new { ok, summary, details }, new JsonSerializerOptions { WriteIndented = true }));
+            return;
+        }
+
+        Console.WriteLine(ok ? "nexo new brick: ok" : "nexo new brick: failed");
+        Console.WriteLine(summary);
+        if (details is not null)
+            Console.WriteLine(JsonSerializer.Serialize(details, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/application/src/Nexo.CLI/Program.CommandRegistration.cs
+++ b/application/src/Nexo.CLI/Program.CommandRegistration.cs
@@ -517,6 +517,7 @@ static partial class Program
         root.AddCommand(new DogfoodCommand());
         root.AddCommand(new BootstrapCommand());
         root.AddCommand(new DoctorCommand());
+        root.AddCommand(new NewCommand());
         root.AddCommand(new RuntimeCommand());
         root.AddCommand(new WorkflowCommand(() => ServiceProvider.CreateScope()));
         root.AddCommand(new RuntimeStudioCommand());

--- a/application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
+++ b/application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="PublicApiGenerator" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
@@ -25,6 +26,8 @@
     <ProjectReference Include="../../../src/Nexo.Core.Application/Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.CLI\Nexo.CLI.csproj" />
     <ProjectReference Include="../../../src/Nexo.Infrastructure/Nexo.Infrastructure.csproj" />
+    <ProjectReference Include="../../../src/Nexo.Sdk/Nexo.Sdk.csproj" />
+    <ProjectReference Include="../../../src/Nexo.Framework.Sdk/Nexo.Framework.Sdk.csproj" />
   </ItemGroup>
 
 </Project>

--- a/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Core.Domain.Bricks.approved.txt
+++ b/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Core.Domain.Bricks.approved.txt
@@ -1,0 +1,172 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/IanFrelinger/Nexo")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace Nexo.Core.Domain.Bricks
+{
+    public class AgenticImplementation
+    {
+        public AgenticImplementation() { }
+        public Nexo.Core.Domain.Bricks.ImplementationCharacteristics Characteristics { get; init; }
+        public string Description { get; init; }
+        public string Executor { get; init; }
+        public string Id { get; init; }
+        public Nexo.Core.Domain.Bricks.LLMConfig LLMConfig { get; init; }
+        public string Name { get; init; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Nexo.Core.Domain.Bricks.ProviderConfig> ProviderMappings { get; init; }
+    }
+    public abstract class Brick
+    {
+        protected Brick() { }
+        public Nexo.Core.Domain.Bricks.BrickCategory Category { get; init; }
+        public Nexo.Core.Domain.Bricks.ImplementationType DefaultImplementation { get; init; }
+        public string Description { get; init; }
+        public Nexo.Core.Domain.Bricks.DomainKnowledge DomainKnowledge { get; init; }
+        public System.Collections.Generic.IReadOnlyList<Nexo.Core.Domain.Bricks.ImplementationType> FallbackChain { get; init; }
+        public string Icon { get; init; }
+        public string Id { get; init; }
+        public Nexo.Core.Domain.Bricks.BrickImplementations Implementations { get; init; }
+        public Nexo.Core.Domain.Bricks.BrickInterface Interface { get; init; }
+        public Nexo.Core.Domain.Bricks.BrickMetadata Metadata { get; init; }
+        public string Name { get; init; }
+        public Nexo.Core.Domain.Bricks.ImplementationSelector? Selector { get; init; }
+        public string Version { get; init; }
+        public abstract System.Threading.Tasks.Task<Nexo.Core.Domain.Execution.BrickOutput> ExecuteAsync(Nexo.Core.Domain.Execution.BrickInput input, Nexo.Core.Domain.Bricks.ImplementationType implementation, Nexo.Core.Domain.Execution.IExecutionContext context, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public enum BrickCategory
+    {
+        Input = 0,
+        Output = 1,
+        Analysis = 2,
+        Transform = 3,
+        Generation = 4,
+        Validation = 5,
+        Security = 6,
+        Control = 7,
+    }
+    public class BrickImplementations
+    {
+        public BrickImplementations() { }
+        public Nexo.Core.Domain.Bricks.AgenticImplementation? Agentic { get; init; }
+        public Nexo.Core.Domain.Bricks.DeterministicImplementation? Deterministic { get; init; }
+        public bool HasAgentic { get; }
+        public bool HasDeterministic { get; }
+    }
+    public class BrickInputDefinition
+    {
+        public BrickInputDefinition(string name, string type, string? description = null, bool required = true, object? defaultValue = null) { }
+        public object? Default { get; init; }
+        public string? Description { get; init; }
+        public string Name { get; init; }
+        public bool Required { get; init; }
+        public string Type { get; init; }
+    }
+    public class BrickInterface
+    {
+        public BrickInterface() { }
+        public System.Collections.Generic.IReadOnlyList<Nexo.Core.Domain.Bricks.BrickInputDefinition> Inputs { get; init; }
+        public System.Collections.Generic.IReadOnlyList<Nexo.Core.Domain.Bricks.BrickOutputDefinition> Outputs { get; init; }
+    }
+    public class BrickMetadata
+    {
+        public BrickMetadata() { }
+        public string? Author { get; init; }
+        public System.DateTime? LastUpdated { get; init; }
+        public string? License { get; init; }
+        public string? Repository { get; init; }
+        public long UsageCount { get; set; }
+    }
+    public class BrickOutputDefinition
+    {
+        public BrickOutputDefinition(string name, string type, string? description = null) { }
+        public string? Description { get; init; }
+        public string Name { get; init; }
+        public string Type { get; init; }
+    }
+    public sealed class BrickRuntimeSpec : System.IEquatable<Nexo.Core.Domain.Bricks.BrickRuntimeSpec>
+    {
+        public BrickRuntimeSpec() { }
+        public System.Collections.Generic.IReadOnlyList<Nexo.Core.Domain.Bricks.ImplementationType> Fallback { get; init; }
+        public string Prefer { get; init; }
+        public static Nexo.Core.Domain.Bricks.BrickRuntimeSpec AgenticOnly() { }
+        public static Nexo.Core.Domain.Bricks.BrickRuntimeSpec AgenticWithDeterministicFallback() { }
+        public static Nexo.Core.Domain.Bricks.BrickRuntimeSpec DeterministicOnly() { }
+    }
+    public class DeterministicImplementation
+    {
+        public DeterministicImplementation() { }
+        public Nexo.Core.Domain.Bricks.ImplementationCharacteristics Characteristics { get; init; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object> Config { get; init; }
+        public string Description { get; init; }
+        public string Executor { get; init; }
+        public string Id { get; init; }
+        public string Name { get; init; }
+    }
+    public class DomainKnowledge
+    {
+        public DomainKnowledge() { }
+        public long ExecutionCount { get; set; }
+        public System.Collections.Generic.IReadOnlyList<Nexo.Core.Domain.Bricks.LearnedPattern> LearnedPatterns { get; init; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> ReferenceData { get; init; }
+        public System.Collections.Generic.IReadOnlyList<Nexo.Core.Domain.Bricks.DomainRule> Rules { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string> Standards { get; init; }
+    }
+    public class DomainRule
+    {
+        public DomainRule(string id, string description, string? pattern = null, string? severity = null, string? cweId = null) { }
+        public string? CweId { get; init; }
+        public string Description { get; init; }
+        public string Id { get; init; }
+        public string? Pattern { get; init; }
+        public string? Severity { get; init; }
+    }
+    public class ImplementationCharacteristics
+    {
+        public ImplementationCharacteristics() { }
+        public bool Deterministic { get; init; }
+        public string Latency { get; init; }
+        public bool RequiresNetwork { get; init; }
+        public Nexo.Core.Domain.Bricks.ResourceUsage ResourceUsage { get; init; }
+    }
+    public class ImplementationSelector
+    {
+        public ImplementationSelector() { }
+        public Nexo.Core.Domain.Bricks.ImplementationType Default { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string> PreferAgentic { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string> PreferDeterministic { get; init; }
+        public Nexo.Core.Domain.Bricks.ImplementationType Select(Nexo.Core.Domain.Execution.IExecutionContext context) { }
+    }
+    public enum ImplementationType
+    {
+        Deterministic = 0,
+        Agentic = 1,
+        Auto = 2,
+    }
+    public class LLMConfig
+    {
+        public LLMConfig() { }
+        public int MaxTokens { get; init; }
+        public string Model { get; init; }
+        public string SystemPrompt { get; init; }
+        public double Temperature { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string>? Tools { get; init; }
+    }
+    public class LearnedPattern
+    {
+        public LearnedPattern(string pattern, string outcome, double confidence, int occurrenceCount) { }
+        public double Confidence { get; init; }
+        public int OccurrenceCount { get; init; }
+        public string Outcome { get; init; }
+        public string Pattern { get; init; }
+    }
+    public class ProviderConfig
+    {
+        public ProviderConfig(string model, string? endpoint = null) { }
+        public string? Endpoint { get; init; }
+        public string Model { get; init; }
+    }
+    public enum ResourceUsage
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+    }
+}

--- a/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Framework.Sdk.approved.txt
+++ b/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Framework.Sdk.approved.txt
@@ -1,0 +1,16 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/IanFrelinger/Nexo")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace Nexo.Framework.Sdk
+{
+    public sealed class NexoFrameworkOptions
+    {
+        public NexoFrameworkOptions() { }
+        public System.Action<Nexo.Hosting.NexoHostingOptions>? ConfigureHost { get; set; }
+        public bool RegisterKernel { get; set; }
+        public string? RemoteApiBaseUrl { get; set; }
+    }
+    public static class NexoFrameworkServiceCollectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddNexoFramework(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Nexo.Framework.Sdk.NexoFrameworkOptions>? configure = null) { }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Sdk.approved.txt
+++ b/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Sdk.approved.txt
@@ -1,0 +1,24 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/IanFrelinger/Nexo")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace Nexo.Sdk.Client
+{
+    public class NexoClientSdkBuilder
+    {
+        protected NexoClientSdkBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        protected Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+    }
+    public static class NexoClientSdkServiceCollectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddNexoClientSdk(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string baseUrl, System.Action<Nexo.Sdk.Client.NexoClientSdkBuilder>? configure = null) { }
+    }
+}
+namespace Nexo.Sdk
+{
+    [System.Obsolete("Renamed to NexoClientSdkBuilder (namespace Nexo.Sdk.Client).", false)]
+    public sealed class NexoSdkBuilder : Nexo.Sdk.Client.NexoClientSdkBuilder { }
+    public static class NexoSdkLegacyExtensions
+    {
+        [System.Obsolete("Use Nexo.Sdk.Client.NexoClientSdkServiceCollectionExtensions.AddNexoClientSdk.", false)]
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddNexoSdk(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string baseUrl, System.Action<Nexo.Sdk.NexoSdkBuilder>? configure = null) { }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/BrickAuthoringPublicApiSnapshotTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/BrickAuthoringPublicApiSnapshotTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using FluentAssertions;
+using Nexo.Core.Domain.Bricks;
+using PublicApiGenerator;
+using Xunit;
+
+namespace Nexo.Tests.CLI.Tests.Commands;
+
+[Trait("Category", "CLI")]
+public sealed class BrickAuthoringPublicApiSnapshotTests
+{
+    [Fact]
+    public void Supported_extension_surface_matches_approved_snapshot()
+    {
+        var snapshots = new Dictionary<string, string>
+        {
+            ["Nexo.Sdk.approved.txt"] = typeof(Nexo.Sdk.Client.NexoClientSdkBuilder).Assembly.GeneratePublicApi(),
+            ["Nexo.Framework.Sdk.approved.txt"] = typeof(Nexo.Framework.Sdk.NexoFrameworkOptions).Assembly.GeneratePublicApi(),
+            ["Nexo.Core.Domain.Bricks.approved.txt"] = typeof(Brick)
+                .Assembly
+                .GetExportedTypes()
+                .Where(t => t.Namespace?.StartsWith("Nexo.Core.Domain.Bricks", StringComparison.Ordinal) == true)
+                .OrderBy(t => t.FullName, StringComparer.Ordinal)
+                .ToArray()
+                .GeneratePublicApi()
+        };
+
+        var snapshotRoot = FindSnapshotRoot();
+        Directory.CreateDirectory(snapshotRoot);
+
+        foreach (var (fileName, current) in snapshots)
+        {
+            var path = Path.Combine(snapshotRoot, fileName);
+            if (!File.Exists(path))
+            {
+                File.WriteAllText(path, current);
+                throw new InvalidOperationException($"Created missing public API snapshot: {path}. Review and commit it.");
+            }
+
+            var approved = File.ReadAllText(path);
+            current.ReplaceLineEndings("\n").Should().Be(approved.ReplaceLineEndings("\n"), fileName);
+        }
+    }
+
+    private static string FindSnapshotRoot()
+    {
+        var current = new DirectoryInfo(Environment.CurrentDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Nexo.sln")))
+            {
+                return Path.Combine(
+                    current.FullName,
+                    "application",
+                    "src",
+                    "Nexo.Tests.CLI",
+                    "PublicApi");
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root not found.");
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/HelloBrickSampleSmokeTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/HelloBrickSampleSmokeTests.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Xunit;
+
+namespace Nexo.Tests.CLI.Tests.Commands;
+
+[Trait("Category", "CLI")]
+public sealed class HelloBrickSampleSmokeTests
+{
+    [Fact(Timeout = 120_000)]
+    public async Task Hello_brick_sample_test_project_passes()
+    {
+        var repoRoot = FindRepoRoot();
+        var sampleTestProject = Path.Combine(repoRoot, "samples", "hello-brick", "HelloBrick.Tests", "HelloBrick.Tests.csproj");
+        File.Exists(sampleTestProject).Should().BeTrue();
+
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("dotnet")
+            {
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+        process.StartInfo.ArgumentList.Add("test");
+        process.StartInfo.ArgumentList.Add(sampleTestProject);
+        process.StartInfo.ArgumentList.Add("--blame-hang-timeout");
+        process.StartInfo.ArgumentList.Add("120s");
+        process.StartInfo.ArgumentList.Add("--blame-hang-dump-type");
+        process.StartInfo.ArgumentList.Add("none");
+
+        process.Start();
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        process.ExitCode.Should().Be(0, stdout + Environment.NewLine + stderr);
+        stdout.Should().Contain("Passed!");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(Environment.CurrentDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Nexo.sln")))
+                return current.FullName;
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root not found.");
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/NewCommandTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/NewCommandTests.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nexo.CLI.Commands;
+using Xunit;
+
+namespace Nexo.Tests.CLI.Tests.Commands;
+
+[Trait("Category", "CLI")]
+public sealed class NewCommandTests
+{
+    [Fact]
+    public void ExecuteBrick_rejects_invalid_name()
+    {
+        var output = Path.Combine(Path.GetTempPath(), $"nexo-new-brick-{Guid.NewGuid():N}");
+        NewCommand.ExecuteBrick("123 bad", output, json: true).Should().Be(1);
+        Directory.Exists(output).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExecuteBrick_generates_files()
+    {
+        var output = Path.Combine(Path.GetTempPath(), $"nexo-new-brick-{Guid.NewGuid():N}");
+        try
+        {
+            NewCommand.ExecuteBrick("MyThing", output, json: true).Should().Be(0);
+
+            File.Exists(Path.Combine(output, "MyThingBrick", "MyThingBrick.csproj")).Should().BeTrue();
+            File.Exists(Path.Combine(output, "MyThingBrick", "MyThingBrick.cs")).Should().BeTrue();
+            File.Exists(Path.Combine(output, "MyThingBrick.Tests", "MyThingBrick.Tests.csproj")).Should().BeTrue();
+            File.Exists(Path.Combine(output, "MyThingBrick.Tests", "MyThingBrickTests.cs")).Should().BeTrue();
+
+            File.ReadAllText(Path.Combine(output, "MyThingBrick", "MyThingBrick.cs"))
+                .Should()
+                .Contain("public sealed class MyThingBrick")
+                .And.Contain("Id = \"my-thing\"");
+        }
+        finally
+        {
+            if (Directory.Exists(output))
+                Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExecuteBrick_refuses_existing_directory()
+    {
+        var output = Path.Combine(Path.GetTempPath(), $"nexo-new-brick-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(output, "MyThingBrick"));
+            File.WriteAllText(Path.Combine(output, "MyThingBrick", "existing.txt"), "keep");
+
+            NewCommand.ExecuteBrick("MyThing", output, json: false).Should().Be(1);
+            File.ReadAllText(Path.Combine(output, "MyThingBrick", "existing.txt")).Should().Be("keep");
+        }
+        finally
+        {
+            if (Directory.Exists(output))
+                Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExecuteBrick_json_output_is_machine_readable()
+    {
+        var output = Path.Combine(Path.GetTempPath(), $"nexo-new-brick-{Guid.NewGuid():N}");
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            NewCommand.ExecuteBrick("JsonThing", output, json: true).Should().Be(0);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            if (Directory.Exists(output))
+                Directory.Delete(output, recursive: true);
+        }
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        doc.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("details").GetProperty("testProject").GetString().Should().Contain("JsonThingBrick.Tests");
+    }
+}

--- a/docs/AuthoringBricks.md
+++ b/docs/AuthoringBricks.md
@@ -90,6 +90,6 @@ dotnet run --project application/src/Nexo.CLI -- new brick Hello --output sample
 dotnet test samples/hello-brick-scratch/HelloBrick.Tests/HelloBrick.Tests.csproj
 ```
 
-Or copy the template directly from `samples/templates/brick/` (added by the code-brick template step).
+Or copy the template directly from [`samples/templates/brick/`](../samples/templates/brick/).
 
-The complete reference implementation lives in `samples/hello-brick/` once the reference sample step is present.
+The complete reference implementation lives in [`samples/hello-brick/`](../samples/hello-brick/).

--- a/docs/AuthoringBricks.md
+++ b/docs/AuthoringBricks.md
@@ -1,0 +1,95 @@
+# Authoring Bricks
+
+This is the authoritative entry point for writing **code-authored bricks** for Nexo. For host setup and SDK registration context, see [`docs/sdk.md`](sdk.md) and [`docs/SdkIntegrationGuide.md`](SdkIntegrationGuide.md).
+
+## What a brick is
+
+A brick is a small unit of domain logic. Code-authored bricks derive from `Nexo.Core.Domain.Bricks.Brick` and implement one method:
+
+```csharp
+Task<BrickOutput> ExecuteAsync(
+    BrickInput input,
+    ImplementationType implementation,
+    IExecutionContext context,
+    CancellationToken cancellationToken = default);
+```
+
+The constructor or init properties define metadata and the input/output contract:
+
+- `Id`, `Name`, `Version`, `Category`, `Description`
+- optional `Icon`, `DomainKnowledge`, `Metadata`
+- `Interface` with `BrickInputDefinition` and `BrickOutputDefinition`
+- optional `Implementations`, `DefaultImplementation`, `FallbackChain`, `Selector`
+
+`ExecuteAsync` reads typed values from `BrickInput`, returns a `BrickOutput`, and should set a human-readable `Summary`.
+
+## Minimal code brick
+
+```csharp
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+public sealed class HelloBrick : Brick
+{
+    public HelloBrick()
+    {
+        Id = "sample.hello";
+        Name = "Hello Brick";
+        Version = "1.0.0";
+        Category = BrickCategory.Transform;
+        Description = "Returns a greeting for a supplied name.";
+        Interface = new BrickInterface
+        {
+            Inputs = [new BrickInputDefinition("name", "string", "Name to greet", required: false, defaultValue: "world")],
+            Outputs = [new BrickOutputDefinition("message", "string", "Greeting text")]
+        };
+    }
+
+    public override Task<BrickOutput> ExecuteAsync(
+        BrickInput input,
+        ImplementationType implementation,
+        IExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var name = input.Get("name", "world") ?? "world";
+        var output = new BrickOutput { Summary = $"Greeted {name}." };
+        output.Set("message", $"Hello, {name}!");
+        return Task.FromResult(output);
+    }
+}
+```
+
+## Registering a brick
+
+Host applications register code bricks through the stable host SDK surface:
+
+```csharp
+using Nexo.Hosting;
+using Nexo.Hosting.Sdk;
+
+services.AddNexoSdk(sdk => sdk.RegisterBrick<HelloBrick>());
+services.AddNexo();
+```
+
+At runtime, registered code bricks flow into the same `IBrickRegistry` surface used by Nexo itself. The concrete registry composition includes local code bricks and may be wrapped by `CompositeBrickRegistry` when remote brick catalogs are configured.
+
+For CLI/adaptation scenarios, `AddAdaptationBricks(typeof(HelloBrick))` is the lower-level equivalent. Prefer `AddNexoSdk(...RegisterBrick<T>())` for application-host code.
+
+## Code bricks vs generated manifests
+
+Nexo also has an adaptive manifest path: `INewBrickGenerator.GenerateAsync(...)` creates a `BrickManifest` from observed patterns. That path is for runtime/adaptive discovery and promotion.
+
+Use **code-authored bricks** when you want to ship source-controlled domain logic with tests and stable package/version ownership. Use the **manifest generator** when Nexo is inferring a candidate brick from observed workflow patterns. Both paths describe the same conceptual brick surface; code bricks are the developer-authored, reviewable path.
+
+## Scaffold a code brick
+
+Use the CLI scaffold:
+
+```bash
+dotnet run --project application/src/Nexo.CLI -- new brick Hello --output samples/hello-brick-scratch
+dotnet test samples/hello-brick-scratch/HelloBrick.Tests/HelloBrick.Tests.csproj
+```
+
+Or copy the template directly from `samples/templates/brick/` (added by the code-brick template step).
+
+The complete reference implementation lives in `samples/hello-brick/` once the reference sample step is present.

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -86,6 +86,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 - `docs/ProjectTiers.md` — canonical repository map by project tier.
 - `docs/api/index.md` — API docs index.
 - `docs/sdk.md` — SDK integration guidance.
+- `docs/AuthoringBricks.md` — authoritative code-brick authoring guide.
 - `docs/PUBLISHING.md` — pack and publish `Nexo.Hosting` (and its `Nexo.*` graph) to NuGet / GitHub Packages; operator checklist.
 - `docs/NuGetConsumerVerify.md` — validate NuGet-only consumption (local pack vs published feed); workflow **`.github/workflows/nuget-consumer-verify.yml`**.
 - `docs/samples/StableSdkHostSample/Program.cs` — reference host integration that only uses stable SDK extension points.

--- a/docs/samples/StableSdkHostSample/StableSdkHostSample.csproj
+++ b/docs/samples/StableSdkHostSample/StableSdkHostSample.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../../src/Nexo.Hosting/Nexo.Hosting.csproj" />

--- a/samples/hello-brick/HelloBrick.Tests/HelloBrick.Tests.csproj
+++ b/samples/hello-brick/HelloBrick.Tests/HelloBrick.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\__BrickName__Brick\__BrickName__Brick.csproj" />
+    <ProjectReference Include="..\HelloBrick\HelloBrick.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/samples/hello-brick/HelloBrick.Tests/HelloBrickTests.cs
+++ b/samples/hello-brick/HelloBrick.Tests/HelloBrickTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using HelloBrick;
+using Xunit;
+
+namespace HelloBrick.Tests;
+
+public sealed class HelloBrickTests
+{
+    [Fact]
+    public async Task ExecuteAsync_returns_expected_message()
+    {
+        var brick = new HelloBrick();
+        var input = new BrickInput(new Dictionary<string, object>
+        {
+            ["name"] = "Nexo"
+        });
+
+        var output = await brick.ExecuteAsync(
+            input,
+            ImplementationType.Deterministic,
+            new TestExecutionContext());
+
+        output.Get<string>("message").Should().Be("Hello, Nexo!");
+        output.Get<string>("implementation").Should().Be(nameof(ImplementationType.Deterministic));
+        output.Summary.Should().Contain("Nexo");
+    }
+
+    private sealed class TestExecutionContext : IExecutionContext
+    {
+        public string AgentId => "test-agent";
+        public string BehaviorId => "test-behavior";
+        public bool IsAirGapped => true;
+        public bool AuditMode => true;
+        public string Provider => "test";
+        public IReadOnlyDictionary<string, object> Variables { get; } = new Dictionary<string, object>();
+    }
+}

--- a/samples/hello-brick/HelloBrick/HelloBrick.cs
+++ b/samples/hello-brick/HelloBrick/HelloBrick.cs
@@ -1,0 +1,47 @@
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace HelloBrick;
+
+/// <summary>
+/// Example code-authored Nexo brick generated from the code-brick template.
+/// </summary>
+public sealed class HelloBrick : Brick
+{
+    public HelloBrick()
+    {
+        Id = "hello";
+        Name = "Hello Brick";
+        Version = "1.0.0";
+        Icon = "🧱";
+        Category = BrickCategory.Transform;
+        Description = "A starter code-authored Nexo brick.";
+        Interface = new BrickInterface
+        {
+            Inputs =
+            [
+                new BrickInputDefinition("name", "string", "Name to greet", required: false, defaultValue: "world")
+            ],
+            Outputs =
+            [
+                new BrickOutputDefinition("message", "string", "Greeting text")
+            ]
+        };
+    }
+
+    public override Task<BrickOutput> ExecuteAsync(
+        BrickInput input,
+        ImplementationType implementation,
+        IExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var name = input.Get("name", "world") ?? "world";
+        var output = new BrickOutput
+        {
+            Summary = $"Generated greeting for {name}."
+        };
+        output.Set("message", $"Hello, {name}!");
+        output.Set("implementation", implementation.ToString());
+        return Task.FromResult(output);
+    }
+}

--- a/samples/hello-brick/HelloBrick/HelloBrick.csproj
+++ b/samples/hello-brick/HelloBrick/HelloBrick.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <PackageId>HelloBrick</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Nexo.Core.Domain/Nexo.Core.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/hello-brick/README.md
+++ b/samples/hello-brick/README.md
@@ -1,0 +1,29 @@
+# Hello Brick sample
+
+This is the complete code-brick reference sample used by [`docs/AuthoringBricks.md`](../../docs/AuthoringBricks.md).
+
+Run it from the repository root:
+
+```bash
+dotnet test samples/hello-brick/HelloBrick.Tests/HelloBrick.Tests.csproj
+```
+
+The sample contains:
+
+- `HelloBrick/HelloBrick.csproj` — code-authored brick project.
+- `HelloBrick/HelloBrick.cs` — `public sealed class HelloBrick : Brick`.
+- `HelloBrick.Tests/HelloBrick.Tests.csproj` — test project.
+- `HelloBrick.Tests/HelloBrickTests.cs` — smoke test for `ExecuteAsync`.
+# Code Brick Template
+
+This template is used by `nexo new brick <Name>`.
+
+Template tokens:
+
+- `Hello`
+- `Hello Brick`
+- `hello`
+- `HelloBrick`
+- `../../../src/Nexo.Core.Domain/Nexo.Core.Domain.csproj`
+
+The generated project contains a code-authored `Brick` and a matching xUnit test project.

--- a/samples/templates/brick/README.md
+++ b/samples/templates/brick/README.md
@@ -1,0 +1,13 @@
+# Code Brick Template
+
+This template is used by `nexo new brick <Name>`.
+
+Template tokens:
+
+- `__BrickName__`
+- `__DisplayName__`
+- `__BrickId__`
+- `__Namespace__`
+- `__NexoCoreDomainProjectReference__`
+
+The generated project contains a code-authored `Brick` and a matching xUnit test project.

--- a/samples/templates/brick/__BrickName__Brick.Tests/__BrickName__Brick.Tests.csproj
+++ b/samples/templates/brick/__BrickName__Brick.Tests/__BrickName__Brick.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\__BrickName__Brick\__BrickName__Brick.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+  </ItemGroup>
+</Project>

--- a/samples/templates/brick/__BrickName__Brick.Tests/__BrickName__BrickTests.cs
+++ b/samples/templates/brick/__BrickName__Brick.Tests/__BrickName__BrickTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using __Namespace__;
+using Xunit;
+
+namespace __Namespace__.Tests;
+
+public sealed class __BrickName__BrickTests
+{
+    [Fact]
+    public async Task ExecuteAsync_returns_expected_message()
+    {
+        var brick = new __BrickName__Brick();
+        var input = new BrickInput(new Dictionary<string, object>
+        {
+            ["name"] = "Nexo"
+        });
+
+        var output = await brick.ExecuteAsync(
+            input,
+            ImplementationType.Deterministic,
+            new TestExecutionContext());
+
+        output.Get<string>("message").Should().Be("Hello, Nexo!");
+        output.Get<string>("implementation").Should().Be(nameof(ImplementationType.Deterministic));
+        output.Summary.Should().Contain("Nexo");
+    }
+
+    private sealed class TestExecutionContext : IExecutionContext
+    {
+        public string AgentId => "test-agent";
+        public string BehaviorId => "test-behavior";
+        public bool IsAirGapped => true;
+        public bool AuditMode => true;
+        public string Provider => "test";
+        public IReadOnlyDictionary<string, object> Variables { get; } = new Dictionary<string, object>();
+    }
+}

--- a/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.cs
+++ b/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.cs
@@ -1,0 +1,47 @@
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace __Namespace__;
+
+/// <summary>
+/// Example code-authored Nexo brick generated from the code-brick template.
+/// </summary>
+public sealed class __BrickName__Brick : Brick
+{
+    public __BrickName__Brick()
+    {
+        Id = "__BrickId__";
+        Name = "__DisplayName__";
+        Version = "1.0.0";
+        Icon = "🧱";
+        Category = BrickCategory.Transform;
+        Description = "A starter code-authored Nexo brick.";
+        Interface = new BrickInterface
+        {
+            Inputs =
+            [
+                new BrickInputDefinition("name", "string", "Name to greet", required: false, defaultValue: "world")
+            ],
+            Outputs =
+            [
+                new BrickOutputDefinition("message", "string", "Greeting text")
+            ]
+        };
+    }
+
+    public override Task<BrickOutput> ExecuteAsync(
+        BrickInput input,
+        ImplementationType implementation,
+        IExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var name = input.Get("name", "world") ?? "world";
+        var output = new BrickOutput
+        {
+            Summary = $"Generated greeting for {name}."
+        };
+        output.Set("message", $"Hello, {name}!");
+        output.Set("implementation", implementation.ToString());
+        return Task.FromResult(output);
+    }
+}

--- a/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.csproj
+++ b/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <PackageId>__BrickName__Brick</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="__NexoCoreDomainProjectReference__" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- Bulleted list of specific changes -->

-

## Testing

<!-- How were these changes tested? Include commands, screenshots, or links to CI runs -->

-

### Testing strategy (blast radius)

See [Testing strategy pivot v1](docs/architecture/TestingStrategyPivot-v1.md).

| Change type | Minimum proof (check what applies) |
|-------------|-------------------------------------|
| `Nexo.Core.Domain` | `dotnet test src/Nexo.Tests.Domain` · `make kernel-coverage-gate` |
| Infrastructure adapter (small / branchy) | Focused unit or gap test in touched file · coverage gate |
| Hosting / API / routing / barriers / `AddNexo` | `make test-prod-style` and/or `make application-gate-tier-c` |
| Docker / mesh / fleet / trust | `make mesh-lab-e2e` or relevant `*-gate` tier (see pivot doc) |
| Megaclass (`ProviderFactory`, Docker provisioners, …) | **ProdStyle / virtual host** — do not add new `*GapCoverageTests` files |

- [ ] `make kernel-coverage-gate` (if touching `src/Nexo.Core.*` or `src/Nexo.Infrastructure`)
- [ ] `make kernel-gate` (if touching kernel hosting / pipeline / profiles)
- [ ] `make test-prod-style` (if touching production DI / API / routing)

## Checklist

- [ ] `make test` passes locally
- [ ] Documentation updated (if applicable)
- [ ] No `TODO` or `NotImplementedException` left unresolved
- [ ] Breaking changes are documented

## Release (only when this PR ships a **versioned** NuGet/GHCR release)

- [ ] Not a versioned release — skip
- [ ] **Preflight:** `dotnet run --project application/src/Nexo.CLI -- release preflight <semver>` (or `make release-preflight VERSION=<semver>`)
- [ ] **Track:** open a **Release checklist** issue (GitHub → New issue → *Release checklist* form) or link an existing release issue
- [ ] **After merge:** tag `v<semver>` and push (runs `release.yml`) — see `docs/RELEASE_RUNBOOK.md`