### PR TITLE
fix(s3): unblock make s3-generate-live CLI parsing

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-  "install": "bash scripts/cursor-agent-setup-s2.sh"
+  "install": "bash scripts/cursor-agent-setup-s3.sh"
 }

--- a/scripts/cursor-agent-setup-s3.sh
+++ b/scripts/cursor-agent-setup-s3.sh
@@ -12,8 +12,9 @@ fi
 
 export PATH="$HOME/.dotnet/tools:$PATH"
 export DOTNET_ROOT="${DOTNET_ROOT:-$HOME/.dotnet}"
+# Keep NEXO_S3_GENERATOR unset so install runs recorded backend (CI-safe).
+# Do not unset ANTHROPIC_API_KEY — it may be injected as a Runtime Secret for live runs.
 unset NEXO_S3_GENERATOR
-unset ANTHROPIC_API_KEY
 unset OPENAI_API_KEY
 unset NEXO_LLM_API_KEY
 

--- a/scripts/cursor-agent-setup-s3.sh
+++ b/scripts/cursor-agent-setup-s3.sh
@@ -6,7 +6,7 @@ cd "$ROOT"
 
 if ! command -v dotnet >/dev/null 2>&1; then
   wget -q https://dot.net/v1/dotnet-install.sh -O /tmp/dotnet-install.sh
-  bash /tmp/dotnet-install.sh --channel 8.0 --install-dir "$HOME/.dotnet"
+  bash /tmp/dotnet-install.sh --version 9.0.100 --install-dir "$HOME/.dotnet"
   export PATH="$HOME/.dotnet:$PATH"
 fi
 

--- a/src/Nexo.Spike.S3/Program.cs
+++ b/src/Nexo.Spike.S3/Program.cs
@@ -150,12 +150,9 @@ internal static class LiveHarnessCli
 
     public static LiveParsedArgs Parse(string[] args)
     {
-        var common = CommonHarnessCli.Parse(args, resetRegistryDefault: true);
         var intents = 1;
         var maxAttempts = 3;
-
-        if (common.IsError)
-            return LiveParsedArgs.FromError(common.ErrorMessage!);
+        var commonArgs = new List<string>();
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -169,8 +166,15 @@ internal static class LiveHarnessCli
                     if (!CommonHarnessCli.TryReadInt(args, ref i, out maxAttempts) || maxAttempts <= 0)
                         return LiveParsedArgs.Error("Invalid --max-attempts value");
                     break;
+                default:
+                    commonArgs.Add(args[i]);
+                    break;
             }
         }
+
+        var common = CommonHarnessCli.Parse(commonArgs.ToArray(), resetRegistryDefault: true);
+        if (common.IsError)
+            return LiveParsedArgs.FromError(common.ErrorMessage!);
 
         return new LiveParsedArgs(
             false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`make s3-generate-live` failed before reaching Claude because `CommonHarnessCli.Parse` rejected live-only flags (`--intents`, `--max-attempts`) before `LiveHarnessCli` could read them.

This change strips live-specific flags first, then passes the remaining args to the shared harness parser.

## Verification

- `dotnet test src/Nexo.Tests.Spike.S3/Nexo.Tests.Spike.S3.csproj -c Release` — 23/23 passed
- `make s3-generate-live` now reaches the Anthropic API call (verified with a dummy key → HTTP 401 as expected)
- Live run still requires a real `ANTHROPIC_API_KEY` (not available in this cloud agent session)

## Live run status

Full s3.2 report generation was **not** completed in cloud because `ANTHROPIC_API_KEY` is not configured as a Background Composer secret. To finish locally:

```bash
export ANTHROPIC_API_KEY=...
make s3-generate-live
```

Expected report: `artifacts/s3/skill-loop-report.json` with `"version": "s3.2-claude-v1"`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-719e021e-bc6f-4b08-bd4c-4b2837bc0fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719e021e-bc6f-4b08-bd4c-4b2837bc0fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

