### PR TITLE
Phase 2: content-bound certs + cross-project brick reuse

### DIFF
--- a/Nexo.sln
+++ b/Nexo.sln
@@ -115,6 +115,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Commercial.Tests.Fleet
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Authoring", "src\Nexo.Authoring\Nexo.Authoring.csproj", "{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Certification.Contracts", "src\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj", "{265B00C0-D947-424D-A624-5233E0FDEC8C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -737,6 +739,18 @@ Global
 		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|x64.Build.0 = Release|Any CPU
 		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|x86.ActiveCfg = Release|Any CPU
 		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E}.Release|x86.Build.0 = Release|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Debug|x64.Build.0 = Debug|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Debug|x86.Build.0 = Debug|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Release|x64.ActiveCfg = Release|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Release|x64.Build.0 = Release|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Release|x86.ActiveCfg = Release|Any CPU
+		{265B00C0-D947-424D-A624-5233E0FDEC8C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -794,6 +808,7 @@ Global
 		{8904A032-99F3-AFCD-AFBD-12F878AC12DB} = {6941732A-EE8F-0657-99DC-FA435846C4C2}
 		{1112CCFA-2A91-489F-ACAB-E43501C0E0AA} = {8904A032-99F3-AFCD-AFBD-12F878AC12DB}
 		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
+		{265B00C0-D947-424D-A624-5233E0FDEC8C} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12345678-1234-1234-1234-123456789ABC}

--- a/docs/certification-evidence.md
+++ b/docs/certification-evidence.md
@@ -124,6 +124,24 @@ Composition: **damage-resolver → health-applier** (`damage-to-health-pipeline`
 
 cert-gate CI: **success**, run [27922375242](https://github.com/IanFrelinger/Nexo/actions/runs/27922375242) — TRX `total="21"`, guard `cert-gate reported 21 tests (expected>=21)`.
 
+## Phase 2: cross-project reuse
+
+trusted-reuse=PASS, tamper-reject=PASS, forged-sig-reject=PASS, tests_reported=24
+
+| Proof | Result |
+|-------|--------|
+| `HonestCertifiedBrick_ProjectB_TrustsAndRunsUntouched` | **PASS** — verifier TRUSTED, brick runs untouched (`finalDamage=40`) |
+| `TamperedBrick_ProjectB_RejectsContentHashMismatch` | **PASS** — `content-hash-mismatch`, refused |
+| `ForgedSignature_ProjectB_Rejects` | **PASS** — `signature-invalid`, refused |
+
+Project B (`samples/certified-brick-reuse/ProjectB`) references only `Nexo.Certification.Contracts`, `Nexo.Brick.Contracts`, `Nexo.Authoring`, and the packed `Nexo.Certified.DamageResolver` artifact — **no generator, no gate**. B verifies signature + content hash; it does not re-certify or regenerate.
+
+Content binding: `CertificationRecord.ContentHash` = SHA-256 (UTF-8) of canonical brick source, included in signed HMAC payload (`Nexo.Certification.Contracts`).
+
+Pack/export: `scripts/pack-certified-brick-reuse.sh` → local feed + `certification-record.json` sidecar.
+
+**v0 trust model:** same-owner cross-project reuse via shared dev HMAC key (`NEXO_CERT_DEV_HMAC_KEY`). Cross-organization trust requires PKI (out of scope).
+
 ## Contract-stability gaps
 
 - Generated brick uses Nexo.Core.Domain.* namespaces (shipped via Nexo.Authoring/Nexo.Brick.Contracts but not the pinned package IDs)

--- a/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/DamageResolverBrick.cs
+++ b/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/DamageResolverBrick.cs
@@ -1,0 +1,48 @@
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace GeneratedBricks;
+
+public sealed class DamageResolverBrick : Brick
+{
+    public DamageResolverBrick()
+    {
+        Id = "damage-resolver";
+        Name = "Damage Resolver";
+        Version = "1.0.0";
+        Category = BrickCategory.Analysis;
+        Description = "Computes final damage from base damage, crit multiplier, armor, and crit flag.";
+        Interface = new BrickInterface
+        {
+            Inputs =
+            [
+                new BrickInputDefinition("baseDamage", "int", "Base damage before modifiers"),
+                new BrickInputDefinition("critMultiplierPercent", "int", "Crit multiplier percent (150 = 1.5x)"),
+                new BrickInputDefinition("armor", "int", "Armor subtracted after crit"),
+                new BrickInputDefinition("isCrit", "bool", "Whether the hit is a critical strike")
+            ],
+            Outputs = [new BrickOutputDefinition("finalDamage", "int", "Final damage dealt")]
+        };
+    }
+
+    public override Task<BrickOutput> ExecuteAsync(
+        BrickInput input,
+        ImplementationType implementation,
+        IExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var baseDamage = input.Get<int>("baseDamage");
+        var critMultiplierPercent = input.Get<int>("critMultiplierPercent");
+        var armor = input.Get<int>("armor");
+        var isCrit = input.Get<bool>("isCrit");
+
+        var raw = isCrit
+            ? baseDamage * critMultiplierPercent / 100
+            : baseDamage;
+        var finalDamage = Math.Max(0, raw - armor);
+
+        var output = new BrickOutput { Summary = $"Final damage: {finalDamage}" };
+        output.Set("finalDamage", finalDamage);
+        return Task.FromResult(output);
+    }
+}

--- a/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/Nexo.Certified.DamageResolver.csproj
+++ b/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/Nexo.Certified.DamageResolver.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>true</IsPackable>
+    <PackageId>Nexo.Certified.DamageResolver</PackageId>
+    <Version>0.1.0</Version>
+    <Title>Certified Damage Resolver Brick</Title>
+    <Description>Content-bound certified damage-resolver brick artifact for cross-project reuse.</Description>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <NoWarn>NU1701;NU1604</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nexo.Brick.Contracts" Version="0.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="certification-record.json" Pack="true" PackagePath="content/certified-brick/" />
+    <None Include="damage-resolver.witness.json" Pack="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/certification-record.json
+++ b/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/certification-record.json
@@ -1,0 +1,25 @@
+{
+  "status": "PASS",
+  "stage": "S0-S2",
+  "admitted": true,
+  "signed": true,
+  "timestamp": "2026-06-22T04:16:52.9738173+00:00",
+  "brickId": "damage-resolver",
+  "contentHash": "TabnO5oqc3oxfLzb3tibk9/QWFMVq7ZZc0rFjUrvHoc=",
+  "escapeRate": 0,
+  "totalMutants": 7,
+  "survivingMutants": 0,
+  "killedMutants": [
+    "mutate-int-literal-40",
+    "mutate-int-literal-42",
+    "mutate-string-literal-34",
+    "mutate-string-literal-35",
+    "mutate-string-literal-36",
+    "mutate-string-literal-37",
+    "remove-statement-34"
+  ],
+  "survivingMutantIds": [],
+  "signature": "A\u002BNXKc3/E1c6JsBgYI392ePkndL53ZbqcYXL2UK2Jb4=",
+  "reason": null,
+  "gate": "Nexo.Infrastructure.Certification.CertificationGate"
+}

--- a/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/damage-resolver.witness.json
+++ b/samples/certified-brick-reuse/Nexo.Certified.DamageResolver/damage-resolver.witness.json
@@ -1,0 +1,29 @@
+{
+  "brickId": "damage-resolver",
+  "cases": [
+    {
+      "input": { "baseDamage": 50, "critMultiplierPercent": 100, "armor": 10, "isCrit": false },
+      "expectedOutput": { "finalDamage": 40 }
+    },
+    {
+      "input": { "baseDamage": 100, "critMultiplierPercent": 150, "armor": 20, "isCrit": true },
+      "expectedOutput": { "finalDamage": 130 }
+    },
+    {
+      "input": { "baseDamage": 100, "critMultiplierPercent": 150, "armor": 30, "isCrit": true },
+      "expectedOutput": { "finalDamage": 120 }
+    },
+    {
+      "input": { "baseDamage": 10, "critMultiplierPercent": 100, "armor": 50, "isCrit": false },
+      "expectedOutput": { "finalDamage": 0 }
+    },
+    {
+      "input": { "baseDamage": 7, "critMultiplierPercent": 150, "armor": 0, "isCrit": true },
+      "expectedOutput": { "finalDamage": 10 }
+    },
+    {
+      "input": { "baseDamage": 0, "critMultiplierPercent": 200, "armor": 5, "isCrit": true },
+      "expectedOutput": { "finalDamage": 0 }
+    }
+  ]
+}

--- a/samples/certified-brick-reuse/ProjectB/Program.cs
+++ b/samples/certified-brick-reuse/ProjectB/Program.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using System.Text.Json;
+using Nexo.Certification.Contracts;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using GeneratedBricks;
+
+namespace CertifiedBrickReuse.ProjectB;
+
+internal static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var brickSourcePath = args.ElementAtOrDefault(0)
+            ?? throw new InvalidOperationException("Usage: ProjectB <path-to-DamageResolverBrick.cs> <path-to-certification-record.json>");
+        var recordPath = args.ElementAtOrDefault(1)
+            ?? throw new InvalidOperationException("Usage: ProjectB <path-to-DamageResolverBrick.cs> <path-to-certification-record.json>");
+
+        var source = await File.ReadAllTextAsync(brickSourcePath).ConfigureAwait(false);
+        var recordJson = await File.ReadAllTextAsync(recordPath).ConfigureAwait(false);
+        var record = JsonSerializer.Deserialize<CertificationRecordData>(
+            recordJson,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+            ?? throw new InvalidOperationException("Invalid certification record JSON.");
+
+        var trust = CertificationTrustVerifier.Verify(record, source);
+        if (!trust.Trusted)
+        {
+            Console.Error.WriteLine($"UNTRUSTED: {trust.FailureCode} — {trust.Reason}");
+            return 2;
+        }
+
+        var brick = new DamageResolverBrick();
+        var output = await brick.ExecuteAsync(
+            new BrickInput(new Dictionary<string, object>
+            {
+                ["baseDamage"] = 50,
+                ["critMultiplierPercent"] = 100,
+                ["armor"] = 10,
+                ["isCrit"] = false
+            }),
+            ImplementationType.Deterministic,
+            new ProjectBExecutionContext()).ConfigureAwait(false);
+
+        Console.WriteLine($"TRUSTED finalDamage={output.Get<int>("finalDamage")}");
+        return 0;
+    }
+}
+
+internal sealed class ProjectBExecutionContext : IExecutionContext
+{
+    public string AgentId { get; } = "project-b";
+    public string BehaviorId { get; } = "certified-brick-smoke";
+    public bool IsAirGapped { get; } = true;
+    public bool AuditMode { get; } = true;
+    public string Provider { get; } = "deterministic";
+    public IReadOnlyDictionary<string, object> Variables { get; } = new Dictionary<string, object>();
+}

--- a/samples/certified-brick-reuse/ProjectB/ProjectB.csproj
+++ b/samples/certified-brick-reuse/ProjectB/ProjectB.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CertifiedBrickReuse.ProjectB</RootNamespace>
+    <AssemblyName>CertifiedBrickReuse.ProjectB</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nexo.Brick.Contracts" Version="0.1.0" />
+    <PackageReference Include="Nexo.Authoring" Version="0.1.0" />
+    <PackageReference Include="Nexo.Certification.Contracts" Version="0.1.0" />
+    <PackageReference Include="Nexo.Certified.DamageResolver" Version="0.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/cert-gate-config.sh
+++ b/scripts/cert-gate-config.sh
@@ -12,6 +12,7 @@ readonly CERT_GATE_FILTER='FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Ce
 #   CompositionCertificationGateTeethTests: 5
 #   DamageResolverDogfoodTests: 2
 #   CompositionDogfoodTests: 2
+#   CrossProjectReuseTests: 3
 
 cert_gate_list_tests() {
   local root="${1:?repo root required}"

--- a/scripts/pack-certified-brick-reuse.sh
+++ b/scripts/pack-certified-brick-reuse.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Pack certified damage-resolver brick + certification sidecar + verifier contracts for Project B reuse.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${NEXO_CERTIFIED_REUSE_VERSION:-0.1.0}"
+FEED="${NEXO_CERTIFIED_REUSE_FEED:-${ROOT}/artifacts/certified-brick-feed}"
+ARTIFACT_DIR="${ROOT}/samples/certified-brick-reuse/Nexo.Certified.DamageResolver"
+RECORD_PATH="${ARTIFACT_DIR}/certification-record.json"
+CFG="${FEED}/NuGet.Config"
+
+mkdir -p "${FEED}"
+
+pack() {
+  dotnet pack "${ROOT}/${1}" -c Release -o "${FEED}" \
+    -p:PackageVersion="${VERSION}" \
+    -p:IncludeTestProjectReferences=false \
+    -p:UseProjectReferences=false \
+    -v minimal
+}
+
+echo "==> Pack base contracts to ${FEED}"
+pack src/Nexo.Brick.Contracts/Nexo.Brick.Contracts.csproj
+pack src/Nexo.Authoring/Nexo.Authoring.csproj
+pack src/Nexo.Certification.Contracts/Nexo.Certification.Contracts.csproj
+
+cat > "${CFG}" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="certified-feed" value="${FEED}" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+EOF
+
+export NEXO_CERT_NUGET_CONFIG="${CFG}"
+
+echo "==> Certify damage-resolver and write content-bound record"
+dotnet run --project "${ROOT}/tools/Nexo.ExportCertifiedBrick/ExportCertifiedBrick.csproj" -- \
+  "${RECORD_PATH}" "${ARTIFACT_DIR}"
+
+echo "==> Pack certified brick artifact"
+pack samples/certified-brick-reuse/Nexo.Certified.DamageResolver/Nexo.Certified.DamageResolver.csproj
+
+echo "==> Feed ready at ${FEED}"
+ls -la "${FEED}"

--- a/src/Nexo.Certification.Contracts/BrickContentHasher.cs
+++ b/src/Nexo.Certification.Contracts/BrickContentHasher.cs
@@ -1,0 +1,24 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nexo.Certification.Contracts;
+
+/// <summary>
+/// Canonical SHA-256 content hash for brick source bound into certification records.
+/// </summary>
+public static class BrickContentHasher
+{
+    public static string ComputeSha256(string canonicalSource)
+    {
+        if (string.IsNullOrEmpty(canonicalSource))
+            throw new ArgumentException("Canonical source is required.", nameof(canonicalSource));
+        var bytes = Encoding.UTF8.GetBytes(canonicalSource);
+#if NET5_0_OR_GREATER
+        var hash = SHA256.HashData(bytes);
+#else
+        using var sha = SHA256.Create();
+        var hash = sha.ComputeHash(bytes);
+#endif
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/src/Nexo.Certification.Contracts/CertificationRecordData.cs
+++ b/src/Nexo.Certification.Contracts/CertificationRecordData.cs
@@ -1,9 +1,9 @@
-namespace Nexo.Core.Application.Certification.Models;
+namespace Nexo.Certification.Contracts;
 
 /// <summary>
-/// Signed certification admission record emitted on ADMIT.
+/// Portable certification record for external consumers (JSON sidecar).
 /// </summary>
-public sealed record CertificationRecord
+public sealed record CertificationRecordData
 {
     public required string Status { get; init; }
     public required string Stage { get; init; }

--- a/src/Nexo.Certification.Contracts/CertificationRecordSigning.cs
+++ b/src/Nexo.Certification.Contracts/CertificationRecordSigning.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Nexo.Certification.Contracts;
+
+/// <summary>
+/// Canonical HMAC signing for certification records (shared by gate and external verifier).
+/// </summary>
+public static class CertificationRecordSigning
+{
+    public const string DefaultDevKey = "nexo-cert-dev-hmac-v0";
+
+    public static string Sign(CertificationRecordData record, string? hmacKey = null)
+    {
+        var payload = BuildPayload(record);
+        var keyBytes = Encoding.UTF8.GetBytes(ResolveKey(hmacKey));
+        using var hmac = new HMACSHA256(keyBytes);
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToBase64String(hash);
+    }
+
+    public static bool VerifySignature(CertificationRecordData record, string? hmacKey = null)
+    {
+        if (string.IsNullOrWhiteSpace(record.Signature))
+            return false;
+
+        try
+        {
+            var expected = Sign(record with { Signature = null }, hmacKey);
+            return FixedTimeEquals(
+                Convert.FromBase64String(record.Signature),
+                Convert.FromBase64String(expected));
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool FixedTimeEquals(byte[] left, byte[] right)
+    {
+#if NET5_0_OR_GREATER
+        return CryptographicOperations.FixedTimeEquals(left, right);
+#else
+        if (left.Length != right.Length)
+            return false;
+        var diff = 0;
+        for (var i = 0; i < left.Length; i++)
+            diff |= left[i] ^ right[i];
+        return diff == 0;
+#endif
+    }
+
+    public static string BuildPayload(CertificationRecordData record)
+    {
+        var clone = new
+        {
+            record.Status,
+            record.Stage,
+            record.Admitted,
+            record.Signed,
+            Timestamp = record.Timestamp.UtcDateTime.ToString("O"),
+            record.BrickId,
+            record.ContentHash,
+            record.EscapeRate,
+            record.TotalMutants,
+            record.SurvivingMutants,
+            KilledMutants = record.KilledMutants.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+            SurvivingMutantIds = record.SurvivingMutantIds.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+            record.Reason
+        };
+        return JsonSerializer.Serialize(clone, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    }
+
+    private static string ResolveKey(string? hmacKey)
+    {
+        if (!string.IsNullOrWhiteSpace(hmacKey))
+            return hmacKey!;
+        return Environment.GetEnvironmentVariable("NEXO_CERT_DEV_HMAC_KEY") ?? DefaultDevKey;
+    }
+}

--- a/src/Nexo.Certification.Contracts/CertificationTrustVerifier.cs
+++ b/src/Nexo.Certification.Contracts/CertificationTrustVerifier.cs
@@ -1,0 +1,40 @@
+namespace Nexo.Certification.Contracts;
+
+/// <summary>
+/// External consumer verifier: signature + content binding. No gate or generator required.
+/// </summary>
+public static class CertificationTrustVerifier
+{
+    public static CertificationTrustResult Verify(
+        CertificationRecordData record,
+        string brickSource,
+        string? hmacKey = null)
+    {
+        if (!record.Admitted || !string.Equals(record.Status, "PASS", StringComparison.Ordinal))
+            return Untrusted("record-not-admitted", "Certification record is not an admitted PASS.");
+
+        if (!record.Signed)
+            return Untrusted("record-unsigned", "Certification record is not signed.");
+
+        if (string.IsNullOrWhiteSpace(record.ContentHash))
+            return Untrusted("content-hash-missing", "Certification record has no content hash.");
+
+        if (!CertificationRecordSigning.VerifySignature(record, hmacKey))
+            return Untrusted("signature-invalid", "Certification record signature is invalid.");
+
+        var actualHash = BrickContentHasher.ComputeSha256(brickSource);
+        if (!string.Equals(actualHash, record.ContentHash, StringComparison.Ordinal))
+        {
+            return Untrusted(
+                "content-hash-mismatch",
+                $"Brick source hash does not match certified content (expected {record.ContentHash}, got {actualHash}).");
+        }
+
+        return new CertificationTrustResult(true, null, null);
+    }
+
+    private static CertificationTrustResult Untrusted(string code, string reason) =>
+        new(false, code, reason);
+}
+
+public sealed record CertificationTrustResult(bool Trusted, string? FailureCode, string? Reason);

--- a/src/Nexo.Certification.Contracts/Nexo.Certification.Contracts.csproj
+++ b/src/Nexo.Certification.Contracts/Nexo.Certification.Contracts.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>Nexo.Certification.Contracts</PackageId>
+    <Title>Nexo Certification Contracts</Title>
+    <Description>Content-bound certification record verification for external brick consumers.</Description>
+    <PackageTags>nexo;certification;bricks;trust</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nexo.Infrastructure/Certification/BrickCertificationProjectLoader.cs
+++ b/src/Nexo.Infrastructure/Certification/BrickCertificationProjectLoader.cs
@@ -125,6 +125,7 @@ public static class BrickCertificationProjectLoader
     private static object FromJsonElement(JsonElement element) => element.ValueKind switch
     {
         JsonValueKind.String => element.GetString()!,
+        JsonValueKind.Number when element.TryGetInt32(out var int32) => int32,
         JsonValueKind.Number when element.TryGetInt64(out var number) => number,
         JsonValueKind.Number => element.GetDouble(),
         JsonValueKind.True => true,

--- a/src/Nexo.Infrastructure/Certification/CertificationGate.cs
+++ b/src/Nexo.Infrastructure/Certification/CertificationGate.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nexo.Certification.Contracts;
 using Nexo.Core.Application.Certification.Models;
 using Nexo.Core.Application.Certification.Ports;
 
@@ -25,6 +26,8 @@ public sealed class CertificationGate : ICertificationGate
         var brickId = request.Brick.Id;
         var timestamp = DateTimeOffset.UtcNow;
 
+        var contentHash = BrickContentHasher.ComputeSha256(request.SourceCode);
+
         CertificationRecord Fail(string check, string reason, MutationTestResult? mutation = null) =>
             BuildRecord(
                 admitted: false,
@@ -32,6 +35,7 @@ public sealed class CertificationGate : ICertificationGate
                 status: "FAIL",
                 brickId,
                 timestamp,
+                contentHash,
                 reason,
                 mutation);
 
@@ -121,6 +125,7 @@ public sealed class CertificationGate : ICertificationGate
             status: "PASS",
             brickId,
             timestamp,
+            contentHash,
             reason: null,
             mutation: mutationResult);
         admittedRecord = admittedRecord with { Signature = _signer.Sign(admittedRecord) };
@@ -139,6 +144,7 @@ public sealed class CertificationGate : ICertificationGate
         string status,
         string brickId,
         DateTimeOffset timestamp,
+        string contentHash,
         string? reason,
         MutationTestResult? mutation)
     {
@@ -150,6 +156,7 @@ public sealed class CertificationGate : ICertificationGate
             Signed = signed,
             Timestamp = timestamp,
             BrickId = brickId,
+            ContentHash = contentHash,
             EscapeRate = mutation?.EscapeRate ?? 0,
             TotalMutants = mutation?.TotalMutants ?? 0,
             SurvivingMutants = mutation?.SurvivingMutantIds.Count ?? 0,

--- a/src/Nexo.Infrastructure/Certification/CertificationRecordMapper.cs
+++ b/src/Nexo.Infrastructure/Certification/CertificationRecordMapper.cs
@@ -1,0 +1,26 @@
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Certification.Contracts;
+
+namespace Nexo.Infrastructure.Certification;
+
+public static class CertificationRecordMapper
+{
+    public static CertificationRecordData ToData(CertificationRecord record) => new()
+    {
+        Status = record.Status,
+        Stage = record.Stage,
+        Admitted = record.Admitted,
+        Signed = record.Signed,
+        Timestamp = record.Timestamp,
+        BrickId = record.BrickId,
+        ContentHash = record.ContentHash,
+        EscapeRate = record.EscapeRate,
+        TotalMutants = record.TotalMutants,
+        SurvivingMutants = record.SurvivingMutants,
+        KilledMutants = record.KilledMutants,
+        SurvivingMutantIds = record.SurvivingMutantIds,
+        Signature = record.Signature,
+        Reason = record.Reason,
+        Gate = record.Gate
+    };
+}

--- a/src/Nexo.Infrastructure/Certification/CertificationRecordSigner.cs
+++ b/src/Nexo.Infrastructure/Certification/CertificationRecordSigner.cs
@@ -1,7 +1,5 @@
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
 using Nexo.Core.Application.Certification.Models;
+using Nexo.Certification.Contracts;
 
 namespace Nexo.Infrastructure.Certification;
 
@@ -10,61 +8,20 @@ namespace Nexo.Infrastructure.Certification;
 /// </summary>
 public sealed class CertificationRecordSigner
 {
-    public const string DefaultDevKey = "nexo-cert-dev-hmac-v0";
+    public const string DefaultDevKey = CertificationRecordSigning.DefaultDevKey;
 
-    private readonly byte[] _keyBytes;
+    private readonly string? _hmacKey;
 
     public CertificationRecordSigner(string? hmacKey = null)
     {
-        var key = string.IsNullOrWhiteSpace(hmacKey)
-            ? Environment.GetEnvironmentVariable("NEXO_CERT_DEV_HMAC_KEY") ?? DefaultDevKey
+        _hmacKey = string.IsNullOrWhiteSpace(hmacKey)
+            ? Environment.GetEnvironmentVariable("NEXO_CERT_DEV_HMAC_KEY")
             : hmacKey;
-        _keyBytes = Encoding.UTF8.GetBytes(key);
     }
 
-    public string Sign(CertificationRecord record)
-    {
-        var payload = BuildPayload(record);
-        using var hmac = new HMACSHA256(_keyBytes);
-        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
-        return Convert.ToBase64String(hash);
-    }
+    public string Sign(CertificationRecord record) =>
+        CertificationRecordSigning.Sign(CertificationRecordMapper.ToData(record), _hmacKey);
 
-    public bool Verify(CertificationRecord record)
-    {
-        if (string.IsNullOrWhiteSpace(record.Signature))
-            return false;
-
-        try
-        {
-            var expected = Sign(record with { Signature = null });
-            return CryptographicOperations.FixedTimeEquals(
-                Convert.FromBase64String(record.Signature),
-                Convert.FromBase64String(expected));
-        }
-        catch (FormatException)
-        {
-            return false;
-        }
-    }
-
-    private static string BuildPayload(CertificationRecord record)
-    {
-        var clone = new
-        {
-            record.Status,
-            record.Stage,
-            record.Admitted,
-            record.Signed,
-            Timestamp = record.Timestamp.UtcDateTime.ToString("O"),
-            record.BrickId,
-            record.EscapeRate,
-            record.TotalMutants,
-            record.SurvivingMutants,
-            KilledMutants = record.KilledMutants.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
-            SurvivingMutantIds = record.SurvivingMutantIds.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
-            record.Reason
-        };
-        return JsonSerializer.Serialize(clone, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-    }
+    public bool Verify(CertificationRecord record) =>
+        CertificationRecordSigning.VerifySignature(CertificationRecordMapper.ToData(record), _hmacKey);
 }

--- a/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+++ b/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Brick.Contracts\Nexo.Brick.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.Core.Domain\Nexo.Core.Domain.csproj" />

--- a/src/Nexo.Tests.Infrastructure/Certification/Reuse/CertifiedBrickCompiler.cs
+++ b/src/Nexo.Tests.Infrastructure/Certification/Reuse/CertifiedBrickCompiler.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+using Nexo.Infrastructure.Testing.CodeAnalysis;
+
+namespace Nexo.Tests.Infrastructure.Certification.Reuse;
+
+/// <summary>
+/// Minimal Roslyn loader for untouched certified brick source (consumer-side, not the cert gate).
+/// </summary>
+internal static class CertifiedBrickCompiler
+{
+    public static Brick InstantiateBrick(string source, string brickTypeName)
+    {
+        var assemblyName = $"CertifiedBrick_{Guid.NewGuid():N}";
+        var outputPath = Path.Combine(Path.GetTempPath(), $"{assemblyName}.dll");
+        var references = new List<string>
+        {
+            typeof(Brick).Assembly.Location,
+            typeof(BrickInput).Assembly.Location
+        };
+
+        var compiler = new RoslynCodeAnalysisService(NullLogger<RoslynCodeAnalysisService>.Instance);
+        var compile = compiler.CompileAsync(
+            WrapForRoslynCompile(source),
+            assemblyName,
+            outputPath,
+            references).GetAwaiter().GetResult();
+
+        if (!compile.Success || string.IsNullOrWhiteSpace(compile.AssemblyPath))
+        {
+            throw new InvalidOperationException(
+                $"Brick compilation failed: {string.Join("; ", compile.Errors)}");
+        }
+
+        var assemblyBytes = File.ReadAllBytes(compile.AssemblyPath);
+        var assembly = Assembly.Load(assemblyBytes);
+        var type = assembly.GetType(brickTypeName, throwOnError: true)
+            ?? throw new InvalidOperationException($"Type {brickTypeName} not found in certified brick assembly.");
+        return (Brick)Activator.CreateInstance(type)!;
+    }
+
+    private static string WrapForRoslynCompile(string sourceCode) =>
+        """
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+""" + sourceCode;
+}

--- a/src/Nexo.Tests.Infrastructure/Certification/Reuse/ProjectBAuditExecutionContext.cs
+++ b/src/Nexo.Tests.Infrastructure/Certification/Reuse/ProjectBAuditExecutionContext.cs
@@ -1,0 +1,13 @@
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.Tests.Infrastructure.Certification.Reuse;
+
+internal sealed class ProjectBAuditExecutionContext : IExecutionContext
+{
+    public string AgentId { get; } = "project-b";
+    public string BehaviorId { get; } = "certified-brick-smoke";
+    public bool IsAirGapped { get; } = true;
+    public bool AuditMode { get; } = true;
+    public string Provider { get; } = "deterministic";
+    public IReadOnlyDictionary<string, object> Variables { get; } = new Dictionary<string, object>();
+}

--- a/src/Nexo.Tests.Infrastructure/Certification/Reuse/ProjectBTrustConsumer.cs
+++ b/src/Nexo.Tests.Infrastructure/Certification/Reuse/ProjectBTrustConsumer.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Nexo.Certification.Contracts;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Domain.Bricks;
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.Tests.Infrastructure.Certification.Reuse;
+
+/// <summary>
+/// Project B consumer surface: verifier + untouched brick execution only (no gate, no generator).
+/// </summary>
+public static class ProjectBTrustConsumer
+{
+    public static CertificationTrustResult VerifyArtifact(string brickSource, CertificationRecordData record) =>
+        CertificationTrustVerifier.Verify(record, brickSource);
+
+    public static async Task<int> ExecuteDamageResolverSmokeAsync(
+        string brickSource,
+        string brickTypeName = "GeneratedBricks.DamageResolverBrick")
+    {
+        var brick = CertifiedBrickCompiler.InstantiateBrick(brickSource, brickTypeName);
+        var input = new Nexo.Core.Domain.Execution.BrickInput(new Dictionary<string, object>
+        {
+            ["baseDamage"] = 50,
+            ["critMultiplierPercent"] = 100,
+            ["armor"] = 10,
+            ["isCrit"] = false
+        });
+
+        var output = await brick.ExecuteAsync(
+            input,
+            ImplementationType.Deterministic,
+            new ProjectBAuditExecutionContext()).ConfigureAwait(false);
+
+        return output.Get<int>("finalDamage");
+    }
+
+    public static CertificationRecordData LoadRecord(string json) =>
+        JsonSerializer.Deserialize<CertificationRecordData>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+        ?? throw new InvalidOperationException("Failed to deserialize certification record.");
+
+    public static CertificationRecordData FromInternalRecord(CertificationRecord record) => new()
+    {
+        Status = record.Status,
+        Stage = record.Stage,
+        Admitted = record.Admitted,
+        Signed = record.Signed,
+        Timestamp = record.Timestamp,
+        BrickId = record.BrickId,
+        ContentHash = record.ContentHash,
+        EscapeRate = record.EscapeRate,
+        TotalMutants = record.TotalMutants,
+        SurvivingMutants = record.SurvivingMutants,
+        KilledMutants = record.KilledMutants,
+        SurvivingMutantIds = record.SurvivingMutantIds,
+        Signature = record.Signature,
+        Reason = record.Reason,
+        Gate = record.Gate
+    };
+
+    public static void AssertProjectBProjectHasNoGateOrGeneratorReferences(string projectBcsprojPath)
+    {
+        var text = File.ReadAllText(projectBcsprojPath);
+        if (text.Contains("Nexo.Infrastructure", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Project B must not reference Nexo.Infrastructure.");
+        if (text.Contains("Adaptation.Generation", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Project B must not reference the generator.");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Certification/Reuse/RepoPaths.cs
+++ b/src/Nexo.Tests.Infrastructure/Certification/Reuse/RepoPaths.cs
@@ -1,0 +1,17 @@
+namespace Nexo.Tests.Infrastructure.Certification.Reuse;
+
+internal static class RepoPaths
+{
+    public static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Nexo.sln")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root (Nexo.sln).");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
+++ b/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Abstractions\Nexo.Abstractions.csproj" />
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.Tests.Contracts\Nexo.Tests.Contracts.csproj" />

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CertificationGateTeethTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CertificationGateTeethTests.cs
@@ -69,6 +69,7 @@ public sealed class CertificationGateTeethTests
         decision.Record.EscapeRate.Should().Be(0);
         decision.Record.Signed.Should().BeTrue();
         decision.Record.Signature.Should().NotBeNullOrWhiteSpace();
+        decision.Record.ContentHash.Should().NotBeNullOrWhiteSpace();
         new CertificationRecordSigner().Verify(decision.Record).Should().BeTrue();
     }
 

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CrossProjectReuseTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CrossProjectReuseTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Nexo.Core.Application.Adaptation.Models;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Infrastructure.Adaptation;
+using Nexo.Infrastructure.Adaptation.Generation;
+using Nexo.Infrastructure.Certification;
+using Nexo.Tests.Infrastructure.Certification.Dogfood;
+using Nexo.Tests.Infrastructure.Certification.Reuse;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class CrossProjectReuseTests
+{
+    private static readonly IntentSpec DamageResolverIntent = new(
+        CursorGeneratorModel.DamageResolverIntentId,
+        "Given baseDamage, critMultiplierPercent, armor, and isCrit, compute final damage.",
+        BrickId: CursorGeneratorModel.DamageResolverIntentId,
+        Name: "Damage Resolver");
+
+    [Fact]
+    public async Task HonestCertifiedBrick_ProjectB_TrustsAndRunsUntouched()
+    {
+        var projectBcsproj = Path.Combine(
+            RepoPaths.FindRepoRoot(),
+            "samples", "certified-brick-reuse", "ProjectB", "ProjectB.csproj");
+        ProjectBTrustConsumer.AssertProjectBProjectHasNoGateOrGeneratorReferences(projectBcsproj);
+
+        var artifact = await ProjectACertifiesDamageResolverAsync();
+        var record = ProjectBTrustConsumer.FromInternalRecord(artifact.Record);
+
+        var trust = ProjectBTrustConsumer.VerifyArtifact(artifact.SourceCode, record);
+        trust.Trusted.Should().BeTrue($"expected TRUSTED, got {trust.FailureCode}: {trust.Reason}");
+        record.ContentHash.Should().NotBeNullOrWhiteSpace();
+
+        var finalDamage = await ProjectBTrustConsumer.ExecuteDamageResolverSmokeAsync(
+            artifact.SourceCode,
+            artifact.BrickTypeName!);
+        finalDamage.Should().Be(40);
+    }
+
+    [Fact]
+    public async Task TamperedBrick_ProjectB_RejectsContentHashMismatch()
+    {
+        var artifact = await ProjectACertifiesDamageResolverAsync();
+        var record = ProjectBTrustConsumer.FromInternalRecord(artifact.Record);
+        var tamperedSource = artifact.SourceCode.Replace("Math.Max(0, raw - armor)", "Math.Max(0, raw - armor + 1)");
+
+        var trust = ProjectBTrustConsumer.VerifyArtifact(tamperedSource, record);
+        trust.Trusted.Should().BeFalse("tampered brick must not be trusted");
+        trust.FailureCode.Should().Be("content-hash-mismatch");
+    }
+
+    [Fact]
+    public async Task ForgedSignature_ProjectB_Rejects()
+    {
+        var artifact = await ProjectACertifiesDamageResolverAsync();
+        var record = ProjectBTrustConsumer.FromInternalRecord(artifact.Record) with
+        {
+            Signature = Convert.ToBase64String(new byte[32])
+        };
+
+        var trust = ProjectBTrustConsumer.VerifyArtifact(artifact.SourceCode, record);
+        trust.Trusted.Should().BeFalse("forged signature must not be trusted");
+        trust.FailureCode.Should().Be("signature-invalid");
+    }
+
+    private static async Task<CertifiedArtifact> ProjectACertifiesDamageResolverAsync()
+    {
+        Environment.SetEnvironmentVariable("NEXO_CERT_NUGET_CONFIG", null);
+        var store = new InMemoryCertificationRecordStore();
+        var signer = new CertificationRecordSigner();
+        var registry = new CertifiedBrickRegistry(store, signer);
+        var gate = new CertificationGate(signer);
+        var admission = new CertifiedBrickAdmission(gate, registry);
+        var generator = new NewBrickGenerator(new CursorGeneratorModel { Variant = "honest" });
+        var service = new GenerateAndCertifyService(generator, admission);
+
+        var witness = DamageResolverDogfoodWitness.Spec;
+        var signature = Nexo.Core.Application.Adaptation.WitnessSignatureBuilder.FromWitness(witness);
+        var manifest = await generator.GenerateFromIntentAsync(DamageResolverIntent, signature).ConfigureAwait(false);
+        var built = await GeneratedBrickBuilder.BuildAsync(manifest).ConfigureAwait(false);
+
+        var decision = await admission.CertifyAndAdmitAsync(new CertificationRequest
+        {
+            Brick = built.Brick,
+            Witness = witness,
+            SourceCode = built.SourceCode,
+            ProjectPath = built.ProjectPath,
+            CompilationReferences = built.CompilationReferences,
+            BrickTypeName = built.BrickTypeName
+        }).ConfigureAwait(false);
+
+        decision.Admitted.Should().BeTrue("project A must certify damage-resolver");
+        decision.Record.ContentHash.Should().NotBeNullOrWhiteSpace();
+
+        return new CertifiedArtifact(built.SourceCode, decision.Record, built.BrickTypeName);
+    }
+
+    private sealed record CertifiedArtifact(string SourceCode, CertificationRecord Record, string? BrickTypeName);
+}

--- a/tools/Nexo.ExportCertifiedBrick/ExportCertifiedBrick.csproj
+++ b/tools/Nexo.ExportCertifiedBrick/ExportCertifiedBrick.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Nexo.ExportCertifiedBrick</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Nexo.Infrastructure\Nexo.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Nexo.ExportCertifiedBrick/Program.cs
+++ b/tools/Nexo.ExportCertifiedBrick/Program.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using Nexo.Certification.Contracts;
+using Nexo.Infrastructure.Certification;
+
+if (args.Length < 2)
+{
+    Console.Error.WriteLine("Usage: ExportCertifiedBrick <output-record.json> <brick-project-dir> [witness.json]");
+    return 1;
+}
+
+var recordPath = Path.GetFullPath(args[0]);
+var brickDir = Path.GetFullPath(args[1]);
+var witnessPath = args.Length > 2
+    ? Path.GetFullPath(args[2])
+    : Path.Combine(brickDir, "damage-resolver.witness.json");
+
+Environment.SetEnvironmentVariable("NEXO_CERT_NUGET_CONFIG", null);
+
+var request = await BrickCertificationProjectLoader.LoadAsync(brickDir, witnessPath).ConfigureAwait(false);
+var gate = new CertificationGate(new CertificationRecordSigner());
+var decision = await gate.CertifyAsync(request).ConfigureAwait(false);
+
+if (!decision.Admitted)
+{
+    Console.Error.WriteLine($"Certification failed: {decision.FailureCheck} {decision.Record.Reason}");
+    return 2;
+}
+
+var data = CertificationRecordMapper.ToData(decision.Record);
+var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+Directory.CreateDirectory(Path.GetDirectoryName(recordPath)!);
+await File.WriteAllTextAsync(recordPath, json).ConfigureAwait(false);
+
+var verify = CertificationTrustVerifier.Verify(data, request.SourceCode);
+if (!verify.Trusted)
+{
+    Console.Error.WriteLine($"Post-export verify failed: {verify.FailureCode} {verify.Reason}");
+    return 3;
+}
+
+Console.WriteLine($"Wrote content-bound record to {recordPath}");
+Console.WriteLine($"contentHash={data.ContentHash}");
+return 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2: content-bound certification records and cross-project brick reuse. A brick certified in project A can be consumed **untouched** in project B via signature + content-hash verification — no regeneration, no re-certification.

## Changes

- **`ContentHash`** on `CertificationRecord` — SHA-256 of canonical UTF-8 brick source, included in signed HMAC payload
- **`Nexo.Certification.Contracts`** — public `CertificationTrustVerifier` (signature + content binding) for external consumers
- **Packable artifact** — `Nexo.Certified.DamageResolver` + `certification-record.json` sidecar (`scripts/pack-certified-brick-reuse.sh`)
- **Project B** — `samples/certified-brick-reuse/ProjectB` references only verifier + brick artifact (no gate/generator)
- **`CrossProjectReuseTests`** (3) — trusted reuse PASS, tamper REJECT, forged sig REJECT

## Proof (local cert-gate)

```
trusted-reuse=PASS, tamper-reject=PASS, forged-sig-reject=PASS, tests_reported=24
```

Evidence: [Phase 2: cross-project reuse](docs/certification-evidence.md#phase-2-cross-project-reuse)

**v0 trust:** same-owner reuse via shared dev HMAC key. Cross-org PKI out of scope.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

