### PR TITLE
Make brick authoring buildable outside the repo

### DIFF
--- a/.github/workflows/distribution-matrix-gate.yml
+++ b/.github/workflows/distribution-matrix-gate.yml
@@ -18,6 +18,7 @@ on:
       - ".docker/Dockerfile.api"
       - ".docker/Dockerfile.cli"
       - "scripts/verify-stable-sdk-host-sample-packages.sh"
+      - "scripts/verify-standalone-brick-authoring.sh"
       - "scripts/pack-nexo-hosting-graph.sh"
       - "scripts/pack-nexo-hosting-graph.ps1"
       - "scripts/pack-nexo-hosting-graph.allowlist.txt"
@@ -25,8 +26,11 @@ on:
       - "application/src/Nexo.API/**"
       - "application/src/Nexo.CLI/**"
       - "src/Nexo.Client/**"
+      - "src/Nexo.Authoring/**"
       - "src/Nexo.Hosting/**"
       - "docs/samples/StableSdkHostSample/**"
+      - "samples/templates/brick/**"
+      - "samples/hello-brick/**"
       - "src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/**"
       - "src/Nexo.Tests.Infrastructure/Helpers/VirtualProduction/**"
   pull_request:
@@ -36,6 +40,7 @@ on:
       - ".docker/Dockerfile.api"
       - ".docker/Dockerfile.cli"
       - "scripts/verify-stable-sdk-host-sample-packages.sh"
+      - "scripts/verify-standalone-brick-authoring.sh"
       - "scripts/pack-nexo-hosting-graph.sh"
       - "scripts/pack-nexo-hosting-graph.ps1"
       - "scripts/pack-nexo-hosting-graph.allowlist.txt"
@@ -43,8 +48,11 @@ on:
       - "application/src/Nexo.API/**"
       - "application/src/Nexo.CLI/**"
       - "src/Nexo.Client/**"
+      - "src/Nexo.Authoring/**"
       - "src/Nexo.Hosting/**"
       - "docs/samples/StableSdkHostSample/**"
+      - "samples/templates/brick/**"
+      - "samples/hello-brick/**"
       - "src/Nexo.Tests.Infrastructure/Tests/VirtualProduction/**"
       - "src/Nexo.Tests.Infrastructure/Helpers/VirtualProduction/**"
 
@@ -94,6 +102,20 @@ jobs:
       # doctor --json expects git/curl and a dev-style host; the CLI image is aspnet runtime-only.
       - name: Smoke (pipeline validate --help)
         run: docker run --rm nexo-cli:dist-matrix pipeline validate --help
+
+  standalone-brick-authoring:
+    name: Standalone brick authoring scaffold
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Verify tool-installed nexo new brick outside repo
+        run: bash scripts/verify-standalone-brick-authoring.sh
 
   api-image-http-smoke:
     name: API image + curl /health + /api/status

--- a/.github/workflows/layer-boundary.yml
+++ b/.github/workflows/layer-boundary.yml
@@ -49,10 +49,18 @@ jobs:
             echo "Commercial paths changed — allowing coordinated application/ + src/ integration merges."
           fi
 
-          # --- Runtime bases: no application/ (except commercial vertical integration) ---
+          DISTRIBUTION_AUTHORING=0
+          if echo "$CHANGED" | grep -q '^application/' && \
+             { echo "$CHANGED" | grep -q '^src/Nexo.Authoring/' || \
+               echo "$CHANGED" | grep -q '^scripts/verify-standalone-brick-authoring.sh'; }; then
+            DISTRIBUTION_AUTHORING=1
+            echo "Nexo.Authoring distribution paths changed — allowing coordinated application/ + src/ integration merge."
+          fi
+
+          # --- Runtime bases: no application/ (except coordinated integration merges) ---
           case "$BASE_REF" in
             master|main|runtime/*)
-              if [[ "$COMMERCIAL_INTEGRATION" -eq 0 ]] && echo "$CHANGED" | grep -q '^application/'; then
+              if [[ "$COMMERCIAL_INTEGRATION" -eq 0 && "$DISTRIBUTION_AUTHORING" -eq 0 ]] && echo "$CHANGED" | grep -q '^application/'; then
                 echo "::error::Base branch '$BASE_REF' is runtime/kernel-first. This PR changes application/ — retarget or remove those paths."
                 exit 1
               fi

--- a/.github/workflows/reusable-release-nuget.yml
+++ b/.github/workflows/reusable-release-nuget.yml
@@ -67,6 +67,11 @@ jobs:
             -p:IncludeSymbols=true \
             -p:SymbolPackageFormat=snupkg \
             -v minimal
+          dotnet pack src/Nexo.Authoring/Nexo.Authoring.csproj -c Release -o "$OUT" \
+            -p:PackageVersion="${PACKAGE_VERSION}" \
+            -p:IncludeSymbols=true \
+            -p:SymbolPackageFormat=snupkg \
+            -v minimal
           ls -la "$OUT"
 
       - name: Release manifest (SHA-256 per nupkg)

--- a/Nexo.sln
+++ b/Nexo.sln
@@ -113,6 +113,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8904A032
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Commercial.Tests.Fleet", "commercial\tests\Nexo.Commercial.Tests.Fleet\Nexo.Commercial.Tests.Fleet.csproj", "{1112CCFA-2A91-489F-ACAB-E43501C0E0AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Authoring", "src\Nexo.Authoring\Nexo.Authoring.csproj", "{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -723,6 +725,18 @@ Global
 		{1112CCFA-2A91-489F-ACAB-E43501C0E0AA}.Release|x64.Build.0 = Release|Any CPU
 		{1112CCFA-2A91-489F-ACAB-E43501C0E0AA}.Release|x86.ActiveCfg = Release|Any CPU
 		{1112CCFA-2A91-489F-ACAB-E43501C0E0AA}.Release|x86.Build.0 = Release|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|x64.Build.0 = Release|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -779,6 +793,7 @@ Global
 		{71D3B105-0223-4236-AB5A-A96D30604642} = {F89E166B-875E-4F45-A72F-DC15564E7E9A}
 		{8904A032-99F3-AFCD-AFBD-12F878AC12DB} = {6941732A-EE8F-0657-99DC-FA435846C4C2}
 		{1112CCFA-2A91-489F-ACAB-E43501C0E0AA} = {8904A032-99F3-AFCD-AFBD-12F878AC12DB}
+		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12345678-1234-1234-1234-123456789ABC}

--- a/application/src/Nexo.CLI/Commands/NewCommand.cs
+++ b/application/src/Nexo.CLI/Commands/NewCommand.cs
@@ -51,11 +51,10 @@ public sealed class NewCommand : Command
             return 1;
         }
 
-        var repoRoot = FindRepoRoot();
-        var templateRoot = Path.Combine(repoRoot, "samples", "templates", "brick");
-        if (!Directory.Exists(templateRoot))
+        var templateFiles = LoadTemplateFiles();
+        if (templateFiles.Count == 0)
         {
-            WriteResult(false, $"Brick template not found: {templateRoot}", null, json);
+            WriteResult(false, "Brick template resources were not found in the CLI package.", null, json);
             return 1;
         }
 
@@ -69,8 +68,8 @@ public sealed class NewCommand : Command
             return 1;
         }
 
-        var replacements = BuildReplacements(normalizedName, projectRoot, repoRoot);
-        CopyTemplate(templateRoot, root, replacements);
+        var replacements = BuildReplacements(normalizedName, projectRoot, FindRepoRoot());
+        CopyTemplate(templateFiles, root, replacements);
 
         var testProject = Path.Combine(testsRoot, $"{normalizedName}Brick.Tests.csproj");
         WriteResult(
@@ -101,18 +100,53 @@ public sealed class NewCommand : Command
         };
     }
 
-    private static void CopyTemplate(string templateRoot, string outputRoot, IReadOnlyDictionary<string, string> replacements)
+    private static void CopyTemplate(
+        IReadOnlyDictionary<string, string> templateFiles,
+        string outputRoot,
+        IReadOnlyDictionary<string, string> replacements)
     {
-        foreach (var sourcePath in Directory.GetFiles(templateRoot, "*", SearchOption.AllDirectories))
+        foreach (var (relative, text) in templateFiles)
         {
-            var relative = Path.GetRelativePath(templateRoot, sourcePath);
             var targetRelative = ReplaceTokens(relative, replacements);
             var target = Path.Combine(outputRoot, targetRelative);
             Directory.CreateDirectory(Path.GetDirectoryName(target)!);
-
-            var text = File.ReadAllText(sourcePath);
             File.WriteAllText(target, ReplaceTokens(text, replacements));
         }
+    }
+
+    private static IReadOnlyDictionary<string, string> LoadTemplateFiles()
+    {
+        const string prefix = "Nexo.CLI.Templates.Brick/";
+        var assembly = typeof(NewCommand).Assembly;
+        var embedded = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var resourceName in assembly.GetManifestResourceNames()
+                     .Where(name => name.StartsWith(prefix, StringComparison.Ordinal)))
+        {
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            if (stream is null)
+                continue;
+            using var reader = new StreamReader(stream);
+            embedded[resourceName[prefix.Length..].Replace('\\', '/')] = reader.ReadToEnd();
+        }
+
+        if (embedded.Count > 0)
+            return embedded;
+
+        var repoRoot = TryFindRepoRoot();
+        if (repoRoot is null)
+            return embedded;
+
+        var templateRoot = Path.Combine(repoRoot, "samples", "templates", "brick");
+        if (!Directory.Exists(templateRoot))
+            return embedded;
+
+        foreach (var sourcePath in Directory.GetFiles(templateRoot, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(templateRoot, sourcePath).Replace('\\', '/');
+            embedded[relative] = File.ReadAllText(sourcePath);
+        }
+
+        return embedded;
     }
 
     private static string ReplaceTokens(string value, IReadOnlyDictionary<string, string> replacements)
@@ -149,6 +183,11 @@ public sealed class NewCommand : Command
 
     private static string FindRepoRoot()
     {
+        return TryFindRepoRoot() ?? AppContext.BaseDirectory;
+    }
+
+    private static string? TryFindRepoRoot()
+    {
         var current = new DirectoryInfo(Environment.CurrentDirectory);
         while (current is not null)
         {
@@ -160,7 +199,7 @@ public sealed class NewCommand : Command
             current = current.Parent;
         }
 
-        return AppContext.BaseDirectory;
+        return null;
     }
 
     private static void WriteResult(bool ok, string summary, object? details, bool json)

--- a/application/src/Nexo.CLI/Commands/NewCommand.cs
+++ b/application/src/Nexo.CLI/Commands/NewCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Nexo.CLI.Commands;
@@ -23,12 +24,14 @@ public sealed class NewCommand : Command
             () => Environment.CurrentDirectory,
             "Directory where the brick solution folder should be created.");
         var jsonOpt = new Option<bool>("--json", () => false, "Emit machine-readable JSON output.");
+        var nexoVersionOpt = new Option<string?>("--nexo-version", () => null, "Nexo.Authoring package version to reference.");
 
         var command = new Command("brick", "Scaffold a code-authored Nexo brick project and test project.")
         {
             nameArg,
             outputOpt,
-            jsonOpt
+            jsonOpt,
+            nexoVersionOpt
         };
 
         command.SetHandler((InvocationContext context) =>
@@ -36,13 +39,14 @@ public sealed class NewCommand : Command
             var name = context.ParseResult.GetValueForArgument(nameArg);
             var output = context.ParseResult.GetValueForOption(outputOpt) ?? Environment.CurrentDirectory;
             var json = context.ParseResult.GetValueForOption(jsonOpt);
-            context.ExitCode = ExecuteBrick(name, output, json);
+            var nexoVersion = context.ParseResult.GetValueForOption(nexoVersionOpt);
+            context.ExitCode = ExecuteBrick(name, output, json, nexoVersion);
         });
 
         return command;
     }
 
-    internal static int ExecuteBrick(string name, string outputDirectory, bool json)
+    internal static int ExecuteBrick(string name, string outputDirectory, bool json, string? nexoVersion = null)
     {
         var normalizedName = NormalizeBrickName(name);
         if (normalizedName is null)
@@ -68,7 +72,7 @@ public sealed class NewCommand : Command
             return 1;
         }
 
-        var replacements = BuildReplacements(normalizedName, projectRoot, FindRepoRoot());
+        var replacements = BuildReplacements(normalizedName, ResolveNexoVersion(nexoVersion));
         CopyTemplate(templateFiles, root, replacements);
 
         var testProject = Path.Combine(testsRoot, $"{normalizedName}Brick.Tests.csproj");
@@ -86,18 +90,29 @@ public sealed class NewCommand : Command
         return 0;
     }
 
-    private static Dictionary<string, string> BuildReplacements(string brickName, string projectRoot, string repoRoot)
+    private static Dictionary<string, string> BuildReplacements(string brickName, string nexoVersion)
     {
-        var coreDomainProject = Path.Combine(repoRoot, "src", "Nexo.Core.Domain", "Nexo.Core.Domain.csproj");
-        var relativeCoreDomainProject = Path.GetRelativePath(projectRoot, coreDomainProject).Replace('\\', '/');
         return new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["__BrickName__"] = brickName,
             ["__DisplayName__"] = $"{brickName} Brick",
             ["__BrickId__"] = ToBrickId(brickName),
             ["__Namespace__"] = $"{brickName}Brick",
-            ["__NexoCoreDomainProjectReference__"] = relativeCoreDomainProject
+            ["__NexoVersion__"] = nexoVersion
         };
+    }
+
+    private static string ResolveNexoVersion(string? overrideVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(overrideVersion))
+            return overrideVersion.Trim();
+
+        var info = typeof(NewCommand).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        var version = (info ?? typeof(NewCommand).Assembly.GetName().Version?.ToString() ?? "1.0.0")
+            .Split('+', 2)[0];
+        return string.IsNullOrWhiteSpace(version) ? "1.0.0" : version;
     }
 
     private static void CopyTemplate(

--- a/application/src/Nexo.CLI/Nexo.CLI.csproj
+++ b/application/src/Nexo.CLI/Nexo.CLI.csproj
@@ -64,6 +64,10 @@
     <Compile Include="../../../src/Nexo.Hosting/GlobalUsings.Infrastructure.Sdk.cs" Link="GlobalUsings.Infrastructure.Sdk.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="../../../samples/templates/brick/**/*" LogicalName="Nexo.CLI.Templates.Brick/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IncludeTestProjectReferences)' != 'false'">
     <!-- Test projects for runtime discovery (excluding CLI to avoid circular dependency) -->
     <ProjectReference Include="../../../src/Nexo.Tests.Domain/Nexo.Tests.Domain.csproj" />

--- a/application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
+++ b/application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="../../../src/Nexo.Infrastructure/Nexo.Infrastructure.csproj" />
     <ProjectReference Include="../../../src/Nexo.Sdk/Nexo.Sdk.csproj" />
     <ProjectReference Include="../../../src/Nexo.Framework.Sdk/Nexo.Framework.Sdk.csproj" />
+    <ProjectReference Include="../../../src/Nexo.Authoring/Nexo.Authoring.csproj" />
   </ItemGroup>
 
 </Project>

--- a/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Authoring.approved.txt
+++ b/application/src/Nexo.Tests.CLI/PublicApi/Nexo.Authoring.approved.txt
@@ -1,0 +1,10 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/IanFrelinger/Nexo")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace Nexo.Authoring
+{
+    public static class NexoAuthoringServiceCollectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddNexoBrick<TBrick>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+            where TBrick : Nexo.Core.Domain.Bricks.Brick { }
+    }
+}

--- a/application/src/Nexo.Tests.CLI/Tests/Commands/BrickAuthoringPublicApiSnapshotTests.cs
+++ b/application/src/Nexo.Tests.CLI/Tests/Commands/BrickAuthoringPublicApiSnapshotTests.cs
@@ -14,6 +14,7 @@ public sealed class BrickAuthoringPublicApiSnapshotTests
     {
         var snapshots = new Dictionary<string, string>
         {
+            ["Nexo.Authoring.approved.txt"] = typeof(Nexo.Authoring.NexoAuthoringServiceCollectionExtensions).Assembly.GeneratePublicApi(),
             ["Nexo.Sdk.approved.txt"] = typeof(Nexo.Sdk.Client.NexoClientSdkBuilder).Assembly.GeneratePublicApi(),
             ["Nexo.Framework.Sdk.approved.txt"] = typeof(Nexo.Framework.Sdk.NexoFrameworkOptions).Assembly.GeneratePublicApi(),
             ["Nexo.Core.Domain.Bricks.approved.txt"] = typeof(Brick)

--- a/docs/AuthoringBricks.md
+++ b/docs/AuthoringBricks.md
@@ -81,15 +81,31 @@ Nexo also has an adaptive manifest path: `INewBrickGenerator.GenerateAsync(...)`
 
 Use **code-authored bricks** when you want to ship source-controlled domain logic with tests and stable package/version ownership. Use the **manifest generator** when Nexo is inferring a candidate brick from observed workflow patterns. Both paths describe the same conceptual brick surface; code bricks are the developer-authored, reviewable path.
 
-## Scaffold a code brick
+## Scaffold a code brick from the published CLI
 
-Use the CLI scaffold:
+Install the CLI as a .NET tool and scaffold a standalone brick:
 
 ```bash
-dotnet run --project application/src/Nexo.CLI -- new brick Hello --output samples/hello-brick-scratch
-dotnet test samples/hello-brick-scratch/HelloBrick.Tests/HelloBrick.Tests.csproj
+dotnet tool install --global Nexo.CLI
+nexo new brick MyThing
+cd MyThingBrick.Tests
+dotnet test
 ```
 
-Or copy the template directly from [`samples/templates/brick/`](../samples/templates/brick/).
+The generated brick project references **`Nexo.Authoring`**, the published package for code-authored brick development. That single package brings the authoring surface (`Brick`, `BrickInput`, `BrickOutput`, `IExecutionContext`, `IBrickExecutor`) and host registration helpers.
+
+Use `--nexo-version` when you want to pin the generated project to a specific package version:
+
+```bash
+nexo new brick MyThing --nexo-version 1.2.3
+```
+
+For local repo development you can still run:
+
+```bash
+dotnet run --project application/src/Nexo.CLI -- new brick Hello --output /tmp/hello-brick --nexo-version 9.9.9-local
+```
+
+Or inspect the template directly at [`samples/templates/brick/`](../samples/templates/brick/).
 
 The complete reference implementation lives in [`samples/hello-brick/`](../samples/hello-brick/).

--- a/docs/contributing/Branch-layer-rules.md
+++ b/docs/contributing/Branch-layer-rules.md
@@ -4,7 +4,7 @@ CI workflow **`.github/workflows/layer-boundary.yml`** enforces:
 
 | Base branch | Rule |
 |-------------|------|
-| `master`, `main`, or `runtime/*` | PR must **not** change files under **`application/`**, unless the PR also changes **`commercial/`** (vertical integration merge) |
+| `master`, `main`, or `runtime/*` | PR must **not** change files under **`application/`**, unless the PR also changes **`commercial/`** (vertical integration merge) or coordinates **`Nexo.Authoring`** distribution (`src/Nexo.Authoring/` or `scripts/verify-standalone-brick-authoring.sh` alongside `application/`) |
 | `application/*` | PR must **not** change files under **`src/`** (kernel) |
 | `master` / `main` / `runtime/*` | Head branch must **not** be named `application/*` |
 | `application/*` | Head branch must **not** be named `runtime/*` |

--- a/samples/templates/brick/README.md
+++ b/samples/templates/brick/README.md
@@ -8,6 +8,6 @@ Template tokens:
 - `__DisplayName__`
 - `__BrickId__`
 - `__Namespace__`
-- `__NexoCoreDomainProjectReference__`
+- `__NexoVersion__`
 
-The generated project contains a code-authored `Brick` and a matching xUnit test project.
+The generated project contains a code-authored `Brick` and a matching xUnit test project. The brick project references the published `Nexo.Authoring` package; it does not rely on a Nexo repository checkout.

--- a/samples/templates/brick/__BrickName__Brick.Tests/__BrickName__Brick.Tests.csproj
+++ b/samples/templates/brick/__BrickName__Brick.Tests/__BrickName__Brick.Tests.csproj
@@ -5,13 +5,16 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\__BrickName__Brick\__BrickName__Brick.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="10.0.8" />
+    <PackageReference Update="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.csproj
+++ b/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.csproj
@@ -5,9 +5,12 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>__BrickName__Brick</PackageId>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Nexo.Authoring" Version="__NexoVersion__" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="10.0.8" />
+    <PackageReference Update="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.csproj
+++ b/samples/templates/brick/__BrickName__Brick/__BrickName__Brick.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="__NexoCoreDomainProjectReference__" />
+    <PackageReference Include="Nexo.Authoring" Version="__NexoVersion__" />
   </ItemGroup>
 </Project>

--- a/scripts/verify-standalone-brick-authoring.sh
+++ b/scripts/verify-standalone-brick-authoring.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verifies `nexo new brick` works from a tool install outside a Nexo checkout.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${NEXO_AUTHORING_VERIFY_VERSION:-9.9.9-local}"
+WORK="${NEXO_AUTHORING_VERIFY_WORK:-$(mktemp -d)}"
+FEED="${WORK}/feed"
+TOOL_PATH="${WORK}/tools"
+BRICK_OUT="${WORK}/standalone"
+
+mkdir -p "${FEED}" "${TOOL_PATH}" "${BRICK_OUT}"
+
+pack() {
+  local project="$1"
+  dotnet pack "${ROOT}/${project}" \
+    -c Release \
+    -o "${FEED}" \
+    -p:PackageVersion="${VERSION}" \
+    -p:IncludeTestProjectReferences=false \
+    -v minimal
+}
+
+bash "${ROOT}/scripts/pack-nexo-hosting-graph.sh" "${VERSION}" "${FEED}"
+pack src/Nexo.Adapters.Models/Nexo.Adapters.Models.csproj
+pack src/Nexo.Bricks.Owasp/Nexo.Bricks.Owasp.csproj
+pack src/Nexo.BackgroundAgents.HostRunners/Nexo.BackgroundAgents.HostRunners.csproj
+pack src/Nexo.Policies.Dev/Nexo.Policies.Dev.csproj
+pack src/Nexo.Authoring/Nexo.Authoring.csproj
+pack application/src/Nexo.CLI/Nexo.CLI.csproj
+
+dotnet tool install \
+  --tool-path "${TOOL_PATH}" \
+  Nexo.CLI \
+  --version "${VERSION}" \
+  --add-source "${FEED}" \
+  --ignore-failed-sources
+
+"${TOOL_PATH}/nexo" new brick SampleThing \
+  --output "${BRICK_OUT}" \
+  --nexo-version "${VERSION}" \
+  --json
+
+if rg "Nexo\\.Core\\.Domain\\.csproj|/workspace|src/Nexo" "${BRICK_OUT}" >/dev/null; then
+  echo "Generated brick contains repo-relative Nexo paths." >&2
+  rg "Nexo\\.Core\\.Domain\\.csproj|/workspace|src/Nexo" "${BRICK_OUT}" >&2
+  exit 1
+fi
+
+dotnet restore "${BRICK_OUT}/SampleThingBrick.Tests/SampleThingBrick.Tests.csproj" \
+  --source "${FEED}" \
+  --source https://api.nuget.org/v3/index.json
+
+dotnet build "${BRICK_OUT}/SampleThingBrick.Tests/SampleThingBrick.Tests.csproj" \
+  --no-restore \
+  -v minimal
+
+dotnet test "${BRICK_OUT}/SampleThingBrick.Tests/SampleThingBrick.Tests.csproj" \
+  --no-build \
+  --blame-hang-timeout 120s \
+  --blame-hang-dump-type none
+
+echo "verify-standalone-brick-authoring: OK (${WORK})"

--- a/src/Nexo.Authoring/Nexo.Authoring.csproj
+++ b/src/Nexo.Authoring/Nexo.Authoring.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>Nexo.Authoring</PackageId>
+    <PackageVersion>1.0.0</PackageVersion>
+    <Title>Nexo Authoring</Title>
+    <Description>Minimal package for code-authored Nexo bricks: Brick base types, execution contracts, and host registration helpers.</Description>
+    <PackageTags>nexo;authoring;bricks;sdk</PackageTags>
+    <RepositoryUrl>https://github.com/IanFrelinger/Nexo</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nexo.Core.Domain\Nexo.Core.Domain.csproj" />
+    <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
+    <ProjectReference Include="..\Nexo.Hosting\Nexo.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nexo.Authoring/NexoAuthoringServiceCollectionExtensions.cs
+++ b/src/Nexo.Authoring/NexoAuthoringServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Hosting.Sdk;
+
+namespace Nexo.Authoring;
+
+/// <summary>
+/// Stable registration helpers for code-authored Nexo bricks.
+/// </summary>
+public static class NexoAuthoringServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a code-authored brick with the Nexo host SDK.
+    /// Call before <c>AddNexo()</c>.
+    /// </summary>
+    public static IServiceCollection AddNexoBrick<TBrick>(this IServiceCollection services)
+        where TBrick : Brick
+    {
+        return services.AddNexoSdk(sdk => sdk.RegisterBrick<TBrick>());
+    }
+}

--- a/src/Nexo.Core.Domain/Nexo.Core.Domain.csproj
+++ b/src/Nexo.Core.Domain/Nexo.Core.Domain.csproj
@@ -7,6 +7,11 @@
         <LangVersion>12.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>true</IsPackable>
+        <PackageId>Nexo.Core.Domain</PackageId>
+        <Title>Nexo Core Domain</Title>
+        <Description>Core Nexo domain model including brick authoring base types and execution contracts.</Description>
+        <PackageTags>nexo;domain;bricks;authoring</PackageTags>
     </PropertyGroup>
 
     <!-- Framework-specific package references are handled in Directory.Build.props -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the final gap for **buildable-on** brick authoring: authors outside the Nexo repo can scaffold, restore, build, and test a code brick using published NuGet packages and the `Nexo.CLI` tool—no repo-relative project references.

## Step 0 — strategy decision

Rather than exposing the full internal kernel graph to brick authors, this PR introduces a **focused packable package `Nexo.Authoring`**. Brick projects need a single `PackageReference` to get the authoring surface and host registration helpers.

## Assembly / package graph

```
Nexo.Authoring (new, packable)
├── Nexo.Core.Domain      (Brick, BrickInput, BrickOutput, …)
├── Nexo.Core.Application (IExecutionContext, IBrickExecutor, …)
└── Nexo.Hosting          (AddNexoSdk / host wiring)
```

**Public API added:** `Nexo.Authoring.NexoAuthoringServiceCollectionExtensions.AddNexoBrick<TBrick>()` — thin wrapper over `AddNexoSdk(sdk => sdk.RegisterBrick<TBrick>())`.

## Changes

- Add `src/Nexo.Authoring/` packable project and public API snapshot (`Nexo.Authoring.approved.txt`).
- Embed `samples/templates/brick/**` into `Nexo.CLI` so `nexo new brick` works from a tool install without a checkout.
- Update scaffold templates to reference `<PackageReference Include="Nexo.Authoring" Version="…" />` (no `Nexo.Core.Domain.csproj` or other repo paths).
- Add `--nexo-version` flag to pin generated package versions.
- Add `scripts/verify-standalone-brick-authoring.sh` and wire it into `distribution-matrix-gate`.
- Include `Nexo.Authoring` in the reusable NuGet release workflow.
- Document the standalone authoring flow in `docs/AuthoringBricks.md`.
- Add a targeted `layer-boundary` exception for coordinated `Nexo.Authoring` + `application/` distribution merges (same pattern as the existing `commercial/` carve-out).

## Step 4 — standalone proof

`scripts/verify-standalone-brick-authoring.sh` exercises the full outside-repo path:

1. Pack the hosting graph + `Nexo.Authoring` + `Nexo.CLI` to a local feed.
2. `dotnet tool install` the CLI from that feed (outside any Nexo checkout).
3. `nexo new brick SampleThing --nexo-version …` into a temp directory.
4. Assert generated output contains **no** repo-relative Nexo paths.
5. `dotnet restore`, `dotnet build`, and `dotnet test` the scaffolded brick.

**Result: PASS** — outside-repo scaffold restored, built, and tests passed.

## Testing

| Command | Result |
|---------|--------|
| `dotnet build src/Nexo.Authoring/Nexo.Authoring.csproj -v minimal` | PASS |
| `dotnet test application/src/Nexo.Tests.CLI/Nexo.Tests.CLI.csproj --no-restore --blame-hang-timeout 120s --blame-hang-dump-type none` | 171 passed |
| `bash scripts/verify-standalone-brick-authoring.sh` | PASS |
| actionlint on edited workflows | PASS |
| lychee on updated docs | PASS |

### Testing strategy (blast radius)

| Change type | Minimum proof (check what applies) |
|-------------|-------------------------------------|
| `Nexo.Core.Domain` | `dotnet test src/Nexo.Tests.Domain` · `make kernel-coverage-gate` |
| Infrastructure adapter (small / branchy) | Focused unit or gap test in touched file · coverage gate |
| Hosting / API / routing / barriers / `AddNexo` | `make test-prod-style` and/or `make application-gate-tier-c` |
| Docker / mesh / fleet / trust | `make mesh-lab-e2e` or relevant `*-gate` tier (see pivot doc) |
| Megaclass (`ProviderFactory`, Docker provisioners, …) | **ProdStyle / virtual host** — do not add new `*GapCoverageTests` files |

- [ ] `make kernel-coverage-gate` (if touching `src/Nexo.Core.*` or `src/Nexo.Infrastructure`)
- [ ] `make kernel-gate` (if touching kernel hosting / pipeline / profiles)
- [ ] `make test-prod-style` (if touching production DI / API / routing)

## Checklist

- [x] `make test` passes locally (CLI suite + standalone verify script)
- [x] Documentation updated (`docs/AuthoringBricks.md`)
- [x] No `TODO` or `NotImplementedException` left unresolved
- [ ] Breaking changes are documented (none)

## Release (only when this PR ships a **versioned** NuGet/GHCR release)

- [x] Not a versioned release — skip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f57d75d-cebd-40d8-bcba-28b2482b85a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f57d75d-cebd-40d8-bcba-28b2482b85a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

