### PR TITLE
feat(release): guarded one-command staging release trigger

### DIFF
--- a/.github/workflows/release-staging-on-label.yml
+++ b/.github/workflows/release-staging-on-label.yml
@@ -1,0 +1,64 @@
+# Deliberate human trigger: label a PR with release:staging to dispatch a staging-only release cut.
+# Refuses when NUGET_PUBLISH_MODE would push to nuget.org.
+name: Release staging on label
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch-staging-release:
+    if: github.event.label.name == 'release:staging'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Abort if nuget.org publish mode is enabled
+        shell: bash
+        run: |
+          MODE="${{ vars.NUGET_PUBLISH_MODE }}"
+          MODE="$(echo "${MODE}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+          case "${MODE}" in
+            oidc|apikey)
+              echo "::error::NUGET_PUBLISH_MODE=${MODE} would push to nuget.org; refusing label-triggered staging dispatch."
+              exit 1
+              ;;
+          esac
+          echo "nuget.org push: SKIPPED — PUBLISH_MODE is not oidc/apikey"
+
+      - name: Require staging feed configuration
+        shell: bash
+        run: |
+          if [[ -z "${{ vars.NUGET_STAGING_FEED_URL }}" ]]; then
+            echo "::error::NUGET_STAGING_FEED_URL is not set (see docs/StagingFeed.md)."
+            exit 1
+          fi
+
+      - name: Resolve canonical version
+        id: version
+        shell: bash
+        run: |
+          if [[ -f VERSION ]]; then
+            V="$(tr -d '[:space:]' < VERSION)"
+          else
+            V="$(sed -n 's:.*<PackageVersion>\([^<]*\)</PackageVersion>.*:\1:p' src/Nexo.Hosting.Bundle/Nexo.Hosting.Bundle.csproj | head -1)"
+          fi
+          if [[ ! "${V}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Could not resolve valid semver (VERSION file or Hosting.Bundle PackageVersion)."
+            exit 1
+          fi
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${V}"
+
+      - name: Dispatch release.yml (staging-only guard passed)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --ref "${{ github.event.pull_request.head.ref }}" \
+            -f "version=${{ steps.version.outputs.version }}" \
+            -f skip_multi_arch=false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-core build-demos prod-dry-run prod-dry-run-agent-server restore-core test test-prod-style test-framework-prod-first test-prime-time test-prime-time-full test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify kernel-gate kernel-gate-tier-b kernel-gate-tier-c kernel-gate-tier-d kernel-gate-tier-e kernel-gate-full application-gate application-gate-tier-a application-gate-tier-b application-gate-tier-c application-gate-tier-d application-gate-full composition-mesh-gate composition-mesh-gate-tier-a composition-mesh-gate-tier-b composition-mesh-gate-tier-c composition-mesh-gate-tier-d composition-mesh-gate-full dependency-boundary-gate ship-gate ship-gate-tier-a ship-gate-tier-b ship-gate-tier-c ship-gate-tier-d ship-gate-full ops-gate ops-gate-tier-a ops-gate-tier-b ops-gate-tier-c ops-gate-tier-d ops-gate-tier-e ops-gate-full security-gate security-gate-tier-a security-gate-tier-b security-gate-tier-c security-gate-tier-d security-gate-tier-e security-gate-full rc-gate rc-gate-tier-a rc-gate-tier-b rc-gate-tier-c rc-gate-tier-d rc-gate-tier-e rc-gate-full perf-gate perf-gate-tier-a perf-gate-tier-b perf-gate-tier-c perf-gate-tier-d perf-gate-full compat-gate compat-gate-tier-a compat-gate-tier-b compat-gate-tier-c compat-gate-full dr-gate dr-gate-tier-a dr-gate-tier-b dr-gate-tier-c dr-gate-full waterproofing-gate-full nexo-ready-gate bootstrap-mesh-lab-env validate-safe review-summary clean-test-artifacts test-readiness-gate release-preflight release-gate release-dispatch verify-external-product-shape mesh-lab-e2e mesh-lab-e2e-workers mesh-lab-e2e-deep mesh-lab-e2e-stress mesh-lab-up mesh-lab-verify mesh-lab-verify-deep mesh-lab-verify-entitlements mesh-lab-verify-governance mesh-lab-verify-director-cli mesh-lab-verify-persistence mesh-lab-verify-network-negative mesh-lab-verify-post-stress mesh-lab-stress mesh-lab-down test-mesh-lab
+.PHONY: build build-core build-demos prod-dry-run prod-dry-run-agent-server restore-core test test-prod-style test-framework-prod-first test-prime-time test-prime-time-full test-cross-platform test-portable test-multi-env test-all-platforms test-all-platforms-ephemeral ci-verify kernel-gate kernel-gate-tier-b kernel-gate-tier-c kernel-gate-tier-d kernel-gate-tier-e kernel-gate-full application-gate application-gate-tier-a application-gate-tier-b application-gate-tier-c application-gate-tier-d application-gate-full composition-mesh-gate composition-mesh-gate-tier-a composition-mesh-gate-tier-b composition-mesh-gate-tier-c composition-mesh-gate-tier-d composition-mesh-gate-full dependency-boundary-gate ship-gate ship-gate-tier-a ship-gate-tier-b ship-gate-tier-c ship-gate-tier-d ship-gate-full ops-gate ops-gate-tier-a ops-gate-tier-b ops-gate-tier-c ops-gate-tier-d ops-gate-tier-e ops-gate-full security-gate security-gate-tier-a security-gate-tier-b security-gate-tier-c security-gate-tier-d security-gate-tier-e security-gate-full rc-gate rc-gate-tier-a rc-gate-tier-b rc-gate-tier-c rc-gate-tier-d rc-gate-tier-e rc-gate-full perf-gate perf-gate-tier-a perf-gate-tier-b perf-gate-tier-c perf-gate-tier-d perf-gate-full compat-gate compat-gate-tier-a compat-gate-tier-b compat-gate-tier-c compat-gate-full dr-gate dr-gate-tier-a dr-gate-tier-b dr-gate-tier-c dr-gate-full waterproofing-gate-full nexo-ready-gate bootstrap-mesh-lab-env validate-safe review-summary clean-test-artifacts test-readiness-gate release-preflight release-gate release-dispatch release-staging verify-staging release-staging-and-verify verify-external-product-shape mesh-lab-e2e mesh-lab-e2e-workers mesh-lab-e2e-deep mesh-lab-e2e-stress mesh-lab-up mesh-lab-verify mesh-lab-verify-deep mesh-lab-verify-entitlements mesh-lab-verify-governance mesh-lab-verify-director-cli mesh-lab-verify-persistence mesh-lab-verify-network-negative mesh-lab-verify-post-stress mesh-lab-stress mesh-lab-down test-mesh-lab
 
 # External product shape: packed Nexo.* feed → authored brick + thin host + HTTP client (no repo refs).
 verify-external-product-shape:
@@ -17,6 +17,20 @@ release-gate:
 release-dispatch:
 	@test -n "$(VERSION)" || (echo "Set VERSION=1.2.3"; exit 1)
 	gh workflow run Release --ref $${REF:-master} -f version="$(VERSION)" -f skip_multi_arch=false
+
+# Staging-only release dispatch (guarded; refuses when NUGET_PUBLISH_MODE enables nuget.org).
+release-staging:
+	@test -n "$(VERSION)" || (echo "Set VERSION=x.y.z"; exit 1)
+	DRY_RUN=$(DRY_RUN) NEXO_RELEASE_STAGING_REF=$${REF:-} bash scripts/release-staging.sh "$(VERSION)"
+
+verify-staging:
+	@test -n "$(VERSION)" || (echo "Set VERSION=x.y.z"; exit 1)
+	bash scripts/verify-staging.sh "$(VERSION)"
+
+release-staging-and-verify:
+	@test -n "$(VERSION)" || (echo "Set VERSION=x.y.z"; exit 1)
+	$(MAKE) release-staging VERSION="$(VERSION)" DRY_RUN="$(DRY_RUN)"
+	@if [ "$(DRY_RUN)" != "1" ]; then $(MAKE) verify-staging VERSION="$(VERSION)"; fi
 
 # All automated test projects in Nexo.PrimeTime.slnf (nine Nexo.Tests.* assemblies).
 PRIME_TIME_SLNF := Nexo.PrimeTime.slnf

--- a/docs/StagingFeed.md
+++ b/docs/StagingFeed.md
@@ -27,6 +27,51 @@ If **`NUGET_STAGING_FEED_URL`** is set but the secret is missing, the workflow *
 
 Leave **`NUGET_STAGING_FEED_URL`** unset to skip staging entirely.
 
+## Pull the trigger (one command)
+
+After one-time bootstrap (below), cut a **staging-only** release and verify the external product shape against the staging feed:
+
+```bash
+make release-staging-and-verify VERSION=0.1.0
+```
+
+That chains:
+
+1. **`make release-staging`** — guarded `gh workflow run release.yml` (staging push only when `NUGET_PUBLISH_MODE` is unset/`none`; **hard-aborts** if `oidc` or `apikey`).
+2. **`make verify-staging`** — round-trip `scripts/verify-external-product-shape-published.sh` against `NUGET_STAGING_FEED_URL` using **`NUGET_STAGING_READ_TOKEN`** from your shell (never committed).
+
+Dry-run the guards without dispatching:
+
+```bash
+make release-staging DRY_RUN=1 VERSION=0.1.0
+```
+
+Canonical version: create a **`VERSION`** file at the repo root before a real cut; `release-staging` refuses a mismatch so `release.yml` cannot fail its tag/input check later.
+
+### One-time bootstrap (`gh` uses your ambient auth; tokens stay in GitHub / your shell)
+
+```bash
+# Staging feed URL (repository variable)
+gh variable set NUGET_STAGING_FEED_URL --body 'https://nuget.pkg.github.com/YOUR_ORG/index.json'
+
+# Push token for reusable-release-nuget.yml (repository secret)
+gh secret set NUGET_STAGING_API_KEY
+
+# Read token for local verify-staging (your shell only — not stored in the repo)
+export NUGET_STAGING_READ_TOKEN='ghp_...'
+
+# Ensure nuget.org push stays OFF for staging cuts
+gh variable set NUGET_PUBLISH_MODE --body 'none'   # or leave unset
+
+# Optional: pin the version you are about to ship
+echo '0.1.0' > VERSION
+git add VERSION && git commit -m 'chore(release): pin VERSION 0.1.0'
+```
+
+**Promotion to nuget.org** is a separate deliberate step: set **`NUGET_PUBLISH_MODE=apikey`** (or `oidc`), configure **`NUGET_API_KEY`** / **`NUGET_USER`**, then dispatch **`release.yml`** or push a tag — not via `release-staging`.
+
+Optional label trigger: add the **`release:staging`** label to a pull request (workflow **`.github/workflows/release-staging-on-label.yml`**) after the same variables are configured.
+
 ## GitHub Packages example
 
 - URL: `https://nuget.pkg.github.com/<OWNER_OR_ORG>/index.json`

--- a/scripts/lib/release-staging-guards.sh
+++ b/scripts/lib/release-staging-guards.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Shared pre-flight guards for staging-only release triggers (sourced, not executed).
+set -euo pipefail
+
+_release_staging_root() {
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
+assert_gh_authenticated() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "ABORT: GitHub CLI (gh) is not installed." >&2
+    return 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "ABORT: gh is not authenticated. Run: gh auth login" >&2
+    return 1
+  fi
+  echo "ASSERT gh auth: OK"
+}
+
+normalize_semver() {
+  local ver="${1#v}"
+  ver="${ver#V}"
+  printf '%s' "${ver}"
+}
+
+assert_valid_semver() {
+  local ver
+  ver="$(normalize_semver "$1")"
+  if [[ ! "${ver}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+    echo "ABORT: VERSION is not valid semver: ${1} (normalized: ${ver})" >&2
+    return 1
+  fi
+  echo "ASSERT semver format: OK (${ver})"
+}
+
+assert_version_matches_canonical() {
+  local requested root canonical
+  requested="$(normalize_semver "$1")"
+  root="$(_release_staging_root)"
+
+  if [[ ! -f "${root}/VERSION" ]]; then
+    echo "ASSERT canonical version match: SKIPPED (no VERSION file; create one before a real staging cut)"
+    return 0
+  fi
+
+  canonical="$(bash "${root}/scripts/resolve-canonical-package-version.sh" | tr -d '[:space:]')"
+
+  if [[ -z "${canonical}" ]]; then
+    echo "ABORT: VERSION file exists but is empty." >&2
+    return 1
+  fi
+
+  if [[ "${requested}" != "${canonical}" ]]; then
+    echo "ABORT: VERSION ${requested} does not match VERSION file (${canonical})." >&2
+    echo "       Update VERSION at repo root or pass the canonical version to avoid release.yml tag/input mismatch." >&2
+    return 1
+  fi
+
+  echo "ASSERT canonical version match: OK (${requested} == ${canonical})"
+}
+
+gh_repo_variable() {
+  local name="$1"
+  local err_file
+  err_file="$(mktemp)"
+  if ! gh variable get "${name}" 2>"${err_file}"; then
+    if grep -q '403\|401\|not accessible' "${err_file}" 2>/dev/null; then
+      rm -f "${err_file}"
+      return 2
+    fi
+    rm -f "${err_file}"
+    return 1
+  fi
+  rm -f "${err_file}"
+}
+
+gh_secret_present() {
+  local name="$1" names err_file
+  err_file="$(mktemp)"
+  if ! names="$(gh secret list --json name -q '.[].name' 2>"${err_file}")"; then
+    if grep -q '403\|401\|not accessible' "${err_file}" 2>/dev/null; then
+      rm -f "${err_file}"
+      return 2
+    fi
+    rm -f "${err_file}"
+    return 1
+  fi
+  rm -f "${err_file}"
+  echo "${names}" | grep -qx "${name}"
+}
+
+assert_nuget_org_push_skipped() {
+  local mode rc=0
+  if [[ -n "${RELEASE_STAGING_TEST_PUBLISH_MODE:-}" ]]; then
+    mode="${RELEASE_STAGING_TEST_PUBLISH_MODE}"
+  else
+    set +e
+    mode="$(gh_repo_variable NUGET_PUBLISH_MODE)"
+    rc=$?
+    set -e
+
+    if [[ "${rc}" -eq 2 ]]; then
+      if [[ "${RELEASE_STAGING_DRY_RUN:-0}" == "1" ]]; then
+        echo "nuget.org push: SKIPPED — NUGET_PUBLISH_MODE unreadable (dry run; assuming unset)"
+        return 0
+      fi
+      echo "ABORT: cannot read NUGET_PUBLISH_MODE (gh token lacks Actions variables permission)." >&2
+      return 1
+    fi
+  fi
+
+  mode="$(echo "${mode}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+
+  case "${mode}" in
+    oidc|apikey)
+      echo "ABORT: NUGET_PUBLISH_MODE=${mode} would enable nuget.org push." >&2
+      echo "       Staging-only release refused. Unset NUGET_PUBLISH_MODE or set it to 'none' before using release-staging." >&2
+      return 1
+      ;;
+    none)
+      echo "nuget.org push: SKIPPED — NUGET_PUBLISH_MODE=none"
+      ;;
+    '')
+      echo "nuget.org push: SKIPPED — NUGET_PUBLISH_MODE unset"
+      ;;
+    *)
+      echo "nuget.org push: SKIPPED — NUGET_PUBLISH_MODE=${mode} (not oidc/apikey)"
+      ;;
+  esac
+}
+
+assert_staging_configured() {
+  local feed_url rc=0 secret_rc=0
+  set +e
+  feed_url="$(gh_repo_variable NUGET_STAGING_FEED_URL)"
+  rc=$?
+  set -e
+  feed_url="$(echo "${feed_url}" | tr -d '[:space:]')"
+
+  if [[ "${rc}" -eq 2 ]]; then
+    if [[ "${RELEASE_STAGING_DRY_RUN:-0}" == "1" ]]; then
+      echo "ASSERT staging feed: SKIP (gh cannot read repository variables in this environment)"
+      echo "ASSERT staging push secret: SKIP (gh cannot read repository secrets in this environment)"
+      return 0
+    fi
+    echo "ABORT: cannot read NUGET_STAGING_FEED_URL (gh token lacks Actions variables permission)." >&2
+    return 1
+  fi
+
+  if [[ -z "${feed_url}" ]]; then
+    echo "ABORT: NUGET_STAGING_FEED_URL repository variable is not set (see docs/StagingFeed.md)." >&2
+    return 1
+  fi
+
+  set +e
+  gh_secret_present NUGET_STAGING_API_KEY
+  secret_rc=$?
+  set -e
+
+  if [[ "${secret_rc}" -eq 2 ]]; then
+    if [[ "${RELEASE_STAGING_DRY_RUN:-0}" == "1" ]]; then
+      echo "ASSERT staging feed: OK (${feed_url})"
+      echo "ASSERT staging push secret: SKIP (gh cannot read repository secrets in this environment)"
+      return 0
+    fi
+    echo "ABORT: cannot read repository secrets (gh token lacks Actions secrets permission)." >&2
+    return 1
+  fi
+
+  if [[ "${secret_rc}" -ne 0 ]]; then
+    echo "ABORT: NUGET_STAGING_API_KEY secret is not configured (required when NUGET_STAGING_FEED_URL is set)." >&2
+    return 1
+  fi
+
+  echo "ASSERT staging feed: OK (${feed_url})"
+  echo "ASSERT staging push secret: OK (NUGET_STAGING_API_KEY present)"
+}

--- a/scripts/release-staging.sh
+++ b/scripts/release-staging.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Guarded staging-only dispatch of release.yml (no nuget.org push when PUBLISH_MODE unset/none).
+#
+# Usage:
+#   bash scripts/release-staging.sh 0.1.0
+#   make release-staging VERSION=0.1.0
+#   make release-staging DRY_RUN=1 VERSION=0.1.0   # plan only, no dispatch
+#
+# Environment:
+#   DRY_RUN=1              Print plan + assert results; do not dispatch.
+#   NEXO_RELEASE_STAGING_REF Branch/ref for workflow_dispatch (default: current branch).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-staging-guards.sh
+source "${ROOT}/scripts/lib/release-staging-guards.sh"
+
+VERSION="${VERSION:-${1:-}}"
+DRY_RUN="${DRY_RUN:-0}"
+REF="${NEXO_RELEASE_STAGING_REF:-$(git -C "${ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo master)}"
+
+if [[ -z "${VERSION}" ]]; then
+  echo "usage: release-staging.sh <semver>   or   make release-staging VERSION=x.y.z [DRY_RUN=1]" >&2
+  exit 1
+fi
+
+VERSION="$(normalize_semver "${VERSION}")"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  export RELEASE_STAGING_DRY_RUN=1
+fi
+
+echo "== release-staging pre-flight =="
+assert_gh_authenticated
+assert_valid_semver "${VERSION}"
+assert_version_matches_canonical "${VERSION}"
+assert_nuget_org_push_skipped
+assert_staging_configured
+
+STAGING_URL="$(gh_repo_variable NUGET_STAGING_FEED_URL 2>/dev/null | tr -d '[:space:]' || true)"
+if [[ -z "${STAGING_URL}" ]]; then
+  STAGING_URL="(see NUGET_STAGING_FEED_URL)"
+fi
+
+echo ""
+echo "Plan:"
+echo "  workflow:      release.yml (workflow_dispatch)"
+echo "  version:       ${VERSION}"
+echo "  ref:           ${REF}"
+echo "  staging feed:  ${STAGING_URL}"
+echo "  nuget.org:     skipped (staging-only guard passed)"
+echo "  dry run:       ${DRY_RUN}"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo ""
+  echo "release-staging: DRY_RUN complete (no workflow dispatched)."
+  exit 0
+fi
+
+echo ""
+echo "==> Dispatching release.yml ..."
+gh workflow run release.yml --ref "${REF}" -f "version=${VERSION}" -f skip_multi_arch=false
+
+echo "Waiting for workflow run to appear ..."
+sleep 5
+RUN_ID=""
+for _ in $(seq 1 12); do
+  RUN_ID="$(gh run list --workflow=release.yml --branch="${REF}" --limit 1 --json databaseId,status -q '.[0].databaseId' 2>/dev/null || true)"
+  if [[ -n "${RUN_ID}" && "${RUN_ID}" != "null" ]]; then
+    break
+  fi
+  sleep 5
+done
+
+if [[ -z "${RUN_ID}" || "${RUN_ID}" == "null" ]]; then
+  echo "ABORT: could not resolve release.yml run id after dispatch." >&2
+  exit 1
+fi
+
+RUN_URL="$(gh run view "${RUN_ID}" --json url -q .url)"
+echo "Watching run ${RUN_ID} (${RUN_URL}) ..."
+if gh run watch "${RUN_ID}" --exit-status; then
+  echo "release-staging: OK (${RUN_URL})"
+else
+  echo "release-staging: FAILED (${RUN_URL})" >&2
+  exit 1
+fi

--- a/scripts/resolve-canonical-package-version.sh
+++ b/scripts/resolve-canonical-package-version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Prints the canonical Nexo package version tracked in-repo (no v prefix).
+# Source order: VERSION file at repo root, then Nexo.Hosting.Bundle metapackage PackageVersion.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -f "${ROOT}/VERSION" ]]; then
+  tr -d '[:space:]' < "${ROOT}/VERSION"
+  exit 0
+fi
+
+sed -n 's:.*<PackageVersion>\([^<]*\)</PackageVersion>.*:\1:p' \
+  "${ROOT}/src/Nexo.Hosting.Bundle/Nexo.Hosting.Bundle.csproj" | head -1

--- a/scripts/verify-external-product-shape-published.sh
+++ b/scripts/verify-external-product-shape-published.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# External product shape verification against an already-published Nexo.* feed (staging or private).
+#
+# Usage:
+#   bash scripts/verify-external-product-shape-published.sh 1.2.3
+#   bash scripts/verify-external-product-shape-published.sh 1.2.3 https://nuget.pkg.github.com/Org/index.json
+#
+# Auth (optional, for private feeds):
+#   NEXO_NUGET_USERNAME + NEXO_NUGET_PASSWORD
+#   or NUGET_STAGING_READ_TOKEN (sets password; username defaults to 'token')
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${1:?usage: verify-external-product-shape-published.sh <PackageVersion> [feed-url]}"
+FEED_URL="${2:-}"
+
+if [[ -z "${FEED_URL}" ]]; then
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "usage: verify-external-product-shape-published.sh <PackageVersion> <feed-url>" >&2
+    echo "       or configure gh auth + NUGET_STAGING_FEED_URL variable." >&2
+    exit 1
+  fi
+  FEED_URL="$(gh variable get NUGET_STAGING_FEED_URL 2>/dev/null | tr -d '[:space:]' || true)"
+fi
+
+if [[ -z "${FEED_URL}" ]]; then
+  echo "ABORT: feed URL required (argument or NUGET_STAGING_FEED_URL)." >&2
+  exit 1
+fi
+
+if [[ -n "${NUGET_STAGING_READ_TOKEN:-}" && -z "${NEXO_NUGET_PASSWORD:-}" ]]; then
+  export NEXO_NUGET_USERNAME="${NEXO_NUGET_USERNAME:-token}"
+  export NEXO_NUGET_PASSWORD="${NUGET_STAGING_READ_TOKEN}"
+fi
+
+export NEXO_EXTERNAL_PRODUCT_VERIFY_VERSION="${VERSION#v}"
+export NEXO_EXTERNAL_PRODUCT_PACKAGE_FEED="${FEED_URL}"
+export NEXO_VERIFY_SOURCE_KEY="${NEXO_VERIFY_SOURCE_KEY:-staging-published}"
+
+bash "${ROOT}/scripts/verify-external-product-shape.sh"

--- a/scripts/verify-external-product-shape.sh
+++ b/scripts/verify-external-product-shape.sh
@@ -12,9 +12,19 @@ CONSUMER_ROOT="${WORK}/consumer"
 CFG="${WORK}/NuGet.Config"
 HOST_PORT="${NEXO_EXTERNAL_PRODUCT_VERIFY_PORT:-0}"
 WAIT_SECS="${NEXO_EXTERNAL_PRODUCT_VERIFY_WAIT_SECS:-120}"
+SOURCE_KEY="${NEXO_VERIFY_SOURCE_KEY:-nexo-local}"
 ISOL_CLEANUP=""
+USE_PUBLISHED_FEED=0
 
-mkdir -p "${FEED}" "${TOOL_PATH}" "${CONSUMER_ROOT}"
+if [[ -n "${NEXO_EXTERNAL_PRODUCT_PACKAGE_FEED:-}" ]]; then
+  USE_PUBLISHED_FEED=1
+  FEED="${NEXO_EXTERNAL_PRODUCT_PACKAGE_FEED}"
+fi
+
+mkdir -p "${TOOL_PATH}" "${CONSUMER_ROOT}"
+if [[ "${USE_PUBLISHED_FEED}" -eq 0 ]]; then
+  mkdir -p "${FEED}"
+fi
 
 pack() {
   local project="$1"
@@ -28,6 +38,9 @@ pack() {
 }
 
 echo "==> Packing consumer surface as version ${VERSION} into ${FEED}"
+if [[ "${USE_PUBLISHED_FEED}" -eq 1 ]]; then
+  echo "==> Using published feed at ${FEED}; skipping local pack."
+else
 bash "${ROOT}/scripts/pack-nexo-hosting-graph.sh" "${VERSION}" "${FEED}"
 pack src/Nexo.Authoring/Nexo.Authoring.csproj
 pack src/Nexo.Sdk/Nexo.Sdk.csproj
@@ -39,6 +52,7 @@ pack src/Nexo.Bricks.Owasp/Nexo.Bricks.Owasp.csproj
 pack src/Nexo.BackgroundAgents.HostRunners/Nexo.BackgroundAgents.HostRunners.csproj
 pack src/Nexo.Policies.Dev/Nexo.Policies.Dev.csproj
 pack application/src/Nexo.CLI/Nexo.CLI.csproj
+fi
 
 if [[ -z "${NEXO_EXTERNAL_PRODUCT_VERIFY_NO_ISOLATED_CACHE:-}" ]]; then
   ISOL_BASE="${NEXO_EXTERNAL_PRODUCT_VERIFY_ISOLATED_ROOT:-$(mktemp -d "${WORK}/nuget-cache-XXXXXX")}"
@@ -49,16 +63,35 @@ if [[ -z "${NEXO_EXTERNAL_PRODUCT_VERIFY_NO_ISOLATED_CACHE:-}" ]]; then
   echo "Isolated restore: NUGET_PACKAGES=${NUGET_PACKAGES} DOTNET_CLI_HOME=${DOTNET_CLI_HOME}"
 fi
 
-cat > "${CFG}" <<EOF
+if [[ -n "${NEXO_NUGET_USERNAME:-}" && -n "${NEXO_NUGET_PASSWORD:-}" ]]; then
+  cat > "${CFG}" <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
-    <add key="nexo-local" value="${FEED}" />
+    <add key="${SOURCE_KEY}" value="${FEED}" protocolVersion="3" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceCredentials>
+    <${SOURCE_KEY}>
+      <add key="Username" value="${NEXO_NUGET_USERNAME}" />
+      <add key="ClearTextPassword" value="${NEXO_NUGET_PASSWORD}" />
+    </${SOURCE_KEY}>
+  </packageSourceCredentials>
+</configuration>
+EOF
+else
+  cat > "${CFG}" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="${SOURCE_KEY}" value="${FEED}" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>
 EOF
+fi
 
 dotnet tool install \
   --tool-path "${TOOL_PATH}" \

--- a/scripts/verify-staging.sh
+++ b/scripts/verify-staging.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Verify external product shape against a published staging feed (post-push).
+#
+# Usage:
+#   NUGET_STAGING_READ_TOKEN=*** bash scripts/verify-staging.sh 0.1.0
+#   make verify-staging VERSION=0.1.0
+#
+# Reads feed URL from gh variable NUGET_STAGING_FEED_URL; token from NUGET_STAGING_READ_TOKEN.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${VERSION:-${1:-}}"
+
+if [[ -z "${VERSION}" ]]; then
+  echo "usage: verify-staging.sh <semver>   or   make verify-staging VERSION=x.y.z" >&2
+  exit 1
+fi
+
+VERSION="${VERSION#v}"
+
+PUBLISHED_SCRIPT="${ROOT}/scripts/verify-external-product-shape-published.sh"
+if [[ ! -f "${PUBLISHED_SCRIPT}" ]]; then
+  echo "ABORT: ${PUBLISHED_SCRIPT} is missing." >&2
+  echo "       Merge the release-prep PR that adds published-feed verification for the external product shape." >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ABORT: gh is required to read NUGET_STAGING_FEED_URL." >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ABORT: gh is not authenticated (gh auth login)." >&2
+  exit 1
+fi
+
+FEED_URL="$(gh variable get NUGET_STAGING_FEED_URL 2>/dev/null | tr -d '[:space:]' || true)"
+if [[ -z "${FEED_URL}" ]]; then
+  echo "ABORT: NUGET_STAGING_FEED_URL is not set." >&2
+  exit 1
+fi
+
+if [[ -z "${NUGET_STAGING_READ_TOKEN:-}" ]]; then
+  echo "ABORT: NUGET_STAGING_READ_TOKEN is not set in the environment (read PAT for the staging feed)." >&2
+  exit 1
+fi
+
+# GitHub Packages / private feeds: username + token (never logged).
+export NEXO_NUGET_USERNAME="${NEXO_NUGET_USERNAME:-token}"
+export NEXO_NUGET_PASSWORD="${NEXO_STAGING_READ_TOKEN}"
+
+echo "verify-staging: version=${VERSION} feed=${FEED_URL}"
+bash "${PUBLISHED_SCRIPT}" "${VERSION}" "${FEED_URL}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a guarded **staging-only** release trigger: one command dispatches `release.yml` with hard safety asserts so nuget.org push cannot fire accidentally, plus post-push verification against the staging feed.

### New commands

| Target | Purpose |
|--------|---------|
| `make release-staging VERSION=x.y.z [DRY_RUN=1]` | Guarded `gh workflow run release.yml` |
| `make verify-staging VERSION=x.y.z` | Published-feed external product shape round-trip |
| `make release-staging-and-verify VERSION=x.y.z` | Chain both (verify skipped when `DRY_RUN=1`) |

Docs: **`docs/StagingFeed.md`** — "Pull the trigger" section.

### Safety gate

`release-staging.sh` **hard-aborts** when `NUGET_PUBLISH_MODE` is `oidc` or `apikey`. Staging feed URL + `NUGET_STAGING_API_KEY` secret must be configured for a real cut.

Also added:

- `scripts/verify-external-product-shape-published.sh` (+ published-feed mode in `verify-external-product-shape.sh`)
- Optional label workflow: **`release:staging`** → `.github/workflows/release-staging-on-label.yml`

## DRY_RUN output (agent verify)

```
== release-staging pre-flight ==
ASSERT gh auth: OK
ASSERT semver format: OK (0.1.0)
ASSERT canonical version match: SKIPPED (no VERSION file; create one before a real staging cut)
nuget.org push: SKIPPED — NUGET_PUBLISH_MODE unreadable (dry run; assuming unset)
ASSERT staging feed: SKIP (gh cannot read repository variables in this environment)
ASSERT staging push secret: SKIP (gh cannot read repository secrets in this environment)

Plan:
  workflow:      release.yml (workflow_dispatch)
  version:       0.1.0
  ref:           chore/release-staging-trigger
  staging feed:  (see NUGET_STAGING_FEED_URL)
  nuget.org:     skipped (staging-only guard passed)
  dry run:       1

release-staging: DRY_RUN complete (no workflow dispatched).
```

Command: `make release-staging DRY_RUN=1 VERSION=0.1.0` → **exit 0**, no dispatch.

## Safety gate abort (simulated)

When `NUGET_PUBLISH_MODE=apikey` (simulated via test hook):

```
ABORT: NUGET_PUBLISH_MODE=apikey would enable nuget.org push.
       Staging-only release refused. Unset NUGET_PUBLISH_MODE or set it to 'none' before using release-staging.
```

On a machine with full `gh` repo access, missing `NUGET_STAGING_FEED_URL` / `NUGET_STAGING_API_KEY` also aborts with a clear message (nonzero).

## Verification

- `shellcheck scripts/release-staging.sh scripts/verify-staging.sh` — pass
- `make release-staging DRY_RUN=1 VERSION=0.1.0` — pass (no dispatch)
- `dotnet build Nexo.sln -c Release` — pass

No workflow was dispatched by the agent (no publish credentials in agent context).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c29b8a8-441c-4325-b560-53a000bfaf6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c29b8a8-441c-4325-b560-53a000bfaf6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

