### PR TITLE
feat(compose): agent-composer proposer seam + propose→certify loop (P3-S1)

### DIFF
--- a/docs/certification-evidence.md
+++ b/docs/certification-evidence.md
@@ -142,6 +142,22 @@ Pack/export: `scripts/pack-certified-brick-reuse.sh` → local feed + `certifica
 
 **v0 trust model:** same-owner cross-project reuse via shared dev HMAC key (`NEXO_CERT_DEV_HMAC_KEY`). Cross-organization trust requires PKI (out of scope).
 
+## Agent-composer: propose→certify loop (P3-S1)
+
+bad-proposals=REJECT (all variants), correct-proposal=ADMIT, independence=PASS, tests_reported=33
+
+| Proof | Result |
+|-------|--------|
+| `BadProposalVariants_AreRejectedByExistingGate` (5 variants) | **REJECT** — `correctness` \| `mutation` \| `seam` \| `constituents` via unchanged `CompositionCertificationGate` |
+| `TamperedConstituentCert_RejectedByConstituentIntegrity` | **REJECT** — `constituents` (atom cert does not verify) |
+| `CorrectProposal_StrongWitness_Admits_WithZeroEscapeRate` | **ADMIT** — `composition_escape_rate=0`, signed |
+| `CorrectProposal_MatchesHandAuthoredCompositionResult` | **ADMIT** — same certified result as hand-authored `CompositionDogfoodFixtures.HonestSpec()` |
+| `ProposerInput_StructurallyCannotCarryWitnessCases` | **PASS** — `CompositionProposerInput` has no witness-bearing fields |
+
+**What this proves:** An untrusted proposer (`ICompositionProposer`) receives only target I/O signature + certified-brick catalog. Its wiring proposal traverses the **identical** composition admission gate as hand-authored specs — no agent bypass. Human witness remains in `CompositionDogfoodWitness.Spec`; the controlled proposer (`ControlledCompositionProposer`) is a deterministic CI double, not a real model.
+
+**v0 boundary:** Controlled proposer only; real LLM/agent proposer is the next sprint.
+
 ## Contract-stability gaps
 
 - Generated brick uses Nexo.Core.Domain.* namespaces (shipped via Nexo.Authoring/Nexo.Brick.Contracts but not the pinned package IDs)

--- a/docs/certification-evidence.md
+++ b/docs/certification-evidence.md
@@ -158,6 +158,8 @@ bad-proposals=REJECT (all variants), correct-proposal=ADMIT, independence=PASS, 
 
 **v0 boundary:** Controlled proposer only; real LLM/agent proposer is the next sprint.
 
+cert-gate CI: **success**, run [28000451847](https://github.com/IanFrelinger/Nexo/actions/runs/28000451847) — TRX `total="33" executed="33" passed="33"`; all 9 `CompositionProposer*` tests `outcome="Passed"` (check-runs API: `cert-gate` conclusion `success` @ `887686a1`).
+
 ## Contract-stability gaps
 
 - Generated brick uses Nexo.Core.Domain.* namespaces (shipped via Nexo.Authoring/Nexo.Brick.Contracts but not the pinned package IDs)

--- a/scripts/cert-gate-config.sh
+++ b/scripts/cert-gate-config.sh
@@ -13,6 +13,8 @@ readonly CERT_GATE_FILTER='FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Ce
 #   DamageResolverDogfoodTests: 2
 #   CompositionDogfoodTests: 2
 #   CrossProjectReuseTests: 3
+#   CompositionProposerDogfoodTests: 8
+#   CompositionProposerIndependenceTests: 1
 
 cert_gate_list_tests() {
   local root="${1:?repo root required}"

--- a/src/Nexo.Core.Application/Certification/CompositionProposerInputBuilder.cs
+++ b/src/Nexo.Core.Application/Certification/CompositionProposerInputBuilder.cs
@@ -1,0 +1,42 @@
+using Nexo.Core.Application.Adaptation.Models;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.Core.Application.Certification;
+
+/// <summary>
+/// Builds proposer input from a declared target spec and admitted certified bricks.
+/// Does not expose witness cases to the proposer.
+/// </summary>
+public static class CompositionProposerInputBuilder
+{
+    public static CompositionProposerInput FromTargetAndRegistry(
+        CompositionTargetSignature target,
+        IBrickRegistry brickRegistry,
+        ICertificationRecordStore certificationStore)
+    {
+        var catalog = new List<CertifiedBrickCatalogEntry>();
+
+        foreach (var brick in brickRegistry.GetAllBricks())
+        {
+            var record = certificationStore.Get(brick.Id);
+            if (record is null || !record.Admitted || !record.Signed)
+                continue;
+
+            catalog.Add(new CertifiedBrickCatalogEntry(
+                brick.Id,
+                brick.Interface.Inputs.Select(i => new WitnessIoField(i.Name, i.Type)).ToList(),
+                brick.Interface.Outputs.Select(o => new WitnessIoField(o.Name, o.Type)).ToList(),
+                AtomCertificationReference: FormatAtomCertRef(record)));
+        }
+
+        return new CompositionProposerInput(target, catalog);
+    }
+
+    public static CompositionTargetSignature TargetFromSpec(CompositionSpec spec) =>
+        new(spec.CompositionId, spec.Inputs, spec.Outputs);
+
+    private static string FormatAtomCertRef(CertificationRecord record) =>
+        $"{record.BrickId}@{record.Timestamp.UtcDateTime:O}";
+}

--- a/src/Nexo.Core.Application/Certification/Models/CompositionProposerModels.cs
+++ b/src/Nexo.Core.Application/Certification/Models/CompositionProposerModels.cs
@@ -1,0 +1,35 @@
+using Nexo.Core.Application.Adaptation.Models;
+
+namespace Nexo.Core.Application.Certification.Models;
+
+/// <summary>
+/// Target composition I/O contract — names and types only, no witness cases.
+/// </summary>
+public sealed record CompositionTargetSignature(
+    string CompositionId,
+    IReadOnlyList<CompositionPort> Inputs,
+    IReadOnlyList<CompositionPort> Outputs);
+
+/// <summary>
+/// A certified brick available for wiring. Carries atom-cert reference, not witness values.
+/// </summary>
+public sealed record CertifiedBrickCatalogEntry(
+    string BrickId,
+    IReadOnlyList<WitnessIoField> Inputs,
+    IReadOnlyList<WitnessIoField> Outputs,
+    string AtomCertificationReference);
+
+/// <summary>
+/// Untrusted proposer input: target signature + certified-brick catalog only.
+/// Structurally cannot carry witness cases (no field of witness-bearing types).
+/// </summary>
+public sealed record CompositionProposerInput(
+    CompositionTargetSignature Target,
+    IReadOnlyList<CertifiedBrickCatalogEntry> CertifiedBricks);
+
+/// <summary>
+/// Output of an untrusted composition proposer — wiring only, witness remains external.
+/// </summary>
+public sealed record ProposedComposition(
+    CompositionSpec Spec,
+    string Provenance);

--- a/src/Nexo.Core.Application/Certification/Ports/ICompositionProposer.cs
+++ b/src/Nexo.Core.Application/Certification/Ports/ICompositionProposer.cs
@@ -1,0 +1,13 @@
+using Nexo.Core.Application.Certification.Models;
+
+namespace Nexo.Core.Application.Certification.Ports;
+
+/// <summary>
+/// Untrusted composition proposer seam. Receives I/O signature + certified catalog only — never witness cases.
+/// </summary>
+public interface ICompositionProposer
+{
+    Task<ProposedComposition> ProposeAsync(
+        CompositionProposerInput input,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/Certification/Ports/IProposeAndCertifyCompositionService.cs
+++ b/src/Nexo.Core.Application/Certification/Ports/IProposeAndCertifyCompositionService.cs
@@ -1,0 +1,19 @@
+using Nexo.Core.Application.Certification.Models;
+
+namespace Nexo.Core.Application.Certification.Ports;
+
+public sealed record ProposeCertifyCompositionResult(
+    ProposedComposition Proposal,
+    CompositionCertificationDecision Decision);
+
+/// <summary>
+/// Propose→certify loop: untrusted proposer output traverses the existing composition gate unchanged.
+/// </summary>
+public interface IProposeAndCertifyCompositionService
+{
+    Task<ProposeCertifyCompositionResult> ProposeCertifyAndAdmitAsync(
+        CompositionProposerInput proposerInput,
+        CompositionWitnessSpec witness,
+        string? wiringMetadata = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Infrastructure/Certification/Composition/ControlledCompositionProposer.cs
+++ b/src/Nexo.Infrastructure/Certification/Composition/ControlledCompositionProposer.cs
@@ -1,0 +1,41 @@
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+
+namespace Nexo.Infrastructure.Certification.Composition;
+
+/// <summary>
+/// <strong>TEST DOUBLE</strong> — deterministic stand-in for an untrusted agent composition proposer.
+/// Emits caller-specified wiring variants; never sees witness cases.
+/// </summary>
+public sealed class ControlledCompositionProposer : ICompositionProposer
+{
+    public const string CorrectVariant = "correct";
+    public const string ReorderedWiringVariant = "reordered-wiring";
+    public const string DroppedBrickVariant = "dropped-brick";
+    public const string TypeMismatchEdgeVariant = "type-mismatch-edge";
+    public const string HallucinatedDependencyVariant = "hallucinated-dependency";
+    public const string UncertifiedConstituentVariant = "uncertified-constituent";
+
+    /// <summary>correct | reordered-wiring | dropped-brick | type-mismatch-edge | hallucinated-dependency | uncertified-constituent</summary>
+    public string Variant { get; set; } = CorrectVariant;
+
+    public Task<ProposedComposition> ProposeAsync(
+        CompositionProposerInput input,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var spec = Variant switch
+        {
+            CorrectVariant => DamageHealthCompositionProposals.Correct(input.Target),
+            ReorderedWiringVariant => DamageHealthCompositionProposals.ReorderedWiring(input.Target),
+            DroppedBrickVariant => DamageHealthCompositionProposals.DroppedBrick(input.Target),
+            TypeMismatchEdgeVariant => DamageHealthCompositionProposals.TypeMismatchEdge(input.Target),
+            HallucinatedDependencyVariant => DamageHealthCompositionProposals.HallucinatedDependency(input.Target),
+            UncertifiedConstituentVariant => DamageHealthCompositionProposals.UncertifiedConstituent(input.Target),
+            _ => throw new NotSupportedException($"Controlled proposer has no variant '{Variant}'.")
+        };
+
+        return Task.FromResult(new ProposedComposition(spec, $"controlled-composition:{Variant}"));
+    }
+}

--- a/src/Nexo.Infrastructure/Certification/Composition/DamageHealthCompositionProposals.cs
+++ b/src/Nexo.Infrastructure/Certification/Composition/DamageHealthCompositionProposals.cs
@@ -1,0 +1,97 @@
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Infrastructure.Adaptation.Generation;
+
+namespace Nexo.Infrastructure.Certification.Composition;
+
+/// <summary>
+/// Deterministic damage→health composition proposals for controlled proposer variants.
+/// </summary>
+internal static class DamageHealthCompositionProposals
+{
+    public const string CompositionId = "damage-to-health-pipeline";
+    public const string DamageNodeId = "damage";
+    public const string HealthNodeId = "health";
+    public const string HallucinatedBrickId = "phantom-damage-aggregator";
+    public const string UncertifiedBrickId = "standby-healer";
+
+    public static CompositionSpec Correct(CompositionTargetSignature target) => new(
+        target.CompositionId,
+        [
+            new CompositionNode(DamageNodeId, CursorGeneratorModel.DamageResolverIntentId),
+            new CompositionNode(HealthNodeId, CursorGeneratorModel.HealthApplierIntentId)
+        ],
+        HonestEdges(),
+        target.Inputs,
+        target.Outputs);
+
+    /// <summary>Swaps brick assignments so health-applier runs on the damage node and vice versa.</summary>
+    public static CompositionSpec ReorderedWiring(CompositionTargetSignature target) =>
+        Correct(target) with
+        {
+            Nodes =
+            [
+                new CompositionNode(DamageNodeId, CursorGeneratorModel.HealthApplierIntentId),
+                new CompositionNode(HealthNodeId, CursorGeneratorModel.DamageResolverIntentId)
+            ]
+        };
+
+    public static CompositionSpec DroppedBrick(CompositionTargetSignature target) =>
+        new(
+            target.CompositionId,
+            [new CompositionNode(DamageNodeId, CursorGeneratorModel.DamageResolverIntentId)],
+            [
+                new CompositionEdge(CompositionGraphConstants.InputNodeId, "baseDamage", DamageNodeId, "baseDamage"),
+                new CompositionEdge(CompositionGraphConstants.InputNodeId, "critMultiplierPercent", DamageNodeId, "critMultiplierPercent"),
+                new CompositionEdge(CompositionGraphConstants.InputNodeId, "armor", DamageNodeId, "armor"),
+                new CompositionEdge(CompositionGraphConstants.InputNodeId, "isCrit", DamageNodeId, "isCrit"),
+                new CompositionEdge(DamageNodeId, "finalDamage", CompositionGraphConstants.OutputNodeId, "newHealth")
+            ],
+            target.Inputs,
+            target.Outputs);
+
+    public static CompositionSpec TypeMismatchEdge(CompositionTargetSignature target)
+    {
+        var edges = new List<CompositionEdge>(HonestEdges())
+        {
+            new CompositionEdge(DamageNodeId, "finalDamage", HealthNodeId, "currentHealth")
+        };
+        edges.RemoveAll(e =>
+            string.Equals(e.SourceNodeId, CompositionGraphConstants.InputNodeId, StringComparison.Ordinal)
+            && string.Equals(e.SourcePort, "currentHealth", StringComparison.Ordinal)
+            && string.Equals(e.TargetNodeId, HealthNodeId, StringComparison.Ordinal)
+            && string.Equals(e.TargetPort, "currentHealth", StringComparison.Ordinal));
+
+        return Correct(target) with { Edges = edges };
+    }
+
+    public static CompositionSpec HallucinatedDependency(CompositionTargetSignature target) =>
+        Correct(target) with
+        {
+            Nodes =
+            [
+                new CompositionNode(DamageNodeId, CursorGeneratorModel.DamageResolverIntentId),
+                new CompositionNode(HealthNodeId, HallucinatedBrickId)
+            ]
+        };
+
+    public static CompositionSpec UncertifiedConstituent(CompositionTargetSignature target) =>
+        Correct(target) with
+        {
+            Nodes =
+            [
+                new CompositionNode(DamageNodeId, CursorGeneratorModel.DamageResolverIntentId),
+                new CompositionNode(HealthNodeId, UncertifiedBrickId)
+            ]
+        };
+
+    private static IReadOnlyList<CompositionEdge> HonestEdges() =>
+    [
+        new CompositionEdge(CompositionGraphConstants.InputNodeId, "baseDamage", DamageNodeId, "baseDamage"),
+        new CompositionEdge(CompositionGraphConstants.InputNodeId, "critMultiplierPercent", DamageNodeId, "critMultiplierPercent"),
+        new CompositionEdge(CompositionGraphConstants.InputNodeId, "armor", DamageNodeId, "armor"),
+        new CompositionEdge(CompositionGraphConstants.InputNodeId, "isCrit", DamageNodeId, "isCrit"),
+        new CompositionEdge(CompositionGraphConstants.InputNodeId, "currentHealth", HealthNodeId, "currentHealth"),
+        new CompositionEdge(DamageNodeId, "finalDamage", HealthNodeId, "finalDamage"),
+        new CompositionEdge(HealthNodeId, "newHealth", CompositionGraphConstants.OutputNodeId, "newHealth")
+    ];
+}

--- a/src/Nexo.Infrastructure/Certification/Composition/ProposeAndCertifyCompositionService.cs
+++ b/src/Nexo.Infrastructure/Certification/Composition/ProposeAndCertifyCompositionService.cs
@@ -1,0 +1,40 @@
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+
+namespace Nexo.Infrastructure.Certification.Composition;
+
+/// <summary>
+/// Propose→certify loop. Proposals traverse the existing composition admission gate unchanged.
+/// </summary>
+public sealed class ProposeAndCertifyCompositionService : IProposeAndCertifyCompositionService
+{
+    private readonly ICompositionProposer _proposer;
+    private readonly ICertifiedCompositionAdmission _admission;
+
+    public ProposeAndCertifyCompositionService(
+        ICompositionProposer proposer,
+        ICertifiedCompositionAdmission admission)
+    {
+        _proposer = proposer ?? throw new ArgumentNullException(nameof(proposer));
+        _admission = admission ?? throw new ArgumentNullException(nameof(admission));
+    }
+
+    public async Task<ProposeCertifyCompositionResult> ProposeCertifyAndAdmitAsync(
+        CompositionProposerInput proposerInput,
+        CompositionWitnessSpec witness,
+        string? wiringMetadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        var proposal = await _proposer.ProposeAsync(proposerInput, cancellationToken).ConfigureAwait(false);
+
+        var request = new CompositionCertificationRequest
+        {
+            Spec = proposal.Spec with { CompositionId = witness.CompositionId },
+            Witness = witness,
+            WiringMetadata = wiringMetadata
+        };
+
+        var decision = await _admission.CertifyAndAdmitAsync(request, cancellationToken).ConfigureAwait(false);
+        return new ProposeCertifyCompositionResult(proposal, decision);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Certification/Dogfood/CompositionDogfoodHarness.cs
+++ b/src/Nexo.Tests.Infrastructure/Certification/Dogfood/CompositionDogfoodHarness.cs
@@ -1,0 +1,132 @@
+using Nexo.Core.Application.Adaptation.Models;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+using Nexo.Infrastructure.Adaptation;
+using Nexo.Infrastructure.Adaptation.Generation;
+using Nexo.Infrastructure.Certification;
+using Nexo.Infrastructure.Certification.Composition;
+using Nexo.Tests.Infrastructure.Certification.Dogfood;
+using Nexo.Tests.Infrastructure.Certification.Fixtures;
+
+namespace Nexo.Tests.Infrastructure.Certification.Dogfood;
+
+/// <summary>
+/// Shared harness: certifies damage-resolver + health-applier constituents and wires composition gate.
+/// </summary>
+public static class CompositionDogfoodHarness
+{
+    public static readonly IntentSpec DamageResolverIntent = new(
+        CursorGeneratorModel.DamageResolverIntentId,
+        "Given baseDamage, critMultiplierPercent, armor, and isCrit, compute final damage as crit-adjusted raw minus armor (floored at zero).",
+        BrickId: CursorGeneratorModel.DamageResolverIntentId,
+        Name: "Damage Resolver");
+
+    public static readonly IntentSpec HealthApplierIntent = new(
+        CursorGeneratorModel.HealthApplierIntentId,
+        "Given currentHealth and finalDamage, compute newHealth as max(0, currentHealth - finalDamage).",
+        BrickId: CursorGeneratorModel.HealthApplierIntentId,
+        Name: "Health Applier");
+
+    public static CompositionWitnessSpec RequireHumanWitness()
+    {
+        if (CompositionDogfoodWitness.Spec is null)
+            throw new InvalidOperationException("HUMAN-AUTHORED WITNESS: populate CompositionDogfoodWitness.Spec");
+
+        return CompositionDogfoodWitness.Spec;
+    }
+
+    public static async Task<CertifiedCompositionTestContext> CreateAdmittedContextAsync()
+    {
+        Environment.SetEnvironmentVariable("NEXO_CERT_NUGET_CONFIG", null);
+
+        var brickStore = new InMemoryCertificationRecordStore();
+        var brickSigner = new CertificationRecordSigner();
+        var brickRegistry = new CertifiedBrickRegistry(brickStore, brickSigner);
+        var brickGate = new CertificationGate(brickSigner);
+        var brickAdmission = new CertifiedBrickAdmission(brickGate, brickRegistry);
+        var generator = new NewBrickGenerator(new CursorGeneratorModel { Variant = "honest" });
+        var generateAndCertify = new GenerateAndCertifyService(generator, brickAdmission);
+
+        var damageResult = await generateAndCertify.GenerateCertifyAndAdmitAsync(
+            DamageResolverIntent,
+            DamageResolverDogfoodWitness.Spec).ConfigureAwait(false);
+
+        if (!damageResult.Decision.Admitted)
+        {
+            throw new InvalidOperationException(
+                $"Failed to admit damage-resolver: {damageResult.Decision.FailureCheck} {damageResult.Decision.Record.Reason}");
+        }
+
+        var healthResult = await generateAndCertify.GenerateCertifyAndAdmitAsync(
+            HealthApplierIntent,
+            HealthApplierConstituentWitness).ConfigureAwait(false);
+
+        if (!healthResult.Decision.Admitted)
+        {
+            throw new InvalidOperationException(
+                $"Failed to admit health-applier: {healthResult.Decision.FailureCheck} {healthResult.Decision.Record.Reason}");
+        }
+
+        var compositionStore = new InMemoryCompositionCertificationRecordStore();
+        var compositionSigner = new CompositionCertificationRecordSigner(brickSigner);
+        var compositionRegistry = new CertifiedCompositionRegistry(compositionStore, compositionSigner);
+        var compositionGate = new CompositionCertificationGate(
+            brickStore,
+            brickSigner,
+            brickRegistry,
+            compositionSigner);
+        var compositionAdmission = new CertifiedCompositionAdmission(compositionGate, compositionRegistry);
+
+        return new CertifiedCompositionTestContext(
+            brickStore,
+            brickSigner,
+            brickRegistry,
+            brickAdmission,
+            compositionStore,
+            compositionSigner,
+            compositionRegistry,
+            compositionGate,
+            compositionAdmission);
+    }
+
+    public static CompositionProposerInput BuildProposerInput(CertifiedCompositionTestContext ctx)
+    {
+        var target = Nexo.Core.Application.Certification.CompositionProposerInputBuilder.TargetFromSpec(
+            CompositionDogfoodFixtures.HonestSpec());
+        return Nexo.Core.Application.Certification.CompositionProposerInputBuilder.FromTargetAndRegistry(
+            target,
+            ctx.BrickRegistry,
+            ctx.BrickStore);
+    }
+
+    /// <summary>
+    /// Atom-level witness for health-applier constituent certification only — not the composition witness.
+    /// </summary>
+    public static readonly WitnessSpec HealthApplierConstituentWitness = new(
+        CursorGeneratorModel.HealthApplierIntentId,
+        [
+            new WitnessCase(
+                new Dictionary<string, object>
+                {
+                    ["currentHealth"] = 100,
+                    ["finalDamage"] = 30
+                },
+                new Dictionary<string, object> { ["newHealth"] = 70 }),
+
+            new WitnessCase(
+                new Dictionary<string, object>
+                {
+                    ["currentHealth"] = 50,
+                    ["finalDamage"] = 60
+                },
+                new Dictionary<string, object> { ["newHealth"] = 0 }),
+
+            new WitnessCase(
+                new Dictionary<string, object>
+                {
+                    ["currentHealth"] = 0,
+                    ["finalDamage"] = 10
+                },
+                new Dictionary<string, object> { ["newHealth"] = 0 })
+        ]);
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionDogfoodTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionDogfoodTests.cs
@@ -1,13 +1,6 @@
 using FluentAssertions;
-using Nexo.Core.Application.Adaptation.Models;
 using Nexo.Core.Application.Certification.Models;
-using Nexo.Core.Application.Certification.Ports;
-using Nexo.Infrastructure.Adaptation;
-using Nexo.Infrastructure.Adaptation.Generation;
-using Nexo.Infrastructure.Certification;
-using Nexo.Infrastructure.Certification.Composition;
 using Nexo.Tests.Infrastructure.Certification.Dogfood;
-using Nexo.Tests.Infrastructure.Certification.Fixtures;
 using Xunit;
 
 namespace Nexo.Tests.Infrastructure.Tests.Certification;
@@ -15,23 +8,11 @@ namespace Nexo.Tests.Infrastructure.Tests.Certification;
 [Trait("Category", "Certification")]
 public sealed class CompositionDogfoodTests
 {
-    private static readonly IntentSpec DamageResolverIntent = new(
-        CursorGeneratorModel.DamageResolverIntentId,
-        "Given baseDamage, critMultiplierPercent, armor, and isCrit, compute final damage as crit-adjusted raw minus armor (floored at zero).",
-        BrickId: CursorGeneratorModel.DamageResolverIntentId,
-        Name: "Damage Resolver");
-
-    private static readonly IntentSpec HealthApplierIntent = new(
-        CursorGeneratorModel.HealthApplierIntentId,
-        "Given currentHealth and finalDamage, compute newHealth as max(0, currentHealth - finalDamage).",
-        BrickId: CursorGeneratorModel.HealthApplierIntentId,
-        Name: "Health Applier");
-
     [Fact]
     public async Task HonestComposition_StrongWitness_Admits_WithZeroEscapeRate()
     {
-        var witness = RequireHumanWitness();
-        var ctx = await CreateAdmittedContextAsync();
+        var witness = CompositionDogfoodHarness.RequireHumanWitness();
+        var ctx = await CompositionDogfoodHarness.CreateAdmittedContextAsync();
 
         var decision = await ctx.CompositionAdmission.CertifyAndAdmitAsync(new CompositionCertificationRequest
         {
@@ -50,8 +31,8 @@ public sealed class CompositionDogfoodTests
     [Fact]
     public async Task BrokenComposition_StrongWitness_Rejects()
     {
-        var witness = RequireHumanWitness();
-        var ctx = await CreateAdmittedContextAsync();
+        var witness = CompositionDogfoodHarness.RequireHumanWitness();
+        var ctx = await CompositionDogfoodHarness.CreateAdmittedContextAsync();
 
         var decision = await ctx.CompositionGate.CertifyAsync(new CompositionCertificationRequest
         {
@@ -63,97 +44,4 @@ public sealed class CompositionDogfoodTests
         decision.Admitted.Should().BeFalse("broken composition wiring must not admit");
         decision.FailureCheck.Should().BeOneOf("seam", "correctness", "mutation");
     }
-
-    private static CompositionWitnessSpec RequireHumanWitness()
-    {
-        if (CompositionDogfoodWitness.Spec is null)
-            throw new InvalidOperationException("HUMAN-AUTHORED WITNESS: populate CompositionDogfoodWitness.Spec");
-
-        return CompositionDogfoodWitness.Spec;
-    }
-
-    private static async Task<CertifiedCompositionTestContext> CreateAdmittedContextAsync()
-    {
-        Environment.SetEnvironmentVariable("NEXO_CERT_NUGET_CONFIG", null);
-
-        var brickStore = new InMemoryCertificationRecordStore();
-        var brickSigner = new CertificationRecordSigner();
-        var brickRegistry = new CertifiedBrickRegistry(brickStore, brickSigner);
-        var brickGate = new CertificationGate(brickSigner);
-        var brickAdmission = new CertifiedBrickAdmission(brickGate, brickRegistry);
-        var generator = new NewBrickGenerator(new CursorGeneratorModel { Variant = "honest" });
-        var generateAndCertify = new GenerateAndCertifyService(generator, brickAdmission);
-
-        var damageResult = await generateAndCertify.GenerateCertifyAndAdmitAsync(
-            DamageResolverIntent,
-            DamageResolverDogfoodWitness.Spec).ConfigureAwait(false);
-
-        if (!damageResult.Decision.Admitted)
-        {
-            throw new InvalidOperationException(
-                $"Failed to admit damage-resolver: {damageResult.Decision.FailureCheck} {damageResult.Decision.Record.Reason}");
-        }
-
-        var healthResult = await generateAndCertify.GenerateCertifyAndAdmitAsync(
-            HealthApplierIntent,
-            HealthApplierConstituentWitness).ConfigureAwait(false);
-
-        if (!healthResult.Decision.Admitted)
-        {
-            throw new InvalidOperationException(
-                $"Failed to admit health-applier: {healthResult.Decision.FailureCheck} {healthResult.Decision.Record.Reason}");
-        }
-
-        var compositionStore = new InMemoryCompositionCertificationRecordStore();
-        var compositionSigner = new CompositionCertificationRecordSigner(brickSigner);
-        var compositionRegistry = new CertifiedCompositionRegistry(compositionStore, compositionSigner);
-        var compositionGate = new CompositionCertificationGate(
-            brickStore,
-            brickSigner,
-            brickRegistry,
-            compositionSigner);
-        var compositionAdmission = new CertifiedCompositionAdmission(compositionGate, compositionRegistry);
-
-        return new CertifiedCompositionTestContext(
-            brickStore,
-            brickSigner,
-            brickRegistry,
-            brickAdmission,
-            compositionStore,
-            compositionSigner,
-            compositionRegistry,
-            compositionGate,
-            compositionAdmission);
-    }
-
-    /// <summary>
-    /// Atom-level witness for health-applier constituent certification only — not the composition witness.
-    /// </summary>
-    private static readonly WitnessSpec HealthApplierConstituentWitness = new(
-        CursorGeneratorModel.HealthApplierIntentId,
-        [
-            new WitnessCase(
-                new Dictionary<string, object>
-                {
-                    ["currentHealth"] = 100,
-                    ["finalDamage"] = 30
-                },
-                new Dictionary<string, object> { ["newHealth"] = 70 }),
-
-            new WitnessCase(
-                new Dictionary<string, object>
-                {
-                    ["currentHealth"] = 50,
-                    ["finalDamage"] = 60
-                },
-                new Dictionary<string, object> { ["newHealth"] = 0 }),
-
-            new WitnessCase(
-                new Dictionary<string, object>
-                {
-                    ["currentHealth"] = 0,
-                    ["finalDamage"] = 10
-                },
-                new Dictionary<string, object> { ["newHealth"] = 0 })
-        ]);
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionProposerDogfoodTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionProposerDogfoodTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
 using Nexo.Infrastructure.Certification;
 using Nexo.Infrastructure.Certification.Composition;
 using Nexo.Tests.Infrastructure.Certification.Dogfood;
+using Nexo.Tests.Infrastructure.Certification.Fixtures;
 using Xunit;
 
 namespace Nexo.Tests.Infrastructure.Tests.Certification;
@@ -10,6 +12,54 @@ namespace Nexo.Tests.Infrastructure.Tests.Certification;
 [Trait("Category", "Certification")]
 public sealed class CompositionProposerDogfoodTests
 {
+    [Fact]
+    public async Task CorrectProposal_StrongWitness_Admits_WithZeroEscapeRate()
+    {
+        var witness = CompositionDogfoodHarness.RequireHumanWitness();
+        var ctx = await CompositionDogfoodHarness.CreateAdmittedContextAsync();
+        var proposerInput = CompositionDogfoodHarness.BuildProposerInput(ctx);
+        var service = CreateProposeCertifyService(ctx, ControlledCompositionProposer.CorrectVariant);
+
+        var result = await service.ProposeCertifyAndAdmitAsync(
+            proposerInput,
+            witness,
+            wiringMetadata: "composition-wiring-v0");
+
+        result.Decision.Admitted.Should().BeTrue(
+            $"expected ADMIT, got {result.Decision.FailureCheck}: {result.Decision.Record.Reason}");
+        result.Decision.Record.CompositionEscapeRate.Should().Be(0);
+        result.Decision.Record.Signed.Should().BeTrue();
+        result.Proposal.Provenance.Should().StartWith("controlled-composition:correct");
+        ctx.CompositionSigner.Verify(result.Decision.Record).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CorrectProposal_MatchesHandAuthoredCompositionResult()
+    {
+        var witness = CompositionDogfoodHarness.RequireHumanWitness();
+        var ctx = await CompositionDogfoodHarness.CreateAdmittedContextAsync();
+
+        var handDecision = await ctx.CompositionGate.CertifyAsync(new CompositionCertificationRequest
+        {
+            Spec = CompositionDogfoodFixtures.HonestSpec(),
+            Witness = witness,
+            WiringMetadata = "composition-wiring-v0"
+        });
+
+        var proposerInput = CompositionDogfoodHarness.BuildProposerInput(ctx);
+        var service = CreateProposeCertifyService(ctx, ControlledCompositionProposer.CorrectVariant);
+        var proposed = await service.ProposeCertifyAndAdmitAsync(
+            proposerInput,
+            witness,
+            wiringMetadata: "composition-wiring-v0");
+
+        handDecision.Admitted.Should().BeTrue();
+        proposed.Decision.Admitted.Should().BeTrue();
+        proposed.Decision.Record.CompositionEscapeRate.Should().Be(handDecision.Record.CompositionEscapeRate);
+        proposed.Decision.Record.Signed.Should().Be(handDecision.Record.Signed);
+        proposed.Decision.Record.CompositionId.Should().Be(handDecision.Record.CompositionId);
+    }
+
     [Theory]
     [InlineData(ControlledCompositionProposer.ReorderedWiringVariant, "correctness", "mutation", "seam")]
     [InlineData(ControlledCompositionProposer.DroppedBrickVariant, "correctness", "mutation", "seam")]
@@ -73,4 +123,11 @@ public sealed class CompositionProposerDogfoodTests
         decision.Admitted.Should().BeFalse();
         decision.FailureCheck.Should().Be("constituents");
     }
+
+    private static ProposeAndCertifyCompositionService CreateProposeCertifyService(
+        CertifiedCompositionTestContext ctx,
+        string variant) =>
+        new(
+            new ControlledCompositionProposer { Variant = variant },
+            ctx.CompositionAdmission);
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionProposerDogfoodTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionProposerDogfoodTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Infrastructure.Certification;
+using Nexo.Infrastructure.Certification.Composition;
+using Nexo.Tests.Infrastructure.Certification.Dogfood;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class CompositionProposerDogfoodTests
+{
+    [Theory]
+    [InlineData(ControlledCompositionProposer.ReorderedWiringVariant, "correctness", "mutation", "seam")]
+    [InlineData(ControlledCompositionProposer.DroppedBrickVariant, "correctness", "mutation", "seam")]
+    [InlineData(ControlledCompositionProposer.TypeMismatchEdgeVariant, "seam", "correctness")]
+    [InlineData(ControlledCompositionProposer.HallucinatedDependencyVariant, "constituents")]
+    [InlineData(ControlledCompositionProposer.UncertifiedConstituentVariant, "constituents")]
+    public async Task BadProposalVariants_AreRejectedByExistingGate(
+        string variant,
+        params string[] expectedFailureChecks)
+    {
+        var witness = CompositionDogfoodHarness.RequireHumanWitness();
+        var ctx = await CompositionDogfoodHarness.CreateAdmittedContextAsync();
+        var proposerInput = CompositionDogfoodHarness.BuildProposerInput(ctx);
+        var proposer = new ControlledCompositionProposer { Variant = variant };
+        var proposal = await proposer.ProposeAsync(proposerInput);
+
+        var decision = await ctx.CompositionGate.CertifyAsync(new CompositionCertificationRequest
+        {
+            Spec = proposal.Spec with { CompositionId = witness.CompositionId },
+            Witness = witness,
+            WiringMetadata = "composition-wiring-v0"
+        });
+
+        decision.Admitted.Should().BeFalse($"bad proposal variant '{variant}' must not admit");
+        decision.FailureCheck.Should().BeOneOf(expectedFailureChecks,
+            $"variant '{variant}' must fail via existing gate checks, not agent bypass");
+    }
+
+    [Fact]
+    public async Task TamperedConstituentCert_RejectedByConstituentIntegrity()
+    {
+        var witness = CompositionDogfoodHarness.RequireHumanWitness();
+        var ctx = await CompositionDogfoodHarness.CreateAdmittedContextAsync();
+
+        ctx.BrickStore.Save(new CertificationRecord
+        {
+            Status = "PASS",
+            Stage = "S0-S2",
+            Admitted = true,
+            Signed = true,
+            Timestamp = DateTimeOffset.UtcNow,
+            BrickId = DamageHealthCompositionProposals.UncertifiedBrickId,
+            ContentHash = "tampered",
+            Signature = Convert.ToBase64String(new byte[32])
+        });
+
+        var proposerInput = CompositionDogfoodHarness.BuildProposerInput(ctx);
+        var proposer = new ControlledCompositionProposer
+        {
+            Variant = ControlledCompositionProposer.UncertifiedConstituentVariant
+        };
+        var proposal = await proposer.ProposeAsync(proposerInput);
+
+        var decision = await ctx.CompositionGate.CertifyAsync(new CompositionCertificationRequest
+        {
+            Spec = proposal.Spec with { CompositionId = witness.CompositionId },
+            Witness = witness,
+            WiringMetadata = "composition-wiring-v0"
+        });
+
+        decision.Admitted.Should().BeFalse();
+        decision.FailureCheck.Should().Be("constituents");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionProposerIndependenceTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CompositionProposerIndependenceTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using FluentAssertions;
+using Nexo.Core.Application.Certification.Models;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class CompositionProposerIndependenceTests
+{
+    [Fact]
+    public void ProposerInput_StructurallyCannotCarryWitnessCases()
+    {
+        var forbidden = new HashSet<string>(StringComparer.Ordinal)
+        {
+            nameof(WitnessCase),
+            nameof(WitnessSpec),
+            nameof(CompositionWitnessSpec)
+        };
+
+        var violations = new List<string>();
+        ScanType(typeof(CompositionProposerInput), forbidden, violations, "CompositionProposerInput");
+
+        violations.Should().BeEmpty(
+            "proposer input must not contain witness-bearing fields: {0}",
+            string.Join(", ", violations));
+    }
+
+    private static void ScanType(
+        Type type,
+        IReadOnlySet<string> forbiddenTypeNames,
+        ICollection<string> violations,
+        string path)
+    {
+        if (forbiddenTypeNames.Contains(type.Name))
+        {
+            violations.Add(path);
+            return;
+        }
+
+        if (type.IsGenericType)
+        {
+            foreach (var arg in type.GetGenericArguments())
+                ScanType(arg, forbiddenTypeNames, violations, $"{path}<{arg.Name}>");
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            ScanType(property.PropertyType, forbiddenTypeNames, violations, $"{path}.{property.Name}");
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stands up the agent-composer **proposer seam** and **propose→certify loop**, proving an untrusted proposer's wiring output is gated by the **existing** `CompositionCertificationGate` with no agent-specific bypass.

Reuses the proven damage→health composition and its human-authored end-to-end witness (`CompositionDogfoodWitness.Spec`) as the fixed target spec.

## What changed

### Proposer seam (`feat`)
- `CompositionProposerInput` — target I/O signature + certified-brick catalog only (no witness fields)
- `ProposedComposition` — wiring output from untrusted proposer
- `ICompositionProposer` port + `CompositionProposerInputBuilder`

### Controlled proposer (`feat`)
- `ControlledCompositionProposer` — deterministic CI double emitting caller-specified variants
- `DamageHealthCompositionProposals` — correct wiring + 5 named bad-proposal variants

### Propose→certify loop (`feat`)
- `IProposeAndCertifyCompositionService` / `ProposeAndCertifyCompositionService` — propose then feed through unchanged `ICertifiedCompositionAdmission`

### Tests (`test`)
- **KEY rejection suite** — reordered wiring, dropped brick, type-mismatch edge, hallucinated dependency, uncertified/tampered constituent — each REJECTED by existing gate checks
- **Happy path** — correct proposal ADMITS with `composition_escape_rate=0` and matches hand-authored result
- **Independence** — reflection scan asserts `CompositionProposerInput` cannot carry witness cases

### Docs
- `docs/certification-evidence.md` — agent-composer evidence section + v0 boundary
- `scripts/cert-gate-config.sh` — test breakdown updated to 33 tests

## Constraints honored

- Proposer is **untrusted** — gated, not made trustworthy
- Oracle independence — proposer input has no witness-bearing fields (structural + test)
- Human owns spec + witness — reuses `CompositionDogfoodWitness.Spec`
- Same gate — proposals traverse identical composition admission path
- Constituent integrity — absent/tampered brick refs rejected at existing teeth

## cert-gate

Expected test count: **33** (24 prior + 9 new proposer tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

