### PR TITLE
spike: atomic brick portability probe (ErrorSummaryExtractor)

### DIFF
--- a/scripts/verify-external-product-shape.sh
+++ b/scripts/verify-external-product-shape.sh
@@ -15,6 +15,14 @@ WAIT_SECS="${NEXO_EXTERNAL_PRODUCT_VERIFY_WAIT_SECS:-120}"
 SOURCE_KEY="${NEXO_VERIFY_SOURCE_KEY:-nexo-local}"
 ISOL_CLEANUP=""
 USE_PUBLISHED_FEED=0
+PROBE_BRICK_SOURCE="${NEXO_EXTERNAL_PRODUCT_PROBE_BRICK_SOURCE:-}"
+if [[ -n "${NEXO_EXTERNAL_PRODUCT_PROBE_BRICK:-}" && -z "${PROBE_BRICK_SOURCE}" ]]; then
+  PROBE_BRICK_SOURCE="${ROOT}/spikes/portability/generated/ErrorSummaryExtractorBrick"
+fi
+USE_PROBE_BRICK=0
+if [[ -n "${PROBE_BRICK_SOURCE}" ]]; then
+  USE_PROBE_BRICK=1
+fi
 
 if [[ -n "${NEXO_EXTERNAL_PRODUCT_PACKAGE_FEED:-}" ]]; then
   USE_PUBLISHED_FEED=1
@@ -47,11 +55,13 @@ pack src/Nexo.Sdk/Nexo.Sdk.csproj
 pack src/Nexo.Client/Nexo.Client.csproj
 
 # CLI + dependencies for `nexo new brick` (same extras as verify-standalone-brick-authoring.sh).
+if [[ "${USE_PROBE_BRICK}" -eq 0 ]]; then
 pack src/Nexo.Adapters.Models/Nexo.Adapters.Models.csproj
 pack src/Nexo.Bricks.Owasp/Nexo.Bricks.Owasp.csproj
 pack src/Nexo.BackgroundAgents.HostRunners/Nexo.BackgroundAgents.HostRunners.csproj
 pack src/Nexo.Policies.Dev/Nexo.Policies.Dev.csproj
 pack application/src/Nexo.CLI/Nexo.CLI.csproj
+fi
 fi
 
 if [[ -z "${NEXO_EXTERNAL_PRODUCT_VERIFY_NO_ISOLATED_CACHE:-}" ]]; then
@@ -93,16 +103,52 @@ else
 EOF
 fi
 
+if [[ "${USE_PROBE_BRICK}" -eq 0 ]]; then
 dotnet tool install \
   --tool-path "${TOOL_PATH}" \
   Nexo.CLI \
   --version "${VERSION}" \
   --add-source "${FEED}" \
   --ignore-failed-sources
+fi
 
 BRICK_OUT="${CONSUMER_ROOT}/brick"
 mkdir -p "${BRICK_OUT}"
 
+BRICK_ID="intensity"
+BRICK_CLASS="IntensityBrick"
+BRICK_NAMESPACE="IntensityBrick"
+BRICK_PROJECT_NAME="IntensityBrick"
+BRICK_PROJECT_DIR="${BRICK_OUT}/IntensityBrick"
+
+if [[ "${USE_PROBE_BRICK}" -eq 1 ]]; then
+  BRICK_ID="error-summary-extractor"
+  BRICK_CLASS="ErrorSummaryExtractorBrick"
+  BRICK_NAMESPACE="ErrorSummaryExtractorBrick"
+  BRICK_PROJECT_NAME="ErrorSummaryExtractorBrick"
+  BRICK_PROJECT_DIR="${BRICK_OUT}/ErrorSummaryExtractorBrick"
+  if [[ ! -f "${PROBE_BRICK_SOURCE}/ErrorSummaryExtractorBrick.cs" ]]; then
+    echo "Probe brick source not found at ${PROBE_BRICK_SOURCE}" >&2
+    exit 1
+  fi
+  echo "==> Copying generated probe brick from ${PROBE_BRICK_SOURCE}"
+  mkdir -p "${BRICK_PROJECT_DIR}"
+  cp "${PROBE_BRICK_SOURCE}/ErrorSummaryExtractorBrick.cs" "${BRICK_PROJECT_DIR}/ErrorSummaryExtractorBrick.cs"
+  cat > "${BRICK_PROJECT_DIR}/ErrorSummaryExtractorBrick.csproj" <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nexo.Brick.Contracts" Version="${VERSION}" />
+    <PackageReference Include="Nexo.Authoring" Version="${VERSION}" />
+  </ItemGroup>
+</Project>
+EOF
+else
 echo "==> Scaffolding authored brick via nexo new brick"
 "${TOOL_PATH}/nexo" new brick Intensity \
   --output "${BRICK_OUT}" \
@@ -159,6 +205,7 @@ public sealed class IntensityBrick : Brick
     }
 }
 CS
+fi
 
 HOST_DIR="${CONSUMER_ROOT}/host/ExternalProductHost"
 CLIENT_DIR="${CONSUMER_ROOT}/client/ExternalProductClient"
@@ -177,12 +224,12 @@ cat > "${HOST_DIR}/ExternalProductHost.csproj" <<EOF
     <PackageReference Include="Nexo.Hosting.Bundle" Version="${VERSION}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../brick/IntensityBrick/IntensityBrick.csproj" />
+    <ProjectReference Include="../../brick/${BRICK_PROJECT_NAME}/${BRICK_PROJECT_NAME}.csproj" />
   </ItemGroup>
 </Project>
 EOF
 
-cat > "${HOST_DIR}/Program.cs" <<'CS'
+cat > "${HOST_DIR}/Program.cs" <<'HOSTCS'
 using Nexo.Authoring;
 using Nexo.BrickContracts;
 using Nexo.Core.Application.Bricks;
@@ -190,11 +237,27 @@ using Nexo.Core.Domain.Bricks;
 using Nexo.Core.Domain.Execution;
 using Nexo.Hosting;
 using Nexo.Infrastructure.Execution;
+HOSTCS
+
+if [[ "${USE_PROBE_BRICK}" -eq 1 ]]; then
+  cat >> "${HOST_DIR}/Program.cs" <<HOSTCS
+using ${BRICK_NAMESPACE};
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddNexoBrick<${BRICK_NAMESPACE}.${BRICK_CLASS}>();
+HOSTCS
+else
+  cat >> "${HOST_DIR}/Program.cs" <<'HOSTCS'
 using IntensityBrick;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddNexoBrick<IntensityBrick.IntensityBrick>();
+HOSTCS
+fi
+
+cat >> "${HOST_DIR}/Program.cs" <<'HOSTCS'
 builder.Services.AddNexo(options =>
 {
     options.RegisterBackgroundAgentHostedService = false;
@@ -270,7 +333,7 @@ static Nexo.Infrastructure.Execution.ExecutionContext ToExecutionContext(Executi
             : new Dictionary<string, object>(dto.Variables)
     };
 }
-CS
+HOSTCS
 
 cat > "${CLIENT_DIR}/ExternalProductClient.csproj" <<EOF
 <Project Sdk="Microsoft.NET.Sdk">
@@ -287,7 +350,10 @@ cat > "${CLIENT_DIR}/ExternalProductClient.csproj" <<EOF
 </Project>
 EOF
 
-cat > "${CLIENT_DIR}/Program.cs" <<'CS'
+if [[ "${USE_PROBE_BRICK}" -eq 1 ]]; then
+  cp "${ROOT}/spikes/portability/templates/ExternalProductProbeClient.cs" "${CLIENT_DIR}/Program.cs"
+else
+cat > "${CLIENT_DIR}/Program.cs" <<'CLIENTCS'
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
@@ -315,7 +381,6 @@ var requestBody = new Dictionary<string, object?>
 var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 using var content = JsonContent.Create(requestBody, options: jsonOptions);
 
-// Route from Nexo.API MapNexoEndpoints: POST /api/bricks/{brickId}/execute
 using var response = await client.InvokeAsync(
     HttpMethod.Post,
     "api/bricks/intensity/execute",
@@ -342,12 +407,13 @@ if (!doc.RootElement.TryGetProperty("output", out var outputEl) ||
 }
 
 Console.WriteLine("external-product-client: brick round-trip OK (intensity 21 -> result 42)");
-CS
+CLIENTCS
+fi
 
 SLN="${CONSUMER_ROOT}/ExternalProduct.sln"
 dotnet new sln -n ExternalProduct -o "${CONSUMER_ROOT}" --force
 dotnet sln "${SLN}" add \
-  "${BRICK_OUT}/IntensityBrick/IntensityBrick.csproj" \
+  "${BRICK_PROJECT_DIR}/${BRICK_PROJECT_NAME}.csproj" \
   "${HOST_DIR}/ExternalProductHost.csproj" \
   "${CLIENT_DIR}/ExternalProductClient.csproj"
 

--- a/spikes/portability/REPORT.md
+++ b/spikes/portability/REPORT.md
@@ -1,0 +1,34 @@
+# Atomic Brick Portability Spike Report
+
+Version pin: `0.1.0` (from `VERSION`)
+Probe brick: `ErrorSummaryExtractor` (deterministic log scanner)
+
+## Step results
+
+| Step | Description | Result |
+|------|-------------|--------|
+| 1 | Generate deterministic probe brick via `INewBrickGenerator` | PASS |
+| 2 | Certify through S0–S2 gate (signed admission record) | FAIL |
+| 3 | Pack Nexo.Brick.Contracts + Nexo.Authoring (+ Hosting.Bundle) @ 0.1.0 | PASS |
+| 4 | Consume generated brick from external template (package pins only) | PASS |
+| 5 | Cross-project HTTP execute assertion | PASS |
+
+**Step 2 detail:** S0–S2 certification gate script not found in repository (see generated/certification-record.json)
+
+## Contract-stability gaps (repo-internal context in generated brick)
+
+- Generated source uses `Nexo.Core.Domain.Bricks` and `Nexo.Core.Domain.Execution` namespaces. These types ship through `Nexo.Authoring` / `Nexo.Brick.Contracts`, but the generated `using` lines do not reference the pinned package IDs directly — external consumers must know the namespace mapping.
+- `NewBrickGenerator` only emits `ImplementationSource` for the hard-coded `ErrorSummaryExtractor` pattern; other pattern types still return `ImplementationSource: null` (manifest-only).
+- No signed certification record or registry admission path exists yet (Step 2 blocker).
+
+## Next steps to close gaps
+
+1. Add S0–S2 brick certification gate with real execution (not rubber-stamp) and signed admission records.
+2. Teach `NewBrickGenerator` to emit package-qualified usings or a stable authoring namespace alias aligned with `Nexo.Brick.Contracts`.
+3. Extend `BrickRecompiler` to compile `ImplementationSource` without repo-internal types.
+
+## Artifacts
+
+- `spikes/portability/generated/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.cs`
+- `spikes/portability/generated/manifest.json`
+- `spikes/portability/generated/certification-record.json`

--- a/spikes/portability/certify-probe-brick.sh
+++ b/spikes/portability/certify-probe-brick.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Step 2: attempt to certify the probe brick through the S0–S2 certification gate.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="${NEXO_PORTABILITY_GENERATED_DIR:-${ROOT}/spikes/portability/generated}"
+RECORD="${OUT}/certification-record.json"
+
+mkdir -p "${OUT}"
+
+# Known certification gate entry points (S0–S2 harness). None found in repo at spike time.
+GATE_CANDIDATES=(
+  "scripts/certify-brick-gate.sh"
+  "scripts/verify-brick-certification-gate.sh"
+  "scripts/verify-brick-certification-s0-s2.sh"
+)
+
+FOUND_GATE=""
+for candidate in "${GATE_CANDIDATES[@]}"; do
+  if [[ -f "${ROOT}/${candidate}" ]]; then
+    FOUND_GATE="${ROOT}/${candidate}"
+    break
+  fi
+done
+
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ -z "${FOUND_GATE}" ]]; then
+  cat > "${RECORD}" <<EOF
+{
+  "status": "FAIL",
+  "stage": "S0-S2",
+  "admitted": false,
+  "signed": false,
+  "timestamp": "${timestamp}",
+  "reason": "No S0-S2 brick certification gate script found in repository",
+  "searched": $(printf '%s\n' "${GATE_CANDIDATES[@]}" | jq -R . | jq -s .),
+  "brickId": "error-summary-extractor"
+}
+EOF
+  echo "certify-probe-brick: FAIL — S0-S2 certification gate not present (see ${RECORD})" >&2
+  exit 1
+fi
+
+echo "==> Running certification gate: ${FOUND_GATE}"
+if bash "${FOUND_GATE}" "${OUT}/ErrorSummaryExtractorBrick"; then
+  cat > "${RECORD}" <<EOF
+{
+  "status": "PASS",
+  "stage": "S0-S2",
+  "admitted": true,
+  "signed": true,
+  "timestamp": "${timestamp}",
+  "gate": "${FOUND_GATE}",
+  "brickId": "error-summary-extractor"
+}
+EOF
+  echo "certify-probe-brick: OK"
+else
+  cat > "${RECORD}" <<EOF
+{
+  "status": "FAIL",
+  "stage": "S0-S2",
+  "admitted": false,
+  "signed": false,
+  "timestamp": "${timestamp}",
+  "gate": "${FOUND_GATE}",
+  "brickId": "error-summary-extractor"
+}
+EOF
+  echo "certify-probe-brick: FAIL — gate rejected brick (see ${RECORD})" >&2
+  exit 1
+fi

--- a/spikes/portability/generate-probe-brick.sh
+++ b/spikes/portability/generate-probe-brick.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Step 1: invoke INewBrickGenerator for ErrorSummaryExtractor and capture artifacts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="${NEXO_PORTABILITY_GENERATED_DIR:-${ROOT}/spikes/portability/generated}"
+VERSION="$(tr -d '[:space:]' < "${ROOT}/VERSION")"
+
+mkdir -p "${OUT}"
+
+echo "==> Generating ErrorSummaryExtractor probe brick (version ${VERSION})"
+dotnet run --project "${ROOT}/spikes/portability/tools/GenerateProbeBrick/GenerateProbeBrick.csproj" \
+  -c Release \
+  -- "${OUT}" "${VERSION}"
+
+if [[ ! -f "${OUT}/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.cs" ]]; then
+  echo "Missing generated brick source." >&2
+  exit 1
+fi
+
+if [[ ! -f "${OUT}/manifest.json" ]]; then
+  echo "Missing manifest.json certification artifact." >&2
+  exit 1
+fi
+
+echo "generate-probe-brick: OK (${OUT})"

--- a/spikes/portability/generated/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.cs
+++ b/spikes/portability/generated/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.cs
@@ -1,0 +1,67 @@
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace ErrorSummaryExtractorBrick;
+
+/// <summary>
+/// Deterministic log scanner: counts ERROR lines and extracts the first error message.
+/// </summary>
+public sealed class ErrorSummaryExtractorBrick : Brick
+{
+    public ErrorSummaryExtractorBrick()
+    {
+        Id = "error-summary-extractor";
+        Name = "Error Summary Extractor";
+        Version = "1.0.0";
+        Icon = "📋";
+        Category = BrickCategory.Analysis;
+        Description = "Counts ERROR lines in a raw log string and returns the first error message.";
+        Interface = new BrickInterface
+        {
+            Inputs =
+            [
+                new BrickInputDefinition("logText", "string", "Raw log text to scan for ERROR lines")
+            ],
+            Outputs =
+            [
+                new BrickOutputDefinition("errorCount", "int", "Number of lines containing ERROR"),
+                new BrickOutputDefinition("firstErrorMessage", "string", "Message from the first ERROR line")
+            ]
+        };
+    }
+
+    public override Task<BrickOutput> ExecuteAsync(
+        BrickInput input,
+        ImplementationType implementation,
+        IExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var logText = input.Get<string>("logText") ?? string.Empty;
+        var errorLines = new List<string>();
+        foreach (var line in logText.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (line.Contains("ERROR", StringComparison.Ordinal))
+                errorLines.Add(line);
+        }
+
+        var errorCount = errorLines.Count;
+        var firstErrorMessage = errorCount > 0 ? ExtractErrorMessage(errorLines[0]) : string.Empty;
+        var output = new BrickOutput
+        {
+            Summary = $"Found {errorCount} ERROR line(s); first: {firstErrorMessage}"
+        };
+        output.Set("errorCount", errorCount);
+        output.Set("firstErrorMessage", firstErrorMessage);
+        return Task.FromResult(output);
+    }
+
+    private static string ExtractErrorMessage(string line)
+    {
+        var idx = line.IndexOf("ERROR", StringComparison.Ordinal);
+        if (idx < 0)
+            return line.Trim();
+
+        var rest = line[(idx + 5)..].TrimStart(' ', ':');
+        return rest;
+    }
+}

--- a/spikes/portability/generated/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.csproj
+++ b/spikes/portability/generated/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nexo.Brick.Contracts" Version="0.1.0" />
+    <PackageReference Include="Nexo.Authoring" Version="0.1.0" />
+  </ItemGroup>
+</Project>

--- a/spikes/portability/generated/certification-record.json
+++ b/spikes/portability/generated/certification-record.json
@@ -3,7 +3,7 @@
   "stage": "S0-S2",
   "admitted": false,
   "signed": false,
-  "timestamp": "2026-06-21T04:30:23Z",
+  "timestamp": "2026-06-21T04:32:47Z",
   "reason": "No S0-S2 brick certification gate script found in repository",
   "searched": [
   "scripts/certify-brick-gate.sh",

--- a/spikes/portability/generated/certification-record.json
+++ b/spikes/portability/generated/certification-record.json
@@ -1,0 +1,14 @@
+{
+  "status": "FAIL",
+  "stage": "S0-S2",
+  "admitted": false,
+  "signed": false,
+  "timestamp": "2026-06-21T04:30:23Z",
+  "reason": "No S0-S2 brick certification gate script found in repository",
+  "searched": [
+  "scripts/certify-brick-gate.sh",
+  "scripts/verify-brick-certification-gate.sh",
+  "scripts/verify-brick-certification-s0-s2.sh"
+],
+  "brickId": "error-summary-extractor"
+}

--- a/spikes/portability/generated/manifest.json
+++ b/spikes/portability/generated/manifest.json
@@ -1,0 +1,31 @@
+{
+  "Id": "error-summary-extractor",
+  "Name": "Error Summary Extractor",
+  "Version": "1.0.0",
+  "Description": "Counts ERROR lines in a raw log string and returns the first error message.",
+  "Category": 2,
+  "Interface": {
+    "Inputs": [
+      {
+        "Name": "logText",
+        "Type": "string",
+        "Description": "Raw log text to scan for ERROR lines",
+        "Required": true
+      }
+    ],
+    "Outputs": [
+      {
+        "Name": "errorCount",
+        "Type": "int",
+        "Description": "Number of lines containing ERROR"
+      },
+      {
+        "Name": "firstErrorMessage",
+        "Type": "string",
+        "Description": "Message from the first ERROR line"
+      }
+    ]
+  },
+  "ImplementationSource": "using Nexo.Core.Domain.Bricks;\nusing Nexo.Core.Domain.Execution;\n\nnamespace ErrorSummaryExtractorBrick;\n\n/// \u003Csummary\u003E\n/// Deterministic log scanner: counts ERROR lines and extracts the first error message.\n/// \u003C/summary\u003E\npublic sealed class ErrorSummaryExtractorBrick : Brick\n{\n    public ErrorSummaryExtractorBrick()\n    {\n        Id = \u0022error-summary-extractor\u0022;\n        Name = \u0022Error Summary Extractor\u0022;\n        Version = \u00221.0.0\u0022;\n        Icon = \u0022\uD83D\uDCCB\u0022;\n        Category = BrickCategory.Analysis;\n        Description = \u0022Counts ERROR lines in a raw log string and returns the first error message.\u0022;\n        Interface = new BrickInterface\n        {\n            Inputs =\n            [\n                new BrickInputDefinition(\u0022logText\u0022, \u0022string\u0022, \u0022Raw log text to scan for ERROR lines\u0022)\n            ],\n            Outputs =\n            [\n                new BrickOutputDefinition(\u0022errorCount\u0022, \u0022int\u0022, \u0022Number of lines containing ERROR\u0022),\n                new BrickOutputDefinition(\u0022firstErrorMessage\u0022, \u0022string\u0022, \u0022Message from the first ERROR line\u0022)\n            ]\n        };\n    }\n\n    public override Task\u003CBrickOutput\u003E ExecuteAsync(\n        BrickInput input,\n        ImplementationType implementation,\n        IExecutionContext context,\n        CancellationToken cancellationToken = default)\n    {\n        var logText = input.Get\u003Cstring\u003E(\u0022logText\u0022) ?? string.Empty;\n        var errorLines = new List\u003Cstring\u003E();\n        foreach (var line in logText.Split([\u0027\\r\u0027, \u0027\\n\u0027], StringSplitOptions.RemoveEmptyEntries))\n        {\n            if (line.Contains(\u0022ERROR\u0022, StringComparison.Ordinal))\n                errorLines.Add(line);\n        }\n\n        var errorCount = errorLines.Count;\n        var firstErrorMessage = errorCount \u003E 0 ? ExtractErrorMessage(errorLines[0]) : string.Empty;\n        var output = new BrickOutput\n        {\n            Summary = $\u0022Found {errorCount} ERROR line(s); first: {firstErrorMessage}\u0022\n        };\n        output.Set(\u0022errorCount\u0022, errorCount);\n        output.Set(\u0022firstErrorMessage\u0022, firstErrorMessage);\n        return Task.FromResult(output);\n    }\n\n    private static string ExtractErrorMessage(string line)\n    {\n        var idx = line.IndexOf(\u0022ERROR\u0022, StringComparison.Ordinal);\n        if (idx \u003C 0)\n            return line.Trim();\n\n        var rest = line[(idx \u002B 5)..].TrimStart(\u0027 \u0027, \u0027:\u0027);\n        return rest;\n    }\n}",
+  "Config": {}
+}

--- a/spikes/portability/pack-local-feed.sh
+++ b/spikes/portability/pack-local-feed.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Step 3: pack consumer-surface packages at VERSION (default 0.1.0) into a local feed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSION="${NEXO_PORTABILITY_PACK_VERSION:-$(tr -d '[:space:]' < "${ROOT}/VERSION")}"
+FEED="${NEXO_PORTABILITY_PACK_FEED:-${ROOT}/artifacts/nuget-local-portability}"
+
+mkdir -p "${FEED}"
+
+pack() {
+  local project="$1"
+  echo "==> dotnet pack ${project}"
+  dotnet pack "${ROOT}/${project}" \
+    -c Release \
+    -o "${FEED}" \
+    -p:PackageVersion="${VERSION}" \
+    -p:IncludeTestProjectReferences=false \
+    -v minimal
+}
+
+echo "==> Packing portability feed as version ${VERSION} into ${FEED}"
+bash "${ROOT}/scripts/pack-nexo-hosting-graph.sh" "${VERSION}" "${FEED}"
+pack src/Nexo.Authoring/Nexo.Authoring.csproj
+pack src/Nexo.Sdk/Nexo.Sdk.csproj
+pack src/Nexo.Client/Nexo.Client.csproj
+
+echo "pack-local-feed: OK (${FEED})"

--- a/spikes/portability/run-portability-spike.sh
+++ b/spikes/portability/run-portability-spike.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Orchestrates atomic brick portability spike (steps 1–5).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSION="$(tr -d '[:space:]' < "${ROOT}/VERSION")"
+GENERATED="${ROOT}/spikes/portability/generated"
+REPORT="${ROOT}/spikes/portability/REPORT.md"
+
+step1_status="PENDING"
+step2_status="PENDING"
+step3_status="PENDING"
+step4_status="PENDING"
+step5_status="PENDING"
+step2_detail=""
+step5_detail=""
+leaks=()
+
+record_leak() { leaks+=("$1"); }
+
+echo "==> Step 1: generate probe brick"
+if bash "${ROOT}/spikes/portability/generate-probe-brick.sh"; then
+  step1_status="PASS"
+else
+  step1_status="FAIL"
+fi
+
+echo "==> Step 2: certify probe brick"
+set +e
+bash "${ROOT}/spikes/portability/certify-probe-brick.sh"
+cert_exit=$?
+set -e
+if [[ "${cert_exit}" -eq 0 ]]; then
+  step2_status="PASS"
+else
+  step2_status="FAIL"
+  step2_detail="S0–S2 certification gate script not found in repository (see generated/certification-record.json)"
+fi
+
+echo "==> Steps 3–5: pack ${VERSION}, consume externally, assert execution"
+set +e
+NEXO_EXTERNAL_PRODUCT_VERIFY_VERSION="${VERSION}" \
+NEXO_EXTERNAL_PRODUCT_PROBE_BRICK=1 \
+NEXO_EXTERNAL_PRODUCT_PROBE_BRICK_SOURCE="${GENERATED}/ErrorSummaryExtractorBrick" \
+  bash "${ROOT}/scripts/verify-external-product-shape.sh"
+verify_exit=$?
+set -e
+
+if [[ "${verify_exit}" -eq 0 ]]; then
+  step3_status="PASS"
+  step4_status="PASS"
+  step5_status="PASS"
+else
+  step3_status="UNKNOWN"
+  step4_status="UNKNOWN"
+  step5_status="FAIL"
+  step5_detail="verify-external-product-shape.sh exited ${verify_exit}"
+fi
+
+# Scan generated brick for repo-internal leaks
+if [[ -f "${GENERATED}/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.cs" ]]; then
+  if rg -q "Nexo\\.Infrastructure|Nexo\\.Core\\.Application|ProjectReference|src/Nexo" "${GENERATED}/ErrorSummaryExtractorBrick"; then
+    record_leak "Generated source references repo-internal namespaces or paths"
+  fi
+  if rg -q "using Nexo\\.Core\\.Domain" "${GENERATED}/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.cs"; then
+    record_leak "Generated brick uses Nexo.Core.Domain.* namespaces (shipped via Nexo.Authoring/Nexo.Brick.Contracts but not the pinned package IDs)"
+  fi
+fi
+
+if [[ -f "${GENERATED}/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.csproj" ]]; then
+  if rg -q "ProjectReference" "${GENERATED}/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.csproj"; then
+    record_leak "Brick csproj contains ProjectReference to repo-internal projects"
+  fi
+fi
+
+mkdir -p "$(dirname "${REPORT}")"
+{
+  echo "# Atomic Brick Portability Spike Report"
+  echo
+  echo "Version pin: \`${VERSION}\` (from \`VERSION\`)"
+  echo "Probe brick: \`ErrorSummaryExtractor\` (deterministic log scanner)"
+  echo
+  echo "## Step results"
+  echo
+  echo "| Step | Description | Result |"
+  echo "|------|-------------|--------|"
+  echo "| 1 | Generate deterministic probe brick via \`INewBrickGenerator\` | ${step1_status} |"
+  echo "| 2 | Certify through S0–S2 gate (signed admission record) | ${step2_status} |"
+  echo "| 3 | Pack Nexo.Brick.Contracts + Nexo.Authoring (+ Hosting.Bundle) @ ${VERSION} | ${step3_status} |"
+  echo "| 4 | Consume generated brick from external template (package pins only) | ${step4_status} |"
+  echo "| 5 | Cross-project HTTP execute assertion | ${step5_status} |"
+  echo
+  if [[ -n "${step2_detail}" ]]; then
+    echo "**Step 2 detail:** ${step2_detail}"
+    echo
+  fi
+  if [[ -n "${step5_detail}" ]]; then
+    echo "**Step 5 detail:** ${step5_detail}"
+    echo
+  fi
+  echo "## Contract-stability gaps (repo-internal context in generated brick)"
+  echo
+  if [[ "${#leaks[@]}" -eq 0 ]]; then
+    echo "- None detected in generated source/csproj (namespaces come from published authoring surface)."
+  else
+    for leak in "${leaks[@]}"; do
+      echo "- ${leak}"
+    done
+  fi
+  echo
+  echo "## Artifacts"
+  echo
+  echo "- \`spikes/portability/generated/ErrorSummaryExtractorBrick/ErrorSummaryExtractorBrick.cs\`"
+  echo "- \`spikes/portability/generated/manifest.json\`"
+  echo "- \`spikes/portability/generated/certification-record.json\`"
+} > "${REPORT}"
+
+cat "${REPORT}"
+
+if [[ "${step1_status}" != "PASS" || "${step5_status}" != "PASS" ]]; then
+  exit 1
+fi

--- a/spikes/portability/templates/ExternalProductProbeClient.cs
+++ b/spikes/portability/templates/ExternalProductProbeClient.cs
@@ -1,0 +1,62 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.Client;
+using Nexo.Sdk.Client;
+
+if (args.Length < 1 || string.IsNullOrWhiteSpace(args[0]))
+{
+    Console.Error.WriteLine("Usage: ExternalProductClient <hostBaseUrl>");
+    Environment.Exit(2);
+}
+
+var hostBaseUrl = args[0].TrimEnd('/');
+var services = new ServiceCollection();
+services.AddNexoClientSdk(hostBaseUrl);
+await using var provider = services.BuildServiceProvider();
+var client = provider.GetRequiredService<INexoClient>();
+
+const string probeLogText =
+    "2024-01-01 INFO Started\n" +
+    "2024-01-01 ERROR First failure: connection reset\n" +
+    "2024-01-01 WARN Retrying\n" +
+    "2024-01-01 ERROR Second failure: timeout";
+
+var requestBody = new Dictionary<string, object?>
+{
+    ["implementation"] = "Deterministic",
+    ["input"] = new Dictionary<string, object> { ["logText"] = probeLogText }
+};
+
+var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+using var content = JsonContent.Create(requestBody, options: jsonOptions);
+
+using var response = await client.InvokeAsync(
+    HttpMethod.Post,
+    "api/bricks/error-summary-extractor/execute",
+    content).ConfigureAwait(false);
+
+response.EnsureSuccessStatusCode();
+await using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+using var doc = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
+
+if (!doc.RootElement.TryGetProperty("success", out var successEl) || !successEl.GetBoolean())
+{
+    var error = doc.RootElement.TryGetProperty("error", out var errEl) ? errEl.GetString() : "unknown";
+    Console.Error.WriteLine($"Brick execute failed: {error}");
+    Environment.Exit(1);
+}
+
+if (!doc.RootElement.TryGetProperty("output", out var outputEl) ||
+    !outputEl.TryGetProperty("errorCount", out var countEl) ||
+    countEl.ValueKind != JsonValueKind.Number ||
+    countEl.GetInt32() != 2 ||
+    !outputEl.TryGetProperty("firstErrorMessage", out var msgEl) ||
+    msgEl.ValueKind != JsonValueKind.String ||
+    msgEl.GetString() != "First failure: connection reset")
+{
+    Console.Error.WriteLine($"Unexpected brick output: {doc.RootElement.GetRawText()}");
+    Environment.Exit(1);
+}
+
+Console.WriteLine("external-product-client: probe brick round-trip OK (errorCount=2, first='First failure: connection reset')");

--- a/spikes/portability/tools/GenerateProbeBrick/GenerateProbeBrick.csproj
+++ b/spikes/portability/tools/GenerateProbeBrick/GenerateProbeBrick.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../src/Nexo.Infrastructure/Nexo.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/spikes/portability/tools/GenerateProbeBrick/Program.cs
+++ b/spikes/portability/tools/GenerateProbeBrick/Program.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Nexo.Core.Application.Adaptation.Models;
+using Nexo.Infrastructure.Adaptation;
+
+var root = args.Length > 0 ? Path.GetFullPath(args[0]) : Path.GetFullPath("spikes/portability/generated");
+var version = args.Length > 1 ? args[1] : File.ReadAllText(Path.Combine(FindRepoRoot(), "VERSION")).Trim();
+
+var generator = new NewBrickGenerator();
+var manifest = await generator.GenerateAsync("ErrorSummaryExtractor").ConfigureAwait(false);
+
+if (string.IsNullOrWhiteSpace(manifest.ImplementationSource))
+{
+    Console.Error.WriteLine("Generator did not emit ImplementationSource for ErrorSummaryExtractor.");
+    return 1;
+}
+
+var brickDir = Path.Combine(root, "ErrorSummaryExtractorBrick");
+Directory.CreateDirectory(brickDir);
+
+var brickCsPath = Path.Combine(brickDir, "ErrorSummaryExtractorBrick.cs");
+await File.WriteAllTextAsync(brickCsPath, manifest.ImplementationSource).ConfigureAwait(false);
+
+var csprojPath = Path.Combine(brickDir, "ErrorSummaryExtractorBrick.csproj");
+await File.WriteAllTextAsync(csprojPath, $"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nexo.Brick.Contracts" Version="{version}" />
+    <PackageReference Include="Nexo.Authoring" Version="{version}" />
+  </ItemGroup>
+</Project>
+""").ConfigureAwait(false);
+
+var manifestPath = Path.Combine(root, "manifest.json");
+var jsonOptions = new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(manifest, jsonOptions)).ConfigureAwait(false);
+
+Console.WriteLine($"Generated probe brick at {brickDir}");
+Console.WriteLine($"Manifest: {manifestPath}");
+return 0;
+
+static string FindRepoRoot()
+{
+    var dir = Directory.GetCurrentDirectory();
+    while (!string.IsNullOrEmpty(dir))
+    {
+        if (File.Exists(Path.Combine(dir, "VERSION")) && File.Exists(Path.Combine(dir, "Nexo.sln")))
+            return dir;
+        dir = Directory.GetParent(dir)?.FullName ?? string.Empty;
+    }
+
+    throw new InvalidOperationException("Could not locate Nexo repo root.");
+}

--- a/src/Nexo.Infrastructure/Adaptation/NewBrickGenerator.cs
+++ b/src/Nexo.Infrastructure/Adaptation/NewBrickGenerator.cs
@@ -19,6 +19,7 @@ public sealed class NewBrickGenerator : INewBrickGenerator
         ["edit-then-build"] = BrickCategory.Control,
         ["MissingOutput"] = BrickCategory.Validation,
         ["code-analysis"] = BrickCategory.Analysis,
+        ["ErrorSummaryExtractor"] = BrickCategory.Analysis,
     };
 
     public NewBrickGenerator(IAdaptationLog? adaptationLog = null)
@@ -33,6 +34,9 @@ public sealed class NewBrickGenerator : INewBrickGenerator
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.Equals(patternType, "ErrorSummaryExtractor", StringComparison.OrdinalIgnoreCase))
+            return CreateErrorSummaryExtractorManifest();
 
         var category = PatternCategoryMap.TryGetValue(patternType, out var c) ? c : BrickCategory.Control;
         var inputs = InferInputs(patternType, patternMetadata);
@@ -89,4 +93,99 @@ public sealed class NewBrickGenerator : INewBrickGenerator
             new BrickOutputDefinition("fixed", "bool", "Whether fix was applied"),
         ];
     }
+
+    private static BrickManifest CreateErrorSummaryExtractorManifest()
+    {
+        return new BrickManifest
+        {
+            Id = "error-summary-extractor",
+            Name = "Error Summary Extractor",
+            Version = "1.0.0",
+            Category = BrickCategory.Analysis,
+            Description = "Counts ERROR lines in a raw log string and returns the first error message.",
+            Interface = new BrickInterface
+            {
+                Inputs =
+                [
+                    new BrickInputDefinition("logText", "string", "Raw log text to scan for ERROR lines")
+                ],
+                Outputs =
+                [
+                    new BrickOutputDefinition("errorCount", "int", "Number of lines containing ERROR"),
+                    new BrickOutputDefinition("firstErrorMessage", "string", "Message from the first ERROR line")
+                ]
+            },
+            ImplementationSource = ErrorSummaryExtractorSource,
+        };
+    }
+
+    private const string ErrorSummaryExtractorSource = """
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace ErrorSummaryExtractorBrick;
+
+/// <summary>
+/// Deterministic log scanner: counts ERROR lines and extracts the first error message.
+/// </summary>
+public sealed class ErrorSummaryExtractorBrick : Brick
+{
+    public ErrorSummaryExtractorBrick()
+    {
+        Id = "error-summary-extractor";
+        Name = "Error Summary Extractor";
+        Version = "1.0.0";
+        Icon = "📋";
+        Category = BrickCategory.Analysis;
+        Description = "Counts ERROR lines in a raw log string and returns the first error message.";
+        Interface = new BrickInterface
+        {
+            Inputs =
+            [
+                new BrickInputDefinition("logText", "string", "Raw log text to scan for ERROR lines")
+            ],
+            Outputs =
+            [
+                new BrickOutputDefinition("errorCount", "int", "Number of lines containing ERROR"),
+                new BrickOutputDefinition("firstErrorMessage", "string", "Message from the first ERROR line")
+            ]
+        };
+    }
+
+    public override Task<BrickOutput> ExecuteAsync(
+        BrickInput input,
+        ImplementationType implementation,
+        IExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var logText = input.Get<string>("logText") ?? string.Empty;
+        var errorLines = new List<string>();
+        foreach (var line in logText.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (line.Contains("ERROR", StringComparison.Ordinal))
+                errorLines.Add(line);
+        }
+
+        var errorCount = errorLines.Count;
+        var firstErrorMessage = errorCount > 0 ? ExtractErrorMessage(errorLines[0]) : string.Empty;
+        var output = new BrickOutput
+        {
+            Summary = $"Found {errorCount} ERROR line(s); first: {firstErrorMessage}"
+        };
+        output.Set("errorCount", errorCount);
+        output.Set("firstErrorMessage", firstErrorMessage);
+        return Task.FromResult(output);
+    }
+
+    private static string ExtractErrorMessage(string line)
+    {
+        var idx = line.IndexOf("ERROR", StringComparison.Ordinal);
+        if (idx < 0)
+            return line.Trim();
+
+        var rest = line[(idx + 5)..].TrimStart(' ', ':');
+        return rest;
+    }
+}
+""";
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/Adaptation/NewBrickGeneratorTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Adaptation/NewBrickGeneratorTests.cs
@@ -18,4 +18,17 @@ public sealed class NewBrickGeneratorTests
         manifest.Name.Should().Contain("repeated-edits");
         manifest.Interface.Outputs.Should().NotBeEmpty();
     }
+
+    [Fact]
+    public async Task GenerateAsync_ErrorSummaryExtractor_EmitsDeterministicSource()
+    {
+        var generator = new NewBrickGenerator();
+        var manifest = await generator.GenerateAsync("ErrorSummaryExtractor");
+
+        manifest.Id.Should().Be("error-summary-extractor");
+        manifest.ImplementationSource.Should().NotBeNullOrWhiteSpace();
+        manifest.ImplementationSource.Should().Contain("errorCount");
+        manifest.ImplementationSource.Should().Contain("firstErrorMessage");
+        manifest.Interface.Inputs.Should().ContainSingle(i => i.Name == "logText");
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Proves atomic brick portability for a generated, deterministic probe brick (`ErrorSummaryExtractor`) through the existing external-product-shape harness at version **0.1.0**.

## Spike results

| Step | Result |
|------|--------|
| 1 — Generate via `INewBrickGenerator` | **PASS** |
| 2 — S0–S2 certification gate | **FAIL** (gate not present in repo) |
| 3 — Pack `Nexo.Brick.Contracts` + `Nexo.Authoring` + `Nexo.Hosting.Bundle` @ 0.1.0 | **PASS** |
| 4 — Consume from external template (package pins only) | **PASS** |
| 5 — HTTP execute round-trip (`errorCount=2`, `firstErrorMessage`) | **PASS** |

Full report: `spikes/portability/REPORT.md`

## Key changes

- Extended `NewBrickGenerator` to emit deterministic `ImplementationSource` for `ErrorSummaryExtractor`.
- Added `spikes/portability/` spike tooling (`generate-probe-brick.sh`, `certify-probe-brick.sh`, `pack-local-feed.sh`, `run-portability-spike.sh`).
- Extended `scripts/verify-external-product-shape.sh` with probe-brick mode (`NEXO_EXTERNAL_PRODUCT_PROBE_BRICK=1`) without changing the default Intensity flow.

## Findings

- **S0–S2 brick certification gate is missing** — no signed admission record path exists yet.
- Generated brick uses `Nexo.Core.Domain.*` namespaces (authoring surface) rather than package-ID-qualified imports.
- `NewBrickGenerator` only materializes source for the hard-coded probe pattern; other patterns remain manifest-only.

## How to re-run

```bash
bash spikes/portability/run-portability-spike.sh
# or end-to-end verify only:
NEXO_EXTERNAL_PRODUCT_VERIFY_VERSION=0.1.0 \
NEXO_EXTERNAL_PRODUCT_PROBE_BRICK=1 \
  bash scripts/verify-external-product-shape.sh
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-524939e4-0833-487f-a756-1a3598d4921c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-524939e4-0833-487f-a756-1a3598d4921c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

