### PR TITLE
feat(spike-s3): live Claude skill generator (sealed, isolation-enforced, cost-capped)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -606,6 +606,20 @@ mesh-lab-down:
 	@test -f .env.mesh-lab || (echo "Missing .env.mesh-lab"; exit 1)
 	DOCKER_DEFAULT_PLATFORM=$${DOCKER_DEFAULT_PLATFORM:-linux/amd64} COMPOSE_PROJECT_NAME=nexo_mesh_lab_local docker compose --profile workers -f docker-compose.mesh-lab.yml --env-file .env.mesh-lab down -v
 
+# Spike S3 — recorded skill loop (offline, CI/cloud default)
+.PHONY: test-spike-s3 s3-loop-recorded s3-generate-live
+
+test-spike-s3:
+	dotnet test src/Nexo.Tests.Spike.S3/Nexo.Tests.Spike.S3.csproj -c Release
+
+s3-loop-recorded:
+	dotnet run --project src/Nexo.Spike.S3 -c Release -- --out artifacts/s3 --reset-registry --density-seeds 2 --escape-seeds 2
+
+# LOCAL ONLY — requires ANTHROPIC_API_KEY; never run in CI/cloud
+s3-generate-live:
+	@test -n "$$ANTHROPIC_API_KEY" || (echo "ANTHROPIC_API_KEY required for live Claude generation"; exit 1)
+	NEXO_S3_GENERATOR=claude dotnet run --project src/Nexo.Spike.S3 -c Release -- live --out artifacts/s3 --reset-registry --intents 1 --max-attempts 3
+
 # Optional dotnet gate mirroring mesh-lab-gate (compose + mesh-lab-verify*.sh). Requires Docker + python3.
 test-mesh-lab:
 	NEXO_RUN_MESH_LAB=1 dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 \

--- a/artifacts/s3/registry/catalog.json
+++ b/artifacts/s3/registry/catalog.json
@@ -2,5 +2,5 @@
   "entryIds": [
     "csv-type-inference"
   ],
-  "updatedAt": "2026-06-20T03:24:21.9960213+00:00"
+  "updatedAt": "2026-06-20T04:17:37.2371098+00:00"
 }

--- a/artifacts/s3/registry/csv-type-inference/entry.json
+++ b/artifacts/s3/registry/csv-type-inference/entry.json
@@ -13,8 +13,8 @@
   "implementationSource": "namespace CsvColumnInferrer;\n\npublic enum ColumnType\n{\n    String,\n    Integer,\n    Decimal,\n    Boolean,\n    Date\n}\n\npublic static class ColumnTypeInferrer\n{\n    public static ColumnType InferType(IReadOnlyList\u003Cstring\u003E values)\n    {\n        if (values.Count == 0)\n            return ColumnType.String;\n\n        var nonEmpty = values.Where(v =\u003E !string.IsNullOrWhiteSpace(v)).ToList();\n        if (nonEmpty.Count == 0)\n            return ColumnType.String;\n\n        if (nonEmpty.All(IsBoolean))\n            return ColumnType.Boolean;\n\n        if (nonEmpty.All(IsDate))\n            return ColumnType.Date;\n\n        if (nonEmpty.All(v =\u003E int.TryParse(v, out _)))\n            return ColumnType.Integer;\n\n        if (nonEmpty.All(v =\u003E decimal.TryParse(v, out _)))\n            return ColumnType.Decimal;\n\n        return ColumnType.String;\n    }\n\n    private static bool IsBoolean(string value) =\u003E\n        value.Equals(\u0022true\u0022, StringComparison.OrdinalIgnoreCase)\n        || value.Equals(\u0022false\u0022, StringComparison.OrdinalIgnoreCase);\n\n    private static bool IsDate(string value) =\u003E\n        DateOnly.TryParse(value, out _);\n}\n",
   "intentSpecPath": "/workspace/samples/spike-s0/intents/honest-csv-inferrer.json",
   "certification": {
-    "recordId": "1399b05c874b477e88bc6fb6adb85e3c",
-    "redReason": 2,
+    "recordId": "33ea356a37d34668bfe014e908b68754",
+    "redReason": "assertionFailure",
     "mutationScore": 93.33,
     "mutationThreshold": 80,
     "mutationSkipped": false,
@@ -23,8 +23,15 @@
     "roleSeparationAttested": true,
     "catalogVersion": "s1.4-v1",
     "probeCorpusVersion": "s1.4-v1",
-    "certifiedAt": "2026-06-20T03:24:21.6490361+00:00",
-    "signature": "R1M9SBfX8tU3kzD1di3GHpsHcj46NnvEvYkCMeJuw4I="
+    "certifiedAt": "2026-06-20T04:17:36.8995189+00:00",
+    "signature": "xHzyDC\u002BoXvCV/qnYzV3HRaqfTBXfVjitvcOkqKx2rRo="
   },
-  "admittedAt": "2026-06-20T03:24:21.9903791+00:00"
+  "provenance": {
+    "generatorBackend": "recorded",
+    "isolationEnforced": false,
+    "modelId": null,
+    "temperature": null,
+    "attemptsUsed": 1
+  },
+  "admittedAt": "2026-06-20T04:17:37.2296068+00:00"
 }

--- a/artifacts/s3/skill-loop-report.json
+++ b/artifacts/s3/skill-loop-report.json
@@ -1,7 +1,7 @@
 {
-  "version": "s3.0-v1",
-  "generatorBackend": "scripted-standin",
-  "runAt": "2026-06-20T03:24:26.6832152+00:00",
+  "version": "s3.1-recorded-v1",
+  "generatorBackend": "recorded",
+  "runAt": "2026-06-20T04:17:51.4714618+00:00",
   "calls": [
     {
       "scenario": "generated-and-admitted",
@@ -10,11 +10,15 @@
       "generationRan": true,
       "certificationRan": true,
       "reused": false,
-      "generatorBackend": "scripted-standin",
+      "generatorBackend": "recorded",
       "entryId": "csv-type-inference",
       "rejectionReason": null,
       "registryEntryCountBefore": 0,
-      "registryEntryCountAfter": 1
+      "registryEntryCountAfter": 1,
+      "isolationEnforced": false,
+      "modelId": null,
+      "attemptsUsed": 1,
+      "temperature": null
     },
     {
       "scenario": "reused-same-intent",
@@ -23,11 +27,15 @@
       "generationRan": false,
       "certificationRan": false,
       "reused": true,
-      "generatorBackend": "scripted-standin",
+      "generatorBackend": "recorded",
       "entryId": "csv-type-inference",
       "rejectionReason": null,
       "registryEntryCountBefore": 1,
-      "registryEntryCountAfter": 1
+      "registryEntryCountAfter": 1,
+      "isolationEnforced": false,
+      "modelId": null,
+      "attemptsUsed": 0,
+      "temperature": null
     },
     {
       "scenario": "reused-other-context",
@@ -36,11 +44,15 @@
       "generationRan": false,
       "certificationRan": false,
       "reused": true,
-      "generatorBackend": "scripted-standin",
+      "generatorBackend": "recorded",
       "entryId": "csv-type-inference",
       "rejectionReason": null,
       "registryEntryCountBefore": 1,
-      "registryEntryCountAfter": 1
+      "registryEntryCountAfter": 1,
+      "isolationEnforced": false,
+      "modelId": null,
+      "attemptsUsed": 0,
+      "temperature": null
     },
     {
       "scenario": "rejected-failed-certification",
@@ -49,11 +61,15 @@
       "generationRan": true,
       "certificationRan": true,
       "reused": false,
-      "generatorBackend": "scripted-standin",
+      "generatorBackend": "recorded",
       "entryId": null,
-      "rejectionReason": "gate stack failed at RED: Determining projects to restore...\n  All projects are up-to-date for restore.\n  CsvColumnInferrer -\u003E /tmp/nexo-s3-cert/aa493e0ddad84815b4c32d3d6b02010f/workspace/CsvColumnInferrer/bin/Release/net8.0/CsvColumnInferrer.dll\n  CsvColumnInferrer.Tests -\u003E /tmp/nexo-s3-cert/aa493e0ddad84815b4c32d3d6b02010f...",
+      "rejectionReason": "gate stack failed at RED: Determining projects to restore...\n  All projects are up-to-date for restore.\n  CsvColumnInferrer -\u003E /tmp/nexo-s3-cert/09e2c6e51d15442cb9ba170111983d0a/workspace/CsvColumnInferrer/bin/Release/net8.0/CsvColumnInferrer.dll\n  CsvColumnInferrer.Tests -\u003E /tmp/nexo-s3-cert/09e2c6e51d15442cb9ba170111983d0a...",
       "registryEntryCountBefore": 1,
-      "registryEntryCountAfter": 1
+      "registryEntryCountAfter": 1,
+      "isolationEnforced": false,
+      "modelId": null,
+      "attemptsUsed": 3,
+      "temperature": null
     }
   ],
   "registryEntryIds": [

--- a/docs/spike/s3-claude-live-run.md
+++ b/docs/spike/s3-claude-live-run.md
@@ -1,0 +1,27 @@
+# S3.2 live Claude generation (local only)
+
+## Prerequisites
+
+- `ANTHROPIC_API_KEY` set in the environment (never committed)
+- `NEXO_S3_GENERATOR=claude` (opt-in gate)
+- Optional: `NEXO_S3_MODEL` (default `claude-sonnet-4-20250514`), `NEXO_S3_TEMPERATURE` (default `0`)
+
+## Run
+
+```bash
+make s3-generate-live
+```
+
+Produces:
+
+- `artifacts/s3/skill-loop-report.json` with version `s3.2-claude-v1`
+- Transcripts under `artifacts/s3/generate-live/<handoff-id>/` (no API key)
+- Registry entry with `isolationEnforced: true` when admitted
+
+## Isolation
+
+The Anthropic prompt is assembled solely from the sealed `GenerationRequest` (intent spec without acceptance criteria). `RequestIsolationTests` assert the assembled prompt contains no oracle, test, property, or acceptance content.
+
+## CI / cloud
+
+Never set `NEXO_S3_GENERATOR=claude` in CI. Default `recorded` backend runs via `make s3-loop-recorded`.

--- a/scripts/cursor-agent-setup-s3.sh
+++ b/scripts/cursor-agent-setup-s3.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Cursor background-agent provisioning for Spike S3 skill registry loop.
-# Offline: no model, no API key, no network for generation (stand-in only).
-
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
@@ -15,11 +12,10 @@ fi
 
 export PATH="$HOME/.dotnet/tools:$PATH"
 export DOTNET_ROOT="${DOTNET_ROOT:-$HOME/.dotnet}"
-unset OPENAI_API_KEY
+unset NEXO_S3_GENERATOR
 unset ANTHROPIC_API_KEY
+unset OPENAI_API_KEY
 unset NEXO_LLM_API_KEY
-unset NEXO_S1_ADVERSARY
-unset NEXO_S2_ADVERSARY
 
 dotnet --version
 

--- a/src/Nexo.Spike.S3/Generation/Claude/AnthropicMessagesTransport.cs
+++ b/src/Nexo.Spike.S3/Generation/Claude/AnthropicMessagesTransport.cs
@@ -1,0 +1,75 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Nexo.Spike.S3.Generation.Claude;
+
+/// <summary>
+/// Anthropic Messages API transport for S3 live generation. Reads API key only at call time.
+/// </summary>
+public sealed class AnthropicMessagesTransport : IS3LlmTransport, IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private readonly Func<ClaudeRuntimeConfig> _configFactory;
+
+    public AnthropicMessagesTransport(HttpClient? httpClient = null)
+        : this(httpClient, ClaudeRuntimeConfig.LoadFromEnvironment)
+    {
+    }
+
+    internal AnthropicMessagesTransport(HttpClient? httpClient, Func<ClaudeRuntimeConfig> configFactory)
+    {
+        _httpClient = httpClient ?? new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(10)
+        };
+        _configFactory = configFactory;
+    }
+
+    public async Task<string> CompleteAsync(S3LlmCompletionRequest request, CancellationToken ct = default)
+    {
+        var config = _configFactory();
+        config.ValidateForCall();
+
+        var body = new Dictionary<string, object?>
+        {
+            ["model"] = request.Model,
+            ["max_tokens"] = 4096,
+            ["system"] = request.SystemPrompt,
+            ["messages"] = new[] { new { role = "user", content = request.UserPrompt } },
+            ["temperature"] = request.Temperature
+        };
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, $"{config.BaseUrl.TrimEnd('/')}/messages");
+        httpRequest.Headers.Add("x-api-key", config.ApiKey);
+        httpRequest.Headers.Add("anthropic-version", "2023-06-01");
+        httpRequest.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+
+        using var response = await _httpClient.SendAsync(httpRequest, ct).ConfigureAwait(false);
+        var payload = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        payload = ClaudeRuntimeConfig.RedactSecrets(payload, config);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Anthropic messages API failed with HTTP {(int)response.StatusCode}. Check model id and quota.");
+        }
+
+        using var doc = JsonDocument.Parse(payload);
+        foreach (var block in doc.RootElement.GetProperty("content").EnumerateArray())
+        {
+            if (block.TryGetProperty("type", out var typeEl)
+                && typeEl.GetString() == "text"
+                && block.TryGetProperty("text", out var textEl))
+            {
+                var text = textEl.GetString()
+                           ?? throw new InvalidOperationException("Anthropic text block was empty.");
+                return ClaudeRuntimeConfig.RedactSecrets(text, config);
+            }
+        }
+
+        throw new InvalidOperationException("Anthropic response did not include a text block.");
+    }
+
+    public void Dispose() => _httpClient.Dispose();
+}

--- a/src/Nexo.Spike.S3/Generation/Claude/ClaudeRuntimeConfig.cs
+++ b/src/Nexo.Spike.S3/Generation/Claude/ClaudeRuntimeConfig.cs
@@ -1,0 +1,57 @@
+namespace Nexo.Spike.S3.Generation.Claude;
+
+public sealed class ClaudeRuntimeConfig
+{
+    public const string DefaultModel = "claude-sonnet-4-20250514";
+    public const double DefaultTemperature = 0;
+
+    public string ApiKey { get; init; } = string.Empty;
+
+    public string BaseUrl { get; init; } = "https://api.anthropic.com/v1";
+
+    public string Model { get; init; } = DefaultModel;
+
+    public double Temperature { get; init; } = DefaultTemperature;
+
+    public void ValidateForCall()
+    {
+        if (string.IsNullOrWhiteSpace(ApiKey))
+        {
+            throw new InvalidOperationException(
+                "ANTHROPIC_API_KEY is not set. Live Claude generation requires the key at call time only; " +
+                "it is never persisted, logged, or included in transcripts.");
+        }
+
+        if (string.IsNullOrWhiteSpace(Model))
+        {
+            throw new InvalidOperationException(
+                "NEXO_S3_MODEL is not set. Provide a Claude model id before live generation.");
+        }
+    }
+
+    public static ClaudeRuntimeConfig LoadFromEnvironment()
+    {
+        var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY") ?? string.Empty;
+        var model = Environment.GetEnvironmentVariable("NEXO_S3_MODEL") ?? DefaultModel;
+        var baseUrl = Environment.GetEnvironmentVariable("ANTHROPIC_BASE_URL") ?? "https://api.anthropic.com/v1";
+        var temperature = double.TryParse(Environment.GetEnvironmentVariable("NEXO_S3_TEMPERATURE"), out var t)
+            ? t
+            : DefaultTemperature;
+
+        return new ClaudeRuntimeConfig
+        {
+            ApiKey = apiKey,
+            BaseUrl = baseUrl,
+            Model = model,
+            Temperature = temperature
+        };
+    }
+
+    public static string RedactSecrets(string text, ClaudeRuntimeConfig config)
+    {
+        if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(config.ApiKey))
+            return text;
+
+        return text.Replace(config.ApiKey, "[REDACTED_API_KEY]", StringComparison.Ordinal);
+    }
+}

--- a/src/Nexo.Spike.S3/Generation/Claude/ClaudeSkillGenerator.cs
+++ b/src/Nexo.Spike.S3/Generation/Claude/ClaudeSkillGenerator.cs
@@ -1,0 +1,110 @@
+using Nexo.Spike.S2.Adversary.Llm;
+using Nexo.Spike.S3.Generation;
+using Nexo.Spike.S3.Models;
+
+namespace Nexo.Spike.S3.Generation.Claude;
+
+/// <summary>
+/// Live Claude generator — isolationEnforced=true; prompt built solely from sealed request.
+/// </summary>
+public sealed class ClaudeSkillGenerator : ISkillGenerator
+{
+    public const string BackendLabel = "claude";
+
+    private readonly IS3LlmTransport _transport;
+    private readonly Func<ClaudeRuntimeConfig> _configFactory;
+    private readonly string? _workRoot;
+    private int _generationCallCount;
+
+    public ClaudeSkillGenerator(IS3LlmTransport? transport = null, string? workRoot = null)
+        : this(transport, ClaudeRuntimeConfig.LoadFromEnvironment, workRoot)
+    {
+    }
+
+    internal ClaudeSkillGenerator(
+        IS3LlmTransport? transport,
+        Func<ClaudeRuntimeConfig> configFactory,
+        string? workRoot)
+    {
+        _transport = transport ?? new AnthropicMessagesTransport();
+        _configFactory = configFactory;
+        _workRoot = workRoot;
+    }
+
+    public string BackendName => BackendLabel;
+
+    public bool IsolationEnforced => true;
+
+    public int GenerationCallCount => _generationCallCount;
+
+    public GenerationHandoff Describe(
+        IntentDescriptor intent,
+        IReadOnlyList<GateVerdictSummary>? priorVerdicts = null,
+        int attemptIndex = 0,
+        string? workRoot = null)
+    {
+        var (request, _) = GenerationRequestSealer.BuildAsync(intent, priorVerdicts, attemptIndex)
+            .GetAwaiter()
+            .GetResult();
+
+        var root = workRoot ?? _workRoot ?? Path.Combine(Path.GetTempPath(), "nexo-s3-claude");
+        var handoffId = $"{BackendLabel}-{attemptIndex:D2}-{Guid.NewGuid():N}";
+        var workDirectory = Path.Combine(root, handoffId);
+        Directory.CreateDirectory(workDirectory);
+
+        var requestPath = Path.Combine(workDirectory, GenerationRequestSealer.RequestFileName);
+        GenerationRequestSealer.Persist(request, requestPath);
+        RequestIsolationGuard.AssertIsolated(File.ReadAllText(requestPath), "claude request.json");
+
+        var prompt = SkillGeneratorPromptAssembler.Assemble(request);
+        File.WriteAllText(Path.Combine(workDirectory, "assembled-system-prompt.txt"), prompt.SystemPrompt);
+        File.WriteAllText(Path.Combine(workDirectory, "assembled-user-prompt.txt"), prompt.UserPrompt);
+        RequestIsolationGuard.AssertIsolated(prompt.SystemPrompt, "claude system prompt");
+        RequestIsolationGuard.AssertIsolated(prompt.UserPrompt, "claude user prompt");
+
+        return new GenerationHandoff(
+            handoffId,
+            workDirectory,
+            requestPath,
+            request,
+            IsolationEnforced: true,
+            BackendLabel);
+    }
+
+    public async Task<SkillCandidate> IngestAsync(GenerationHandoff handoff, CancellationToken ct = default)
+    {
+        _generationCallCount++;
+        var config = _configFactory();
+        config.ValidateForCall();
+
+        var prompt = SkillGeneratorPromptAssembler.Assemble(handoff.Request);
+        RequestIsolationGuard.AssertIsolated(prompt.SystemPrompt, "claude ingest system prompt");
+        RequestIsolationGuard.AssertIsolated(prompt.UserPrompt, "claude ingest user prompt");
+
+        var response = await _transport.CompleteAsync(
+            new S3LlmCompletionRequest(config.Model, prompt.SystemPrompt, prompt.UserPrompt, config.Temperature),
+            ct).ConfigureAwait(false);
+
+        var redacted = ClaudeRuntimeConfig.RedactSecrets(response, config);
+        File.WriteAllText(Path.Combine(handoff.WorkDirectory, "model-response.txt"), redacted);
+
+        var implementation = ImplementationSourceParser.Parse(redacted);
+        var (_, intentSpecPath) = await GenerationRequestSealer
+            .BuildAsync(handoff.Request.Intent, handoff.Request.PriorGateVerdicts, handoff.Request.AttemptIndex, ct)
+            .ConfigureAwait(false);
+
+        return new SkillCandidate(
+            $"claude-{handoff.HandoffId}",
+            handoff.Request.Intent,
+            intentSpecPath,
+            implementation,
+            BackendLabel,
+            $"Claude generated implementation (model={config.Model}, attempt={handoff.Request.AttemptIndex + 1})",
+            new SkillProvenance(
+                BackendLabel,
+                true,
+                config.Model,
+                config.Temperature,
+                handoff.Request.AttemptIndex + 1));
+    }
+}

--- a/src/Nexo.Spike.S3/Generation/Claude/IS3LlmTransport.cs
+++ b/src/Nexo.Spike.S3/Generation/Claude/IS3LlmTransport.cs
@@ -1,0 +1,12 @@
+namespace Nexo.Spike.S3.Generation.Claude;
+
+public sealed record S3LlmCompletionRequest(
+    string Model,
+    string SystemPrompt,
+    string UserPrompt,
+    double Temperature);
+
+public interface IS3LlmTransport
+{
+    Task<string> CompleteAsync(S3LlmCompletionRequest request, CancellationToken ct = default);
+}

--- a/src/Nexo.Spike.S3/Generation/Claude/SkillGeneratorPromptAssembler.cs
+++ b/src/Nexo.Spike.S3/Generation/Claude/SkillGeneratorPromptAssembler.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using Nexo.Spike.S3.Models;
+
+namespace Nexo.Spike.S3.Generation.Claude;
+
+public sealed record AssembledPrompt(string SystemPrompt, string UserPrompt);
+
+/// <summary>
+/// Builds Anthropic prompts from the sealed generation request only.
+/// </summary>
+public static class SkillGeneratorPromptAssembler
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public const string SystemPromptTemplate =
+        """
+        You are the implementer for a pure C# brick in namespace CsvColumnInferrer.
+        Return ONLY a single fenced ```csharp block containing ColumnType enum and ColumnTypeInferrer class.
+        Do not include tests, properties, oracle labels, or acceptance examples.
+        Honor the sealed intent invariants exactly. No I/O, clocks, or randomness.
+        """;
+
+    public static AssembledPrompt Assemble(GenerationRequest request)
+    {
+        var intentJson = JsonSerializer.Serialize(
+            new
+            {
+                request.Intent,
+                request.IntentSpec,
+                request.AttemptIndex
+            },
+            SerializerOptions);
+
+        var retrySection = request.PriorGateVerdicts.Count == 0
+            ? "No prior gate failures."
+            : string.Join(
+                "\n",
+                request.PriorGateVerdicts.Select(v =>
+                    $"- attempt {v.AttemptIndex}: gate={v.FailedGate ?? "unknown"}; summary={v.RejectionSummary ?? "n/a"}"));
+
+        var userPrompt =
+            $"""
+             Sealed intent request (no acceptance criteria provided):
+             {intentJson}
+
+             Prior gate verdict summaries:
+             {retrySection}
+
+             Produce ColumnTypeInferrer implementation source only.
+             """;
+
+        return new AssembledPrompt(SystemPromptTemplate, userPrompt);
+    }
+}

--- a/src/Nexo.Spike.S3/Generation/GenerationRequestSealer.cs
+++ b/src/Nexo.Spike.S3/Generation/GenerationRequestSealer.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using Nexo.Spike.S0;
+using Nexo.Spike.S0.Models;
+using Nexo.Spike.S3.Models;
+
+namespace Nexo.Spike.S3.Generation;
+
+public static class GenerationRequestSealer
+{
+    public const string RequestFileName = "request.json";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public static async Task<(GenerationRequest Request, string IntentSpecPath)> BuildAsync(
+        IntentDescriptor intent,
+        IReadOnlyList<GateVerdictSummary>? priorVerdicts,
+        int attemptIndex,
+        CancellationToken ct = default)
+    {
+        var intentSpecPath = ResolveIntentSpecPath();
+        var spec = await BrickSpecLoader.LoadAsync(intentSpecPath, ct).ConfigureAwait(false);
+        var sealedSpec = ToSealedSpec(spec);
+        var request = new GenerationRequest(
+            intent,
+            sealedSpec,
+            priorVerdicts ?? [],
+            attemptIndex);
+
+        return (request, intentSpecPath);
+    }
+
+    public static SealedIntentSpec ToSealedSpec(BrickSpec spec) =>
+        new(
+            spec.IntentId,
+            spec.Title,
+            spec.Description,
+            spec.Inputs,
+            spec.Outputs,
+            spec.Invariants);
+
+    public static void Persist(GenerationRequest request, string requestPath)
+    {
+        var json = JsonSerializer.Serialize(request, SerializerOptions);
+        Directory.CreateDirectory(Path.GetDirectoryName(requestPath)!);
+        File.WriteAllText(requestPath, json);
+    }
+
+    public static GenerationRequest Load(string requestPath)
+    {
+        var json = File.ReadAllText(requestPath);
+        return JsonSerializer.Deserialize<GenerationRequest>(json, SerializerOptions)
+               ?? throw new InvalidOperationException($"Could not deserialize generation request: {requestPath}");
+    }
+
+    internal static string ResolveIntentSpecPath()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(Directory.GetCurrentDirectory(), "samples", "spike-s0", "intents", "honest-csv-inferrer.json"),
+            Path.Combine(Directory.GetCurrentDirectory(), "src", "Nexo.Spike.S1", "Fixtures", "honest-csv-inferrer.json"),
+            Path.Combine(AppContext.BaseDirectory, "Fixtures", "honest-csv-inferrer.json")
+        };
+
+        foreach (var path in candidates)
+        {
+            if (File.Exists(path))
+                return path;
+        }
+
+        throw new FileNotFoundException("honest-csv-inferrer intent fixture not found");
+    }
+}

--- a/src/Nexo.Spike.S3/Generation/ISkillGenerator.cs
+++ b/src/Nexo.Spike.S3/Generation/ISkillGenerator.cs
@@ -1,0 +1,23 @@
+using Nexo.Spike.S3.Models;
+
+namespace Nexo.Spike.S3.Generation;
+
+/// <summary>
+/// Describe (sealed request) → Ingest (candidate) generation seam.
+/// </summary>
+public interface ISkillGenerator
+{
+    string BackendName { get; }
+
+    bool IsolationEnforced { get; }
+
+    int GenerationCallCount { get; }
+
+    GenerationHandoff Describe(
+        IntentDescriptor intent,
+        IReadOnlyList<GateVerdictSummary>? priorVerdicts = null,
+        int attemptIndex = 0,
+        string? workRoot = null);
+
+    Task<SkillCandidate> IngestAsync(GenerationHandoff handoff, CancellationToken ct = default);
+}

--- a/src/Nexo.Spike.S3/Generation/RecordedSkillGenerator.cs
+++ b/src/Nexo.Spike.S3/Generation/RecordedSkillGenerator.cs
@@ -1,0 +1,72 @@
+using Nexo.Spike.S3.Models;
+
+namespace Nexo.Spike.S3.Generation;
+
+/// <summary>
+/// Default offline recorded generator — deterministic catalog replay, isolationEnforced=false.
+/// </summary>
+public sealed class RecordedSkillGenerator : ISkillGenerator
+{
+    public const string BackendLabel = "recorded";
+
+    private int _generationCallCount;
+
+    public string BackendName => BackendLabel;
+
+    public bool IsolationEnforced => false;
+
+    public int GenerationCallCount => _generationCallCount;
+
+    public GenerationHandoff Describe(
+        IntentDescriptor intent,
+        IReadOnlyList<GateVerdictSummary>? priorVerdicts = null,
+        int attemptIndex = 0,
+        string? workRoot = null)
+    {
+        var (request, _) = GenerationRequestSealer.BuildAsync(intent, priorVerdicts, attemptIndex)
+            .GetAwaiter()
+            .GetResult();
+
+        var root = workRoot ?? Path.Combine(Path.GetTempPath(), "nexo-s3-recorded", Guid.NewGuid().ToString("N"));
+        var handoffId = $"{BackendLabel}-{attemptIndex:D2}-{Guid.NewGuid():N}";
+        var workDirectory = Path.Combine(root, handoffId);
+        Directory.CreateDirectory(workDirectory);
+
+        var requestPath = Path.Combine(workDirectory, GenerationRequestSealer.RequestFileName);
+        GenerationRequestSealer.Persist(request, requestPath);
+        RequestIsolationGuard.AssertIsolated(File.ReadAllText(requestPath), "recorded request.json");
+
+        return new GenerationHandoff(
+            handoffId,
+            workDirectory,
+            requestPath,
+            request,
+            IsolationEnforced: false,
+            BackendLabel);
+    }
+
+    public Task<SkillCandidate> IngestAsync(GenerationHandoff handoff, CancellationToken ct = default)
+    {
+        _generationCallCount++;
+        var catalog = StandInSkillCatalog.Resolve(handoff.Request.Intent);
+        var (_, intentSpecPath) = GenerationRequestSealer
+            .BuildAsync(handoff.Request.Intent, handoff.Request.PriorGateVerdicts, handoff.Request.AttemptIndex, ct)
+            .GetAwaiter()
+            .GetResult();
+
+        var candidate = new SkillCandidate(
+            catalog.CandidateId,
+            handoff.Request.Intent,
+            intentSpecPath,
+            catalog.ImplementationSource,
+            BackendLabel,
+            catalog.Hypothesis,
+            new SkillProvenance(BackendLabel, false, null, null, handoff.Request.AttemptIndex + 1));
+
+        File.WriteAllText(
+            Path.Combine(handoff.WorkDirectory, "candidate.json"),
+            System.Text.Json.JsonSerializer.Serialize(candidate));
+
+        return Task.FromResult(candidate);
+    }
+}

--- a/src/Nexo.Spike.S3/Generation/RequestIsolationGuard.cs
+++ b/src/Nexo.Spike.S3/Generation/RequestIsolationGuard.cs
@@ -1,0 +1,122 @@
+using Nexo.Spike.S0;
+using Nexo.Spike.S0.Models;
+
+namespace Nexo.Spike.S3.Generation;
+
+/// <summary>
+/// Ensures generator prompts/requests never include oracle, test, property, or acceptance content.
+/// </summary>
+public static class RequestIsolationGuard
+{
+    public sealed record Violation(string Category, string Excerpt);
+
+    public static IReadOnlyList<Violation> FindViolations(string content)
+    {
+        var violations = new List<Violation>();
+        foreach (var sample in LoadForbiddenSamples())
+        {
+            if (ContainsDistinctiveFragment(content, sample.Value))
+            {
+                violations.Add(new Violation(sample.Key, Truncate(sample.Value)));
+            }
+        }
+
+        return violations;
+    }
+
+    public static void AssertIsolated(string content, string contextLabel)
+    {
+        var violations = FindViolations(content);
+        if (violations.Count == 0)
+            return;
+
+        var details = string.Join(
+            "; ",
+            violations.Select(v => $"{v.Category}: '{v.Excerpt}'"));
+
+        throw new InvalidOperationException(
+            $"Request isolation violated for {contextLabel}: {details}");
+    }
+
+    private static bool ContainsDistinctiveFragment(string haystack, string needle)
+    {
+        if (string.IsNullOrWhiteSpace(needle))
+            return false;
+
+        foreach (var fragment in DistinctiveFragments(needle))
+        {
+            if (haystack.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> DistinctiveFragments(string sample)
+    {
+        var lines = sample.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var line in lines)
+        {
+            if (line.Length >= 12)
+                yield return line;
+        }
+
+        if (sample.Length >= 12)
+            yield return sample[..Math.Min(sample.Length, 48)];
+    }
+
+    private static Dictionary<string, string> LoadForbiddenSamples()
+    {
+        var samples = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var intentPath = GenerationRequestSealer.ResolveIntentSpecPath();
+        var intentJson = File.ReadAllText(intentPath);
+        var spec = BrickSpecLoader.LoadAsync(intentPath).GetAwaiter().GetResult();
+        samples["acceptance-criteria"] = string.Join('\n', spec.AcceptanceCriteria);
+
+        foreach (var path in ResolveForbiddenPaths())
+        {
+            if (!File.Exists(path))
+                continue;
+
+            var text = File.ReadAllText(path);
+            var key = Path.GetFileName(path);
+            samples[key] = text;
+        }
+
+        return samples;
+    }
+
+    private static IEnumerable<string> ResolveForbiddenPaths()
+    {
+        var relative = new[]
+        {
+            Path.Combine("src", "Nexo.Spike.S1", "Fixtures", "honest-tests.cs"),
+            Path.Combine("src", "Nexo.Spike.S1", "Fixtures", "honest-impl.cs"),
+            Path.Combine("samples", "spike-s0", "template", "CsvColumnInferrer.Properties", "MetamorphicPropertyTests.cs"),
+            Path.Combine("samples", "spike-s0", "template", "CsvColumnInferrer.Properties", "SpecAcceptancePropertyTests.cs"),
+            Path.Combine("artifacts", "s2", "reference-oracle.json")
+        };
+
+        var roots = new List<string> { Directory.GetCurrentDirectory() };
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            roots.Add(dir.FullName);
+            dir = dir.Parent;
+        }
+
+        foreach (var root in roots.Distinct())
+        {
+            foreach (var rel in relative)
+            {
+                var full = Path.Combine(root, rel);
+                if (File.Exists(full))
+                    yield return full;
+            }
+        }
+    }
+
+    private static string Truncate(string value, int max = 60) =>
+        value.Length <= max ? value : value[..max] + "...";
+}

--- a/src/Nexo.Spike.S3/Generation/SkillGeneratorFactory.cs
+++ b/src/Nexo.Spike.S3/Generation/SkillGeneratorFactory.cs
@@ -1,0 +1,45 @@
+namespace Nexo.Spike.S3.Generation;
+
+public static class SkillGeneratorFactory
+{
+    public const string RecordedMode = "recorded";
+    public const string ClaudeMode = "claude";
+
+    /// <summary>Legacy alias kept for S3.0 compatibility in reports/tests.</summary>
+    public const string ScriptedStandInMode = "scripted-standin";
+
+    public static string ResolveMode()
+    {
+        var configured = Environment.GetEnvironmentVariable("NEXO_S3_GENERATOR")?.Trim();
+        if (string.IsNullOrWhiteSpace(configured))
+            return RecordedMode;
+
+        return configured.ToLowerInvariant() switch
+        {
+            RecordedMode or ScriptedStandInMode => RecordedMode,
+            ClaudeMode => ClaudeMode,
+            _ => throw new InvalidOperationException(
+                $"Unknown NEXO_S3_GENERATOR value '{configured}'. Use '{RecordedMode}' or '{ClaudeMode}'.")
+        };
+    }
+
+    public static ISkillGenerator Create(string? workRoot = null) =>
+        ResolveMode() switch
+        {
+            ClaudeMode => new Claude.ClaudeSkillGenerator(workRoot: workRoot),
+            _ => new RecordedSkillGenerator()
+        };
+
+    public static void EnsureLiveModeConfigured()
+    {
+        if (!string.Equals(ResolveMode(), ClaudeMode, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY")))
+        {
+            throw new InvalidOperationException(
+                "NEXO_S3_GENERATOR=claude requires ANTHROPIC_API_KEY at call time. " +
+                "The key is read from the environment only and is never persisted.");
+        }
+    }
+}

--- a/src/Nexo.Spike.S3/LiveGenerateRunner.cs
+++ b/src/Nexo.Spike.S3/LiveGenerateRunner.cs
@@ -1,0 +1,167 @@
+using Nexo.Spike.S3.Certification;
+using Nexo.Spike.S3.Generation;
+using Nexo.Spike.S3.Generation.Claude;
+using Nexo.Spike.S3.Loop;
+using Nexo.Spike.S3.Models;
+using Nexo.Spike.S3.Registry;
+using Nexo.Spike.S3.Reporting;
+
+namespace Nexo.Spike.S3;
+
+public static class LiveGenerateRunner
+{
+    public sealed record LiveGenerateOptions(
+        string ArtifactsRoot,
+        int IntentCount,
+        int MaxAttemptsPerIntent,
+        bool ResetRegistry,
+        double MutationThreshold,
+        bool RequireMutation,
+        int DensitySeeds,
+        int EscapeSeeds);
+
+    public static async Task<int> RunAsync(LiveGenerateOptions options, CancellationToken ct = default)
+    {
+        SkillGeneratorFactory.EnsureLiveModeConfigured();
+
+        var mode = SkillGeneratorFactory.ResolveMode();
+        if (!string.Equals(mode, SkillGeneratorFactory.ClaudeMode, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Live generation requires NEXO_S3_GENERATOR=claude. CI/cloud must use the recorded backend.");
+        }
+
+        var config = ClaudeRuntimeConfig.LoadFromEnvironment();
+        var estimatedCalls = options.IntentCount * options.MaxAttemptsPerIntent;
+        Console.WriteLine("Live Claude generation (LOCAL ONLY — costs credits)");
+        Console.WriteLine($"Model: {config.Model}");
+        Console.WriteLine($"Temperature: {config.Temperature}");
+        Console.WriteLine($"Isolation enforced: true");
+        Console.WriteLine($"Estimated Anthropic calls (worst case): {estimatedCalls}");
+        Console.WriteLine("API key: read from ANTHROPIC_API_KEY at call time only — never persisted.");
+
+        var registryRoot = Path.Combine(options.ArtifactsRoot, RegistryPaths.RegistryFolderName);
+        var generateRoot = Path.Combine(options.ArtifactsRoot, "generate-live");
+        if (options.ResetRegistry && Directory.Exists(registryRoot))
+            Directory.Delete(registryRoot, recursive: true);
+        Directory.CreateDirectory(generateRoot);
+
+        var registry = new SkillRegistry(registryRoot);
+        var generator = SkillGeneratorFactory.Create(generateRoot);
+        var certification = new SkillCertificationHarness(
+            mutationThresholdPercent: options.MutationThreshold,
+            requireMutation: options.RequireMutation,
+            densitySeeds: options.DensitySeeds,
+            escapeSeeds: options.EscapeSeeds);
+        var loop = new SkillReuseLoop(
+            registry,
+            generator,
+            certification,
+            new SkillReuseLoopOptions
+            {
+                MaxAttemptsPerIntent = options.MaxAttemptsPerIntent,
+                GenerationWorkRoot = generateRoot
+            });
+
+        var intents = BuildLiveIntents().Take(Math.Max(1, options.IntentCount)).ToList();
+        var calls = new List<SkillLoopCallRecord>();
+
+        foreach (var scenario in intents)
+        {
+            ct.ThrowIfCancellationRequested();
+            var before = registry.ListEntries().Count;
+            var result = await loop.EnsureSkillAsync(scenario.Intent, scenario.ContextLabel, ct)
+                .ConfigureAwait(false);
+            var after = registry.ListEntries().Count;
+
+            calls.Add(new SkillLoopCallRecord(
+                scenario.Name,
+                scenario.ContextLabel,
+                result.Outcome,
+                result.GenerationRan,
+                result.CertificationRan,
+                result.Reused,
+                result.GeneratorBackend,
+                result.Entry?.EntryId,
+                result.RejectionReason,
+                before,
+                after,
+                result.IsolationEnforced,
+                result.ModelId ?? config.Model,
+                result.AttemptsUsed,
+                config.Temperature));
+
+            if (result.Outcome == EnsureSkillOutcome.Generated)
+            {
+                var reuse = await loop.EnsureSkillAsync(scenario.Intent, "reuse-proof", ct)
+                    .ConfigureAwait(false);
+                calls.Add(new SkillLoopCallRecord(
+                    $"{scenario.Name}-reuse-proof",
+                    "reuse-proof",
+                    reuse.Outcome,
+                    reuse.GenerationRan,
+                    reuse.CertificationRan,
+                    reuse.Reused,
+                    reuse.GeneratorBackend,
+                    reuse.Entry?.EntryId,
+                    reuse.RejectionReason,
+                    registry.ListEntries().Count,
+                    registry.ListEntries().Count,
+                    reuse.IsolationEnforced,
+                    reuse.ModelId ?? config.Model,
+                    reuse.AttemptsUsed,
+                    config.Temperature));
+            }
+        }
+
+        var report = new SkillLoopReport(
+            Version: "s3.2-claude-v1",
+            GeneratorBackend: generator.BackendName,
+            RunAt: DateTimeOffset.UtcNow,
+            Calls: calls,
+            RegistryEntryIds: registry.ListEntries().Select(e => e.EntryId).OrderBy(id => id).ToList());
+
+        var reportPath = await SkillLoopReportWriter.WriteAsync(
+            report,
+            Path.Combine(options.ArtifactsRoot, "skill-loop-report.json")).ConfigureAwait(false);
+
+        Console.WriteLine($"Wrote live report: {reportPath}");
+        Console.WriteLine($"Transcripts: {generateRoot}");
+        Console.WriteLine($"Generation calls: {loop.GenerationCallCount}");
+        Console.WriteLine($"Certification invocations: {loop.CertificationInvocationCount}");
+
+        foreach (var call in calls)
+        {
+            Console.WriteLine(
+                $"  [{call.Scenario}] outcome={call.Outcome} isolation={call.IsolationEnforced} " +
+                $"generationRan={call.GenerationRan} attempts={call.AttemptsUsed}");
+        }
+
+        var hasOutcome = calls.Any(c => c.Outcome is EnsureSkillOutcome.Generated or EnsureSkillOutcome.Rejected);
+        var reuseProof = calls.Any(c => c.Scenario.EndsWith("-reuse-proof", StringComparison.Ordinal)
+                                         && c.Outcome == EnsureSkillOutcome.Reused
+                                         && !c.GenerationRan);
+
+        return hasOutcome && (reuseProof || calls.All(c => c.Outcome == EnsureSkillOutcome.Rejected)) ? 0 : 1;
+    }
+
+    private static IReadOnlyList<LiveScenario> BuildLiveIntents() =>
+    [
+        new(
+            "claude-csv-type-inference",
+            new IntentDescriptor(
+                "csv-column-type-inference",
+                ["live", "claude"],
+                CapabilityKey: "csv-type-inference"),
+            "live-primary"),
+        new(
+            "claude-null-safe-inference",
+            new IntentDescriptor(
+                "csv-null-safe-type-inference",
+                ["live", "claude"],
+                CapabilityKey: "csv-null-safe-inference"),
+            "live-secondary")
+    ];
+
+    private sealed record LiveScenario(string Name, IntentDescriptor Intent, string ContextLabel);
+}

--- a/src/Nexo.Spike.S3/Loop/SkillReuseLoop.cs
+++ b/src/Nexo.Spike.S3/Loop/SkillReuseLoop.cs
@@ -5,36 +5,49 @@ using Nexo.Spike.S3.Registry;
 
 namespace Nexo.Spike.S3.Loop;
 
+public sealed class SkillReuseLoopOptions
+{
+    public int MaxAttemptsPerIntent { get; init; } = 3;
+
+    public string? GenerationWorkRoot { get; init; }
+}
+
 /// <summary>
-/// Lookup → generate (stand-in) → certify → admit reuse loop.
+/// Lookup → Describe → Ingest → certify → admit reuse loop with attempt cap.
 /// </summary>
 public sealed class SkillReuseLoop
 {
     private readonly SkillRegistry _registry;
-    private readonly IStandInSkillGenerator _generator;
+    private readonly ISkillGenerator _generator;
     private readonly ISkillCertificationHarness _certification;
+    private readonly SkillReuseLoopOptions _options;
     private int _certificationInvocationCount;
 
     public SkillReuseLoop(
         SkillRegistry registry,
-        IStandInSkillGenerator generator,
-        ISkillCertificationHarness certification)
+        ISkillGenerator generator,
+        ISkillCertificationHarness certification,
+        SkillReuseLoopOptions? options = null)
     {
         _registry = registry;
         _generator = generator;
         _certification = certification;
+        _options = options ?? new SkillReuseLoopOptions();
     }
 
     public int CertificationInvocationCount => _certificationInvocationCount;
 
-    public int GenerationCount => _generator.GenerationCount;
+    public int GenerationCallCount => _generator.GenerationCallCount;
+
+    public string GeneratorBackend => _generator.BackendName;
+
+    public bool GeneratorIsolationEnforced => _generator.IsolationEnforced;
 
     public async Task<EnsureSkillResult> EnsureSkillAsync(
         IntentDescriptor intent,
         string? contextLabel = null,
         CancellationToken ct = default)
     {
-        var registryBefore = _registry.ListEntries().Count;
         var lookup = _registry.Lookup(intent);
         if (lookup.Found)
         {
@@ -45,46 +58,112 @@ public sealed class SkillReuseLoop
                 GenerationRan: false,
                 CertificationRan: false,
                 Reused: true,
-                GeneratorBackend: _generator.BackendName);
+                GeneratorBackend: _generator.BackendName,
+                IsolationEnforced: lookup.Entry?.Provenance.IsolationEnforced,
+                ModelId: lookup.Entry?.Provenance.ModelId,
+                AttemptsUsed: 0);
         }
 
-        var candidate = _generator.Generate(intent);
-        _certificationInvocationCount++;
-        var certification = await _certification.CertifyAsync(candidate, ct).ConfigureAwait(false);
-        if (!certification.SatisfiesPromotionContract || certification.Record is null)
+        var priorVerdicts = new List<GateVerdictSummary>();
+        var workRoot = _options.GenerationWorkRoot
+                       ?? Path.Combine(Path.GetTempPath(), "nexo-s3-generate", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workRoot);
+
+        for (var attempt = 0; attempt < _options.MaxAttemptsPerIntent; attempt++)
         {
-            var registryAfterReject = _registry.ListEntries().Count;
-            return new EnsureSkillResult(
-                EnsureSkillOutcome.Rejected,
-                null,
-                certification.RejectionReason ?? "certification failed",
-                GenerationRan: true,
-                CertificationRan: true,
-                Reused: false,
-                GeneratorBackend: _generator.BackendName);
+            ct.ThrowIfCancellationRequested();
+
+            var handoff = _generator.Describe(intent, priorVerdicts, attempt, workRoot);
+            var candidate = await _generator.IngestAsync(handoff, ct).ConfigureAwait(false);
+
+            _certificationInvocationCount++;
+            var certification = await _certification.CertifyAsync(candidate, ct).ConfigureAwait(false);
+            if (certification.SatisfiesPromotionContract && certification.Record is not null)
+            {
+                var admission = _registry.Admit(candidate, certification.Record);
+                if (admission.Status == AdmissionStatus.Admitted && admission.Entry is not null)
+                {
+                    return new EnsureSkillResult(
+                        EnsureSkillOutcome.Generated,
+                        admission.Entry,
+                        null,
+                        GenerationRan: true,
+                        CertificationRan: true,
+                        Reused: false,
+                        GeneratorBackend: _generator.BackendName,
+                        IsolationEnforced: candidate.Provenance?.IsolationEnforced ?? _generator.IsolationEnforced,
+                        ModelId: candidate.Provenance?.ModelId,
+                        AttemptsUsed: attempt + 1);
+                }
+
+                return new EnsureSkillResult(
+                    EnsureSkillOutcome.Rejected,
+                    null,
+                    admission.RejectionReason ?? "admission rejected",
+                    GenerationRan: true,
+                    CertificationRan: true,
+                    Reused: false,
+                    GeneratorBackend: _generator.BackendName,
+                    IsolationEnforced: candidate.Provenance?.IsolationEnforced ?? _generator.IsolationEnforced,
+                    ModelId: candidate.Provenance?.ModelId,
+                    AttemptsUsed: attempt + 1);
+            }
+
+            priorVerdicts.Add(new GateVerdictSummary(
+                attempt,
+                ExtractFailedGate(certification.RejectionReason),
+                SanitizeRejection(certification.RejectionReason)));
+
+            if (attempt + 1 >= _options.MaxAttemptsPerIntent)
+            {
+                return new EnsureSkillResult(
+                    EnsureSkillOutcome.Rejected,
+                    null,
+                    certification.RejectionReason ?? "certification failed after attempt cap",
+                    GenerationRan: true,
+                    CertificationRan: true,
+                    Reused: false,
+                    GeneratorBackend: _generator.BackendName,
+                    IsolationEnforced: candidate.Provenance?.IsolationEnforced ?? _generator.IsolationEnforced,
+                    ModelId: candidate.Provenance?.ModelId,
+                    AttemptsUsed: attempt + 1);
+            }
         }
 
-        var admission = _registry.Admit(candidate, certification.Record);
-        if (admission.Status != AdmissionStatus.Admitted || admission.Entry is null)
-        {
-            return new EnsureSkillResult(
-                EnsureSkillOutcome.Rejected,
-                null,
-                admission.RejectionReason ?? "admission rejected",
-                GenerationRan: true,
-                CertificationRan: true,
-                Reused: false,
-                GeneratorBackend: _generator.BackendName);
-        }
-
-        _ = registryBefore;
         return new EnsureSkillResult(
-            EnsureSkillOutcome.Generated,
-            admission.Entry,
+            EnsureSkillOutcome.Rejected,
             null,
+            "attempt cap exhausted without certified candidate",
             GenerationRan: true,
             CertificationRan: true,
             Reused: false,
-            GeneratorBackend: _generator.BackendName);
+            GeneratorBackend: _generator.BackendName,
+            IsolationEnforced: _generator.IsolationEnforced,
+            ModelId: null,
+            AttemptsUsed: _options.MaxAttemptsPerIntent);
+    }
+
+    private static string? ExtractFailedGate(string? reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+            return null;
+
+        const string prefix = "gate stack failed at ";
+        var index = reason.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+            return null;
+
+        var remainder = reason[(index + prefix.Length)..];
+        var colon = remainder.IndexOf(':');
+        return colon < 0 ? remainder.Trim() : remainder[..colon].Trim();
+    }
+
+    private static string? SanitizeRejection(string? reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+            return null;
+
+        var trimmed = reason.Trim();
+        return trimmed.Length <= 160 ? trimmed : trimmed[..160] + "...";
     }
 }

--- a/src/Nexo.Spike.S3/Models/EnsureSkillResult.cs
+++ b/src/Nexo.Spike.S3/Models/EnsureSkillResult.cs
@@ -14,4 +14,7 @@ public sealed record EnsureSkillResult(
     bool GenerationRan,
     bool CertificationRan,
     bool Reused,
-    string GeneratorBackend);
+    string GeneratorBackend,
+    bool? IsolationEnforced = null,
+    string? ModelId = null,
+    int? AttemptsUsed = null);

--- a/src/Nexo.Spike.S3/Models/GateVerdictSummary.cs
+++ b/src/Nexo.Spike.S3/Models/GateVerdictSummary.cs
@@ -1,0 +1,9 @@
+namespace Nexo.Spike.S3.Models;
+
+/// <summary>
+/// Sanitized prior gate outcome passed to generators on retry — no test/oracle output.
+/// </summary>
+public sealed record GateVerdictSummary(
+    int AttemptIndex,
+    string? FailedGate,
+    string? RejectionSummary);

--- a/src/Nexo.Spike.S3/Models/GenerationHandoff.cs
+++ b/src/Nexo.Spike.S3/Models/GenerationHandoff.cs
@@ -1,0 +1,12 @@
+namespace Nexo.Spike.S3.Models;
+
+/// <summary>
+/// Describe → persist → Ingest seam envelope.
+/// </summary>
+public sealed record GenerationHandoff(
+    string HandoffId,
+    string WorkDirectory,
+    string RequestPath,
+    GenerationRequest Request,
+    bool IsolationEnforced,
+    string GeneratorBackend);

--- a/src/Nexo.Spike.S3/Models/GenerationRequest.cs
+++ b/src/Nexo.Spike.S3/Models/GenerationRequest.cs
@@ -1,0 +1,10 @@
+namespace Nexo.Spike.S3.Models;
+
+/// <summary>
+/// Sealed generation handoff payload — intent only plus sanitized prior verdicts on retry.
+/// </summary>
+public sealed record GenerationRequest(
+    IntentDescriptor Intent,
+    SealedIntentSpec IntentSpec,
+    IReadOnlyList<GateVerdictSummary> PriorGateVerdicts,
+    int AttemptIndex);

--- a/src/Nexo.Spike.S3/Models/RegistryEntry.cs
+++ b/src/Nexo.Spike.S3/Models/RegistryEntry.cs
@@ -11,4 +11,5 @@ public sealed record RegistryEntry(
     string ImplementationSource,
     string IntentSpecPath,
     SignedCertificationRecord Certification,
+    SkillProvenance Provenance,
     DateTimeOffset AdmittedAt);

--- a/src/Nexo.Spike.S3/Models/SealedIntentSpec.cs
+++ b/src/Nexo.Spike.S3/Models/SealedIntentSpec.cs
@@ -1,0 +1,12 @@
+namespace Nexo.Spike.S3.Models;
+
+/// <summary>
+/// Intent specification exposed to generators — acceptance criteria deliberately excluded.
+/// </summary>
+public sealed record SealedIntentSpec(
+    string IntentId,
+    string Title,
+    string Description,
+    IReadOnlyList<string> Inputs,
+    IReadOnlyList<string> Outputs,
+    IReadOnlyList<string> Invariants);

--- a/src/Nexo.Spike.S3/Models/SkillCandidate.cs
+++ b/src/Nexo.Spike.S3/Models/SkillCandidate.cs
@@ -9,4 +9,5 @@ public sealed record SkillCandidate(
     string IntentSpecPath,
     string ImplementationSource,
     string GeneratorBackend,
-    string Hypothesis);
+    string Hypothesis,
+    SkillProvenance? Provenance = null);

--- a/src/Nexo.Spike.S3/Models/SkillProvenance.cs
+++ b/src/Nexo.Spike.S3/Models/SkillProvenance.cs
@@ -1,0 +1,8 @@
+namespace Nexo.Spike.S3.Models;
+
+public sealed record SkillProvenance(
+    string GeneratorBackend,
+    bool IsolationEnforced,
+    string? ModelId,
+    double? Temperature,
+    int AttemptsUsed);

--- a/src/Nexo.Spike.S3/Program.cs
+++ b/src/Nexo.Spike.S3/Program.cs
@@ -1,3 +1,4 @@
+using Nexo.Spike.S3;
 using Nexo.Spike.S3.Models;
 using Nexo.Spike.S3.Certification;
 using Nexo.Spike.S3.Generation;
@@ -5,79 +6,112 @@ using Nexo.Spike.S3.Loop;
 using Nexo.Spike.S3.Registry;
 using Nexo.Spike.S3.Reporting;
 
-var parsed = HarnessCli.Parse(args);
-if (parsed.ShowHelp)
+if (args.Length > 0 && string.Equals(args[0], "live", StringComparison.OrdinalIgnoreCase))
 {
-    Console.WriteLine(HarnessCli.HelpText);
-    return parsed.IsError ? 2 : 0;
+    return await RunLiveAsync(args[1..]).ConfigureAwait(false);
 }
 
-if (parsed.IsError)
+return await RunRecordedLoopAsync(args).ConfigureAwait(false);
+
+static async Task<int> RunRecordedLoopAsync(string[] args)
 {
-    Console.Error.WriteLine(parsed.ErrorMessage);
-    Console.Error.WriteLine(HarnessCli.HelpText);
-    return 2;
+    var parsed = RecordedHarnessCli.Parse(args);
+    if (parsed.ShowHelp)
+    {
+        Console.WriteLine(RecordedHarnessCli.HelpText);
+        return parsed.IsError ? 2 : 0;
+    }
+
+    if (parsed.IsError)
+    {
+        Console.Error.WriteLine(parsed.ErrorMessage);
+        Console.Error.WriteLine(RecordedHarnessCli.HelpText);
+        return 2;
+    }
+
+    var registryRoot = Path.Combine(parsed.ArtifactsRoot, RegistryPaths.RegistryFolderName);
+    if (parsed.ResetRegistry && Directory.Exists(registryRoot))
+        Directory.Delete(registryRoot, recursive: true);
+
+    var registry = new SkillRegistry(registryRoot);
+    var generator = SkillGeneratorFactory.Create();
+    var certification = new SkillCertificationHarness(
+        mutationThresholdPercent: parsed.MutationThreshold,
+        requireMutation: parsed.RequireMutation,
+        densitySeeds: parsed.DensitySeeds,
+        escapeSeeds: parsed.EscapeSeeds);
+    var loop = new SkillReuseLoop(registry, generator, certification);
+
+    var report = await SkillLoopDemonstration.RunAsync(loop, registry, generator.BackendName)
+        .ConfigureAwait(false);
+
+    var reportPath = await SkillLoopReportWriter.WriteAsync(
+        report,
+        Path.Combine(parsed.ArtifactsRoot, "skill-loop-report.json")).ConfigureAwait(false);
+
+    Console.WriteLine($"Wrote skill loop report: {reportPath}");
+    Console.WriteLine($"Generator backend: {report.GeneratorBackend} (recorded — offline)");
+    Console.WriteLine($"Registry root: {registryRoot}");
+    Console.WriteLine($"Generation calls: {loop.GenerationCallCount}");
+    Console.WriteLine($"Certification invocations: {loop.CertificationInvocationCount}");
+
+    var success = report.Calls.Count == 4
+                  && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Generated)
+                  && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Reused && c.Scenario == "reused-same-intent")
+                  && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Reused && c.Scenario == "reused-other-context")
+                  && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Rejected)
+                  && loop.GenerationCallCount == 4
+                  && loop.CertificationInvocationCount == 4;
+
+    return success ? 0 : 1;
 }
 
-var registryRoot = Path.Combine(parsed.ArtifactsRoot, RegistryPaths.RegistryFolderName);
-if (parsed.ResetRegistry && Directory.Exists(registryRoot))
+static async Task<int> RunLiveAsync(string[] args)
 {
-    Directory.Delete(registryRoot, recursive: true);
+    var parsed = LiveHarnessCli.Parse(args);
+    if (parsed.ShowHelp)
+    {
+        Console.WriteLine(LiveHarnessCli.HelpText);
+        return parsed.IsError ? 2 : 0;
+    }
+
+    if (parsed.IsError)
+    {
+        Console.Error.WriteLine(parsed.ErrorMessage);
+        Console.Error.WriteLine(LiveHarnessCli.HelpText);
+        return 2;
+    }
+
+    try
+    {
+        return await LiveGenerateRunner.RunAsync(new LiveGenerateRunner.LiveGenerateOptions(
+            parsed.ArtifactsRoot,
+            parsed.IntentCount,
+            parsed.MaxAttempts,
+            parsed.ResetRegistry,
+            parsed.MutationThreshold,
+            parsed.RequireMutation,
+            parsed.DensitySeeds,
+            parsed.EscapeSeeds)).ConfigureAwait(false);
+    }
+    catch (InvalidOperationException ex)
+    {
+        Console.Error.WriteLine(ex.Message);
+        return 1;
+    }
 }
 
-var registry = new SkillRegistry(registryRoot);
-var generator = new ScriptedStandInSkillGenerator();
-var certification = new SkillCertificationHarness(
-    mutationThresholdPercent: parsed.MutationThreshold,
-    requireMutation: parsed.RequireMutation,
-    densitySeeds: parsed.DensitySeeds,
-    escapeSeeds: parsed.EscapeSeeds);
-var loop = new SkillReuseLoop(registry, generator, certification);
-
-var report = await SkillLoopDemonstration.RunAsync(
-    loop,
-    registry,
-    ScriptedStandInSkillGenerator.BackendLabel).ConfigureAwait(false);
-
-var reportPath = await SkillLoopReportWriter.WriteAsync(
-    report,
-    Path.Combine(parsed.ArtifactsRoot, "skill-loop-report.json")).ConfigureAwait(false);
-
-Console.WriteLine($"Wrote skill loop report: {reportPath}");
-Console.WriteLine($"Generator backend: {report.GeneratorBackend} (StandIn — not a model)");
-Console.WriteLine($"Registry root: {registryRoot}");
-Console.WriteLine($"Registry entries: {string.Join(", ", report.RegistryEntryIds)}");
-Console.WriteLine($"Generation count: {loop.GenerationCount}");
-Console.WriteLine($"Certification invocations: {loop.CertificationInvocationCount}");
-
-foreach (var call in report.Calls)
-{
-    Console.WriteLine(
-        $"  [{call.Scenario}] outcome={call.Outcome} reused={call.Reused} " +
-        $"generationRan={call.GenerationRan} certificationRan={call.CertificationRan} " +
-        $"registry={call.RegistryEntryCountBefore}->{call.RegistryEntryCountAfter}");
-}
-
-var success = report.Calls.Count == 4
-              && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Generated)
-              && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Reused && c.Scenario == "reused-same-intent")
-              && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Reused && c.Scenario == "reused-other-context")
-              && report.Calls.Any(c => c.Outcome == EnsureSkillOutcome.Rejected)
-              && loop.GenerationCount == 2;
-
-return success ? 0 : 1;
-
-internal static class HarnessCli
+internal static class RecordedHarnessCli
 {
     public const string HelpText = """
-        Nexo Spike S3 — skill registry + capability lookup + reuse loop (stand-in generation)
+        Nexo Spike S3 — recorded skill loop (default, offline)
 
         Usage:
           dotnet run --project src/Nexo.Spike.S3 -- [--out path] [--reset-registry]
 
         Options:
           --out path                 Artifacts root (default: artifacts/s3)
-          --reset-registry           Delete registry before run (demo default: on)
+          --reset-registry           Delete registry before run
           --no-reset-registry        Keep existing registry entries
           --mutation-threshold P     Mutation score threshold percent (default: 80)
           --require-mutation         Fail certification if dotnet-stryker unavailable (default: true)
@@ -85,14 +119,99 @@ internal static class HarnessCli
           --density-seeds N          Intent density seeds (default: 4)
           --escape-seeds N           Escape-rate seeds (default: 2)
           --help                     Show help
-
-        Stand-in generation only — offline, deterministic, labeled scripted-standin.
         """;
 
-    public static ParsedArgs Parse(string[] args)
+    public static CommonHarnessCli.ParsedArgs Parse(string[] args) => CommonHarnessCli.Parse(args, resetRegistryDefault: true);
+}
+
+internal static class LiveHarnessCli
+{
+    public const string HelpText = """
+        Nexo Spike S3 — live Claude generation (LOCAL ONLY)
+
+        Usage:
+          NEXO_S3_GENERATOR=claude ANTHROPIC_API_KEY=... \
+            dotnet run --project src/Nexo.Spike.S3 -- live [--out path]
+
+        Options:
+          --out path                 Artifacts root (default: artifacts/s3)
+          --intents N                Intents to generate (default: 1, max catalog size)
+          --max-attempts N           Attempt cap per intent (default: 3)
+          --reset-registry           Delete registry before run (default)
+          --no-reset-registry        Keep registry entries
+          --mutation-threshold P     Mutation threshold percent (default: 80)
+          --no-require-mutation      Skip mutation when stryker missing
+          --density-seeds N          Intent density seeds (default: 4)
+          --escape-seeds N           Escape-rate seeds (default: 2)
+          --help                     Show help
+
+        Never run in CI/cloud. Transcripts land in artifacts/s3/generate-live/.
+        """;
+
+    public static LiveParsedArgs Parse(string[] args)
+    {
+        var common = CommonHarnessCli.Parse(args, resetRegistryDefault: true);
+        var intents = 1;
+        var maxAttempts = 3;
+
+        if (common.IsError)
+            return LiveParsedArgs.FromError(common.ErrorMessage!);
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--intents":
+                    if (!CommonHarnessCli.TryReadInt(args, ref i, out intents) || intents <= 0)
+                        return LiveParsedArgs.Error("Invalid --intents value");
+                    break;
+                case "--max-attempts":
+                    if (!CommonHarnessCli.TryReadInt(args, ref i, out maxAttempts) || maxAttempts <= 0)
+                        return LiveParsedArgs.Error("Invalid --max-attempts value");
+                    break;
+            }
+        }
+
+        return new LiveParsedArgs(
+            false,
+            common.ShowHelp,
+            common.ArtifactsRoot,
+            intents,
+            maxAttempts,
+            common.ResetRegistry,
+            common.MutationThreshold,
+            common.RequireMutation,
+            common.DensitySeeds,
+            common.EscapeSeeds,
+            null);
+    }
+
+    internal sealed record LiveParsedArgs(
+        bool IsError,
+        bool ShowHelp,
+        string ArtifactsRoot,
+        int IntentCount,
+        int MaxAttempts,
+        bool ResetRegistry,
+        double MutationThreshold,
+        bool RequireMutation,
+        int DensitySeeds,
+        int EscapeSeeds,
+        string? ErrorMessage)
+    {
+        public static LiveParsedArgs Error(string message) =>
+            new(true, false, string.Empty, 1, 3, true, 80, true, 4, 2, message);
+
+        public static LiveParsedArgs FromError(string message) => Error(message);
+    }
+}
+
+internal static class CommonHarnessCli
+{
+    public static ParsedArgs Parse(string[] args, bool resetRegistryDefault)
     {
         var artifactsRoot = Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "s3");
-        var resetRegistry = true;
+        var resetRegistry = resetRegistryDefault;
         var mutationThreshold = 80.0;
         var requireMutation = true;
         var densitySeeds = 4;
@@ -136,14 +255,16 @@ internal static class HarnessCli
                         return ParsedArgs.Error("Invalid --escape-seeds value");
                     break;
                 default:
-                    return ParsedArgs.Error($"Unknown argument: {args[i]}");
+                    if (args[i].StartsWith("--", StringComparison.Ordinal))
+                        return ParsedArgs.Error($"Unknown argument: {args[i]}");
+                    break;
             }
         }
 
         return new ParsedArgs(false, showHelp, artifactsRoot, resetRegistry, mutationThreshold, requireMutation, densitySeeds, escapeSeeds, null);
     }
 
-    private static bool TryReadInt(string[] args, ref int index, out int value)
+    public static bool TryReadInt(string[] args, ref int index, out int value)
     {
         value = 0;
         if (index + 1 >= args.Length || !int.TryParse(args[index + 1], out value))

--- a/src/Nexo.Spike.S3/README.md
+++ b/src/Nexo.Spike.S3/README.md
@@ -1,30 +1,33 @@
 # S3 — Skill registry + reuse loop
 
-Offline skill registry that admits only promotion-contract-certified bricks, looks up
-existing capabilities before regenerating, and reuses stored skills without
-re-certification.
+Offline skill registry with deterministic lookup and sealed generation seam.
 
-## Components
+## Backends
 
-| Piece | Role |
-| --- | --- |
-| `SkillRegistry` | File-backed catalog under `artifacts/s3/registry/` |
-| `IntentMatcher` | Deterministic lookup (see `docs/spike/s3-intent-matching.md`) |
-| `ScriptedStandInSkillGenerator` | Stand-in generation (`scripted-standin`, not a model) |
-| `SkillCertificationHarness` | Reuses S0→S2 gates + S1 density/escape envelope |
-| `SkillReuseLoop` | `EnsureSkill` → lookup → generate → certify → admit |
+| Backend | Env gate | Isolation enforced | Where |
+| --- | --- | --- | --- |
+| `recorded` (default) | _(unset)_ | `false` | CI / cloud |
+| `claude` | `NEXO_S3_GENERATOR=claude` | `true` | **Local only** |
 
-## Run (headless, offline)
+## Recorded loop (CI/cloud)
 
 ```bash
-dotnet run --project src/Nexo.Spike.S3 -- --out artifacts/s3 --reset-registry
+make s3-loop-recorded
+# or: dotnet test src/Nexo.Tests.Spike.S3
 ```
 
-Writes `artifacts/s3/skill-loop-report.json` with four scripted outcomes:
-generated+admitted, reused (gen skipped), reused-other-context, rejected.
-
-## Tests
+## Live Claude generation (local, keyed)
 
 ```bash
-dotnet test src/Nexo.Tests.Spike.S3
+export ANTHROPIC_API_KEY=...
+export NEXO_S3_MODEL=claude-sonnet-4-20250514   # optional
+make s3-generate-live
 ```
+
+Transcripts: `artifacts/s3/generate-live/`. API key is read at call time only — never persisted.
+
+## Sealed generation seam
+
+`ISkillGenerator`: `Describe()` → sealed `request.json` (intent only) → `Ingest()` → candidate.
+
+Prompt isolation: `docs/spike/s3-intent-matching.md` + `RequestIsolationGuard`.

--- a/src/Nexo.Spike.S3/Registry/SkillRegistry.cs
+++ b/src/Nexo.Spike.S3/Registry/SkillRegistry.cs
@@ -63,6 +63,8 @@ public sealed class SkillRegistry
             candidate.ImplementationSource,
             candidate.IntentSpecPath,
             certification,
+            candidate.Provenance
+            ?? new SkillProvenance(candidate.GeneratorBackend, false, null, null, 1),
             DateTimeOffset.UtcNow);
 
         WriteEntry(entry);

--- a/src/Nexo.Spike.S3/Reporting/SkillLoopReport.cs
+++ b/src/Nexo.Spike.S3/Reporting/SkillLoopReport.cs
@@ -13,7 +13,11 @@ public sealed record SkillLoopCallRecord(
     string? EntryId,
     string? RejectionReason,
     int RegistryEntryCountBefore,
-    int RegistryEntryCountAfter);
+    int RegistryEntryCountAfter,
+    bool? IsolationEnforced = null,
+    string? ModelId = null,
+    int? AttemptsUsed = null,
+    double? Temperature = null);
 
 public sealed record SkillLoopReport(
     string Version,

--- a/src/Nexo.Spike.S3/Reporting/SkillLoopReportWriter.cs
+++ b/src/Nexo.Spike.S3/Reporting/SkillLoopReportWriter.cs
@@ -83,11 +83,19 @@ public static class SkillLoopDemonstration
                 result.Entry?.EntryId,
                 result.RejectionReason,
                 before,
-                after));
+                after,
+                result.IsolationEnforced,
+                result.ModelId,
+                result.AttemptsUsed,
+                result.Entry?.Provenance.Temperature));
         }
 
+        var version = string.Equals(generatorBackend, SkillGeneratorFactory.ClaudeMode, StringComparison.OrdinalIgnoreCase)
+            ? "s3.2-claude-v1"
+            : "s3.1-recorded-v1";
+
         return new SkillLoopReport(
-            Version: "s3.0-v1",
+            Version: version,
             GeneratorBackend: generatorBackend,
             RunAt: DateTimeOffset.UtcNow,
             Calls: calls,

--- a/src/Nexo.Tests.Spike.S3/ClaudeGeneratorTests.cs
+++ b/src/Nexo.Tests.Spike.S3/ClaudeGeneratorTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Nexo.Spike.S0.Models;
+using Nexo.Spike.S3.Certification;
+using Nexo.Spike.S3.Generation;
+using Nexo.Spike.S3.Generation.Claude;
+using Nexo.Spike.S3.Loop;
+using Nexo.Spike.S3.Models;
+using Nexo.Spike.S3.Registry;
+using Xunit;
+
+namespace Nexo.Tests.Spike.S3;
+
+public sealed class ClaudeGeneratorTests
+{
+    [Fact]
+    public async Task Claude_generator_sets_isolation_enforced_provenance()
+    {
+        var workRoot = CreateTempWorkRoot();
+        try
+        {
+            var transport = new RequestIsolationTests.FakeS3LlmTransport();
+            var generator = new ClaudeSkillGenerator(
+                transport,
+                () => new ClaudeRuntimeConfig { ApiKey = "test-key", Model = "claude-test-model", Temperature = 0 },
+                workRoot);
+
+            var intent = new IntentDescriptor("csv-column-type-inference", ["live"], CapabilityKey: "csv-type-inference");
+            var handoff = generator.Describe(intent);
+            var candidate = await generator.IngestAsync(handoff);
+
+            candidate.Provenance.Should().NotBeNull();
+            candidate.Provenance!.IsolationEnforced.Should().BeTrue();
+            candidate.Provenance.GeneratorBackend.Should().Be("claude");
+            candidate.Provenance.ModelId.Should().Be("claude-test-model");
+            transport.CallCount.Should().Be(1);
+        }
+        finally
+        {
+            TryDelete(workRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Claude_loop_reuse_skips_second_transport_call()
+    {
+        var root = CreateTempRegistryRoot();
+        var workRoot = CreateTempWorkRoot();
+        try
+        {
+            var transport = new RequestIsolationTests.FakeS3LlmTransport();
+            var generator = new ClaudeSkillGenerator(
+                transport,
+                () => new ClaudeRuntimeConfig { ApiKey = "test-key", Model = "claude-test-model", Temperature = 0 },
+                workRoot);
+            var registry = new SkillRegistry(root);
+            var certification = new TrackingCertificationHarness();
+            var loop = new SkillReuseLoop(registry, generator, certification);
+
+            var intent = new IntentDescriptor("csv-column-type-inference", ["live"], CapabilityKey: "csv-type-inference");
+            var first = await loop.EnsureSkillAsync(intent);
+            var second = await loop.EnsureSkillAsync(intent);
+
+            first.Outcome.Should().Be(EnsureSkillOutcome.Generated);
+            first.IsolationEnforced.Should().BeTrue();
+            second.Outcome.Should().Be(EnsureSkillOutcome.Reused);
+            second.GenerationRan.Should().BeFalse();
+            transport.CallCount.Should().Be(1);
+            loop.GenerationCallCount.Should().Be(1);
+        }
+        finally
+        {
+            TryDelete(root);
+            TryDelete(workRoot);
+        }
+    }
+
+    [Fact]
+    public void Transcript_redacts_api_key()
+    {
+        const string key = "sk-ant-test-redaction-key";
+        var redacted = ClaudeRuntimeConfig.RedactSecrets($"Bearer {key}", new ClaudeRuntimeConfig { ApiKey = key });
+        redacted.Should().NotContain(key);
+        redacted.Should().Contain("[REDACTED_API_KEY]");
+    }
+
+    private static string CreateTempRegistryRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nexo-s3-registry-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string CreateTempWorkRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nexo-s3-work-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private sealed class TrackingCertificationHarness : ISkillCertificationHarness
+    {
+        public Task<CertificationResult> CertifyAsync(SkillCandidate candidate, CancellationToken ct = default)
+        {
+            var unsigned = new SignedCertificationRecord(
+                Guid.NewGuid().ToString("N"),
+                RedFailureReason.AssertionFailure,
+                85,
+                80,
+                false,
+                1.0,
+                0,
+                true,
+                "s1.4-v1",
+                "s1.4-v1",
+                DateTimeOffset.UtcNow,
+                string.Empty);
+
+            return Task.FromResult(new CertificationResult(true, CertificationRecordSigner.WithSignature(unsigned), null));
+        }
+    }
+}

--- a/src/Nexo.Tests.Spike.S3/IntentMatcherTests.cs
+++ b/src/Nexo.Tests.Spike.S3/IntentMatcherTests.cs
@@ -19,15 +19,17 @@ public sealed class IntentMatcherTests
     }
 
     [Fact]
-    public void Scripted_stand_in_generator_is_labeled_scripted_standin()
+    public async Task Recorded_generator_is_labeled_recorded_and_not_isolation_enforced()
     {
-        var generator = new ScriptedStandInSkillGenerator();
-        ScriptedStandInSkillGenerator.BackendLabel.Should().Be("scripted-standin");
+        var generator = new RecordedSkillGenerator();
+        generator.BackendName.Should().Be("recorded");
+        generator.IsolationEnforced.Should().BeFalse();
 
-        var candidate = generator.Generate(
+        var handoff = generator.Describe(
             new IntentDescriptor("csv-column-type-inference", ["core"], CapabilityKey: "csv-type-inference"));
+        var candidate = await generator.IngestAsync(handoff);
 
-        candidate.GeneratorBackend.Should().Be("scripted-standin");
+        candidate.GeneratorBackend.Should().Be("recorded");
         candidate.Hypothesis.Should().StartWith("StandIn:");
     }
 }

--- a/src/Nexo.Tests.Spike.S3/RequestIsolationTests.cs
+++ b/src/Nexo.Tests.Spike.S3/RequestIsolationTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Nexo.Spike.S3.Generation;
+using Nexo.Spike.S3.Generation.Claude;
+using Nexo.Spike.S3.Models;
+using Xunit;
+
+namespace Nexo.Tests.Spike.S3;
+
+public sealed class RequestIsolationTests
+{
+    [Fact]
+    public void Sealed_request_json_contains_no_oracle_test_property_or_acceptance_content()
+    {
+        var intent = new IntentDescriptor("csv-column-type-inference", ["core"], CapabilityKey: "csv-type-inference");
+        var generator = new RecordedSkillGenerator();
+        var handoff = generator.Describe(intent);
+
+        var requestJson = File.ReadAllText(handoff.RequestPath);
+        RequestIsolationGuard.AssertIsolated(requestJson, "sealed request.json");
+        requestJson.Should().NotContain("acceptanceCriteria");
+        requestJson.Should().NotContain("FluentAssertions");
+        requestJson.Should().NotContain("reference-oracle");
+    }
+
+    [Fact]
+    public async Task Assembled_Claude_prompt_contains_no_oracle_test_property_or_acceptance_content()
+    {
+        var intent = new IntentDescriptor("csv-column-type-inference", ["live"], CapabilityKey: "csv-type-inference");
+        var (request, _) = await GenerationRequestSealer.BuildAsync(intent, [], 0);
+        var prompt = SkillGeneratorPromptAssembler.Assemble(request);
+
+        RequestIsolationGuard.AssertIsolated(prompt.SystemPrompt, "assembled system prompt");
+        RequestIsolationGuard.AssertIsolated(prompt.UserPrompt, "assembled user prompt");
+
+        prompt.UserPrompt.Should().NotContain("acceptanceCriteria");
+        prompt.UserPrompt.Should().NotContain("ColumnTypeInferrerRedTests");
+        prompt.UserPrompt.Should().NotContain("MetamorphicPropertyTests");
+        prompt.UserPrompt.Should().NotContain("held-out");
+    }
+
+    [Fact]
+    public void Claude_Describe_persists_isolated_prompt_artifacts()
+    {
+        var generator = new ClaudeSkillGenerator(new FakeS3LlmTransport(), workRoot: CreateTempWorkRoot());
+        var intent = new IntentDescriptor("csv-column-type-inference", ["live"], CapabilityKey: "csv-type-inference");
+        var handoff = generator.Describe(intent);
+
+        handoff.IsolationEnforced.Should().BeTrue();
+        File.Exists(Path.Combine(handoff.WorkDirectory, "assembled-system-prompt.txt")).Should().BeTrue();
+        File.Exists(Path.Combine(handoff.WorkDirectory, "assembled-user-prompt.txt")).Should().BeTrue();
+
+        var system = File.ReadAllText(Path.Combine(handoff.WorkDirectory, "assembled-system-prompt.txt"));
+        var user = File.ReadAllText(Path.Combine(handoff.WorkDirectory, "assembled-user-prompt.txt"));
+        RequestIsolationGuard.AssertIsolated(system + user, "claude persisted prompts");
+    }
+
+    private static string CreateTempWorkRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nexo-s3-isolation-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    internal sealed class FakeS3LlmTransport : IS3LlmTransport
+    {
+        public int CallCount { get; private set; }
+
+        public Task<string> CompleteAsync(S3LlmCompletionRequest request, CancellationToken ct = default)
+        {
+            CallCount++;
+            RequestIsolationGuard.AssertIsolated(request.SystemPrompt + request.UserPrompt, "fake transport prompt");
+            return Task.FromResult(
+                """
+                ```csharp
+                namespace CsvColumnInferrer;
+                public enum ColumnType { String, Integer, Decimal, Boolean, Date }
+                public static class ColumnTypeInferrer
+                {
+                    public static ColumnType InferType(IReadOnlyList<string> values) => ColumnType.String;
+                }
+                ```
+                """);
+        }
+    }
+}

--- a/src/Nexo.Tests.Spike.S3/SkillGeneratorFactoryTests.cs
+++ b/src/Nexo.Tests.Spike.S3/SkillGeneratorFactoryTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Nexo.Spike.S3.Generation;
+using Xunit;
+
+namespace Nexo.Tests.Spike.S3;
+
+public sealed class SkillGeneratorFactoryTests
+{
+    [Fact]
+    public void ResolveMode_defaults_to_recorded_when_env_unset()
+    {
+        using var scope = EnvScope.Unset("NEXO_S3_GENERATOR");
+        SkillGeneratorFactory.ResolveMode().Should().Be(SkillGeneratorFactory.RecordedMode);
+    }
+
+    [Fact]
+    public void Create_without_claude_gate_returns_recorded_generator()
+    {
+        using var scope = EnvScope.Unset("NEXO_S3_GENERATOR", "ANTHROPIC_API_KEY");
+        var generator = SkillGeneratorFactory.Create();
+        generator.BackendName.Should().Be(RecordedSkillGenerator.BackendLabel);
+        generator.IsolationEnforced.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnsureLiveModeConfigured_fails_fast_without_key_when_claude_gate_set()
+    {
+        using var scope = EnvScope.Set(
+            ("NEXO_S3_GENERATOR", "claude"),
+            ("ANTHROPIC_API_KEY", null));
+
+        var act = () => SkillGeneratorFactory.EnsureLiveModeConfigured();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ANTHROPIC_API_KEY*")
+            .Which.Message.Should().NotContain("sk-");
+    }
+
+    [Fact]
+    public void EnsureLiveModeConfigured_does_not_require_key_for_recorded_backend()
+    {
+        using var scope = EnvScope.Unset("NEXO_S3_GENERATOR", "ANTHROPIC_API_KEY");
+        var act = () => SkillGeneratorFactory.EnsureLiveModeConfigured();
+        act.Should().NotThrow();
+    }
+
+    internal sealed class EnvScope : IDisposable
+    {
+        private readonly Dictionary<string, string?> _original = new(StringComparer.Ordinal);
+
+        private EnvScope()
+        {
+        }
+
+        public static EnvScope Unset(params string[] keys) => Set(keys.Select(k => (k, (string?)null)).ToArray());
+
+        public static EnvScope Set(params (string Key, string? Value)[] entries)
+        {
+            var scope = new EnvScope();
+            foreach (var (key, value) in entries)
+            {
+                scope._original[key] = Environment.GetEnvironmentVariable(key);
+                Environment.SetEnvironmentVariable(key, value);
+            }
+
+            return scope;
+        }
+
+        public void Dispose()
+        {
+            foreach (var (key, value) in _original)
+                Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/src/Nexo.Tests.Spike.S3/SkillLookupReuseTests.cs
+++ b/src/Nexo.Tests.Spike.S3/SkillLookupReuseTests.cs
@@ -18,7 +18,7 @@ public sealed class SkillLookupReuseTests
         try
         {
             var registry = new SkillRegistry(root);
-            var generator = new TrackingStandInGenerator();
+            var generator = new TrackingSkillGenerator();
             var certification = new TrackingCertificationHarness();
             var loop = new SkillReuseLoop(registry, generator, certification);
 
@@ -31,11 +31,9 @@ public sealed class SkillLookupReuseTests
             result.Reused.Should().BeTrue();
             result.GenerationRan.Should().BeFalse();
             result.CertificationRan.Should().BeFalse();
-            result.Entry.Should().NotBeNull();
-            result.Entry!.EntryId.Should().Be("csv-type-inference");
-            generator.GenerationCount.Should().Be(0);
+            generator.GenerationCallCount.Should().Be(0);
             certification.InvocationCount.Should().Be(0);
-            loop.GenerationCount.Should().Be(0);
+            loop.GenerationCallCount.Should().Be(0);
             loop.CertificationInvocationCount.Should().Be(0);
         }
         finally
@@ -51,7 +49,7 @@ public sealed class SkillLookupReuseTests
         try
         {
             var registry = new SkillRegistry(root);
-            var generator = new TrackingStandInGenerator();
+            var generator = new TrackingSkillGenerator();
             var certification = new TrackingCertificationHarness();
             var loop = new SkillReuseLoop(registry, generator, certification);
 
@@ -62,10 +60,8 @@ public sealed class SkillLookupReuseTests
 
             first.Outcome.Should().Be(EnsureSkillOutcome.Generated);
             second.Outcome.Should().Be(EnsureSkillOutcome.Reused);
-            loop.GenerationCount.Should().Be(1);
+            loop.GenerationCallCount.Should().Be(1);
             loop.CertificationInvocationCount.Should().Be(1);
-            generator.GenerationCount.Should().Be(1);
-            certification.InvocationCount.Should().Be(1);
             registry.ListEntries().Should().HaveCount(1);
         }
         finally
@@ -81,9 +77,13 @@ public sealed class SkillLookupReuseTests
         try
         {
             var registry = new SkillRegistry(root);
-            var generator = new TrackingStandInGenerator();
+            var generator = new TrackingSkillGenerator();
             var certification = new TrackingCertificationHarness(alwaysPass: false);
-            var loop = new SkillReuseLoop(registry, generator, certification);
+            var loop = new SkillReuseLoop(
+                registry,
+                generator,
+                certification,
+                new SkillReuseLoopOptions { MaxAttemptsPerIntent = 1 });
 
             var intent = new IntentDescriptor("csv-constant-type-guess", ["constant-guess"], CapabilityKey: "csv-constant-guess");
             var result = await loop.EnsureSkillAsync(intent);
@@ -99,6 +99,35 @@ public sealed class SkillLookupReuseTests
         }
     }
 
+    [Fact]
+    public async Task Attempt_cap_stops_retrying_after_max_attempts()
+    {
+        var root = CreateTempRegistryRoot();
+        try
+        {
+            var registry = new SkillRegistry(root);
+            var generator = new TrackingSkillGenerator();
+            var certification = new TrackingCertificationHarness(alwaysPass: false);
+            var loop = new SkillReuseLoop(
+                registry,
+                generator,
+                certification,
+                new SkillReuseLoopOptions { MaxAttemptsPerIntent = 3 });
+
+            var intent = new IntentDescriptor("csv-column-type-inference", ["core"], CapabilityKey: "csv-type-inference");
+            var result = await loop.EnsureSkillAsync(intent);
+
+            result.Outcome.Should().Be(EnsureSkillOutcome.Rejected);
+            result.AttemptsUsed.Should().Be(3);
+            loop.GenerationCallCount.Should().Be(3);
+            loop.CertificationInvocationCount.Should().Be(3);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     private static void SeedAdmittedEntry(SkillRegistry registry, IntentDescriptor intent)
     {
         var candidate = new SkillCandidate(
@@ -106,8 +135,9 @@ public sealed class SkillLookupReuseTests
             intent,
             "/tmp/intent.json",
             "namespace CsvColumnInferrer; public static class ColumnTypeInferrer {}",
-            ScriptedStandInSkillGenerator.BackendLabel,
-            "seed");
+            RecordedSkillGenerator.BackendLabel,
+            "seed",
+            new SkillProvenance(RecordedSkillGenerator.BackendLabel, false, null, null, 1));
 
         var unsigned = new SignedCertificationRecord(
             "seed-record",
@@ -147,24 +177,38 @@ public sealed class SkillLookupReuseTests
         }
     }
 
-    private sealed class TrackingStandInGenerator : IStandInSkillGenerator
+    private sealed class TrackingSkillGenerator : ISkillGenerator
     {
         private int _count;
 
-        public string BackendName => ScriptedStandInSkillGenerator.BackendLabel;
+        public string BackendName => RecordedSkillGenerator.BackendLabel;
 
-        public int GenerationCount => _count;
+        public bool IsolationEnforced => false;
 
-        public SkillCandidate Generate(IntentDescriptor intent)
+        public int GenerationCallCount => _count;
+
+        public GenerationHandoff Describe(
+            IntentDescriptor intent,
+            IReadOnlyList<GateVerdictSummary>? priorVerdicts = null,
+            int attemptIndex = 0,
+            string? workRoot = null)
+        {
+            var root = workRoot ?? Path.Combine(Path.GetTempPath(), $"nexo-s3-track-{Guid.NewGuid():N}");
+            var handoff = new RecordedSkillGenerator().Describe(intent, priorVerdicts, attemptIndex, root);
+            return handoff;
+        }
+
+        public Task<SkillCandidate> IngestAsync(GenerationHandoff handoff, CancellationToken ct = default)
         {
             _count++;
-            return new SkillCandidate(
+            return Task.FromResult(new SkillCandidate(
                 "tracking-candidate",
-                intent,
+                handoff.Request.Intent,
                 "/tmp/intent.json",
                 "namespace CsvColumnInferrer; public static class ColumnTypeInferrer {}",
                 BackendName,
-                "tracking");
+                "tracking",
+                new SkillProvenance(BackendName, false, null, null, handoff.Request.AttemptIndex + 1)));
         }
     }
 
@@ -181,9 +225,7 @@ public sealed class SkillLookupReuseTests
         {
             _count++;
             if (!_alwaysPass)
-            {
                 return Task.FromResult(new CertificationResult(false, null, "forced certification failure"));
-            }
 
             var unsigned = new SignedCertificationRecord(
                 Guid.NewGuid().ToString("N"),

--- a/src/Nexo.Tests.Spike.S3/SkillRegistryAdmissionTests.cs
+++ b/src/Nexo.Tests.Spike.S3/SkillRegistryAdmissionTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Nexo.Spike.S0.Models;
+using Nexo.Spike.S3.Generation;
 using Nexo.Spike.S3.Models;
 using Nexo.Spike.S3.Registry;
 using Xunit;
@@ -65,13 +66,14 @@ public sealed class SkillRegistryAdmissionTests
         try
         {
             var registry = new SkillRegistry(root);
-            var candidate = BuildCandidate();
-            var record = BuildValidRecord();
+        var candidate = BuildCandidate();
+        var record = BuildValidRecord();
 
-            var result = registry.Admit(candidate, record);
+        var result = registry.Admit(candidate, record);
 
-            result.Status.Should().Be(AdmissionStatus.Admitted);
-            result.Entry.Should().NotBeNull();
+        result.Status.Should().Be(AdmissionStatus.Admitted);
+        result.Entry.Should().NotBeNull();
+        result.Entry!.Provenance.GeneratorBackend.Should().Be(RecordedSkillGenerator.BackendLabel);
             registry.ListEntries().Should().HaveCount(1);
             File.Exists(RegistryPaths.EntryFilePath(root, "csv-type-inference")).Should().BeTrue();
             File.Exists(RegistryPaths.ImplementationFilePath(root, "csv-type-inference")).Should().BeTrue();
@@ -89,7 +91,8 @@ public sealed class SkillRegistryAdmissionTests
             "/tmp/intent.json",
             "public static class Impl {}",
             "test",
-            "test hypothesis");
+            "test hypothesis",
+            new SkillProvenance(RecordedSkillGenerator.BackendLabel, false, null, null, 1));
 
     private static SignedCertificationRecord BuildValidRecord()
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **S3.1 sealed generation seam** and **S3.2 live Claude generator** behind `ISkillGenerator`. The recorded backend remains the CI/cloud default; live Claude is opt-in via `NEXO_S3_GENERATOR=claude` + `ANTHROPIC_API_KEY` (local only).

## S3.1 — Sealed generation seam

- `ISkillGenerator`: `Describe()` → sealed `request.json` (intent only, no acceptance) → `Ingest()` → `SkillCandidate`
- `RecordedSkillGenerator` default backend (`recorded`, `isolationEnforced=false`)
- `SkillReuseLoop` with attempt cap (default ≤3) and sanitized `GateVerdictSummary` on retry
- `SkillProvenance` on candidates and registry entries

## S3.2 — Live Claude (local, keyed)

- `ClaudeSkillGenerator` + `AnthropicMessagesTransport` (key read at call time only — never logged/persisted)
- `SkillGeneratorPromptAssembler` builds prompts solely from sealed request
- **`isolationEnforced=true`** on Claude-admitted skills
- `make s3-generate-live` — cost-capped, transcripts in `artifacts/s3/generate-live/` (no key)
- Report version `s3.2-claude-v1` from local live run (see below)

## Prompt isolation (tested)

`RequestIsolationTests` assert **both** `request.json` **and** assembled Anthropic prompts contain no oracle, test, property, or acceptance content.

## CI / cloud (recorded backend)

```bash
make test-spike-s3          # 23 passed
make s3-loop-recorded       # artifacts/s3/skill-loop-report.json (s3.1-recorded-v1)
```

- `NEXO_S3_GENERATOR` unset → no live Claude path invoked
- S0/S1/S2 tests green (11 + 93 + 21)

## Local Claude run (by reviewer)

```bash
export ANTHROPIC_API_KEY=...
make s3-generate-live
```

Expected: `s3.2-claude-v1` report, admitted or honestly rejected per intent, reuse skips second Anthropic call, no key in artifacts.

See `docs/spike/s3-claude-live-run.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07655182-33bf-4442-81be-b82e125444b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07655182-33bf-4442-81be-b82e125444b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

