### PR TITLE
feat(sx): enforce self-extend safety invariants A/B/C fail-closed

### DIFF
--- a/application/src/Nexo.CLI/Commands/BackgroundAgent/BackgroundAgentCommand.cs
+++ b/application/src/Nexo.CLI/Commands/BackgroundAgent/BackgroundAgentCommand.cs
@@ -321,7 +321,7 @@ public class BackgroundAgentCommand
                     var autoConfig = CloneForAutoscale(template, autoId);
                     var spec = _specBuilder.BuildSpec(autoConfig);
                     var agent = _agentFactory.CreateAgent(spec);
-                    await _registry.RegisterAsync(agent, autoConfig, ct);
+                    await _registry.RegisterAsync(agent, autoConfig, cancellationToken: ct);
                     await _registry.StartAsync(autoId, ct);
                     created.Add(autoId);
                     started.Add(autoId);
@@ -405,7 +405,7 @@ public class BackgroundAgentCommand
             ?? throw new InvalidOperationException($"Agent '{id}' not found in configuration");
         var spec = _specBuilder.BuildSpec(config);
         var agent = _agentFactory.CreateAgent(spec);
-        await _registry.RegisterAsync(agent, config, ct);
+        await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, ct);
     }
 
     public static int CalculateDesiredAgentCount(int demand, int minAgents, int maxAgents, int unitsPerAgent)

--- a/application/src/Nexo.CLI/Commands/BackgroundAgent/ExecuteBackgroundAgentCommand.cs
+++ b/application/src/Nexo.CLI/Commands/BackgroundAgent/ExecuteBackgroundAgentCommand.cs
@@ -75,6 +75,6 @@ public class ExecuteBackgroundAgentCommand
             ?? throw new InvalidOperationException($"Agent '{id}' not found in configuration");
         var spec = _specBuilder.BuildSpec(config);
         var agent = _agentFactory.CreateAgent(spec);
-        await _registry.RegisterAsync(agent, config, ct).ConfigureAwait(false);
+        await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, ct).ConfigureAwait(false);
     }
 }

--- a/docs/SELF-EXTEND-AUDIT.md
+++ b/docs/SELF-EXTEND-AUDIT.md
@@ -1,12 +1,12 @@
-# Self-Extend Safety Audit (SX-AUDIT)
+# Self-Extend Safety Audit (SX-AUDIT / SX-ENFORCE)
 
-**Sprint:** SX-AUDIT — characterize existing teeth; do **not** build new enforcement.  
-**Branch:** `cursor/self-extend-audit-6118`  
+**Sprint:** SX-AUDIT (characterize) + SX-ENFORCE (A/B/C teeth)  
+**Branch:** `cursor/self-extend-enforce-6118` (off `cursor/self-extend-audit-6118`)  
 **Scope:** Background-agent self-extend path only (not CLI `nexo self-extend`, not orchestration `LifecycleManager`).
 
 ## Purpose
 
-Trace the **executing** control flow for background extender agents and record whether four safety invariants are enforced today. A documented **GAP** is a successful audit outcome.
+Trace the **executing** control flow for background extender agents and record whether four safety invariants are enforced. Invariant **D** remains deferred.
 
 ## Control-flow trace
 
@@ -20,7 +20,9 @@ BackgroundAgentService.ExecuteAsync                    [BackgroundAgentService.c
          ├─ BackgroundAgentSpecBuilder.BuildSpec       [BackgroundAgentService.cs:123]
          ├─ AgentFactory.CreateAgent                   [BackgroundAgentService.cs:126]
          └─ BackgroundAgentRegistry.RegisterAsync       [BackgroundAgentService.cs:129]
-              └─ stores instance; no cert/policy gates [BackgroundAgentRegistry.cs:191–209]
+              ├─ AgentPolicyNarrowingValidator (B)     [BackgroundAgentRegistry.cs:203–206]
+              │    skip when ParentId absent (trust root)
+              └─ stores instance                       [BackgroundAgentRegistry.cs:209–217]
 
 BackgroundAgentService → registry.StartAllAsync        [BackgroundAgentService.cs:87]
   └─ AgentScheduler schedules extender cadence         [BackgroundAgentRegistry.cs:345]
@@ -29,19 +31,20 @@ Scheduler tick → TrackedExecuteAgentAsync              [BackgroundAgentRegistr
   └─ ExecuteAgentAsync                                 [BackgroundAgentRegistry.cs:416+]
        └─ role == "extender" + RepoRoot/Path param    [BackgroundAgentRegistry.cs:513–516]
             ├─ IAggressivenessModeStore.GetMode        [BackgroundAgentRegistry.cs:518]
-            │    default Active when store missing     [BackgroundAgentRegistry.cs:518]
-            ├─ Passive → skip                          [BackgroundAgentRegistry.cs:519–525]
-            ├─ SemiActive → IApprovalGate              [BackgroundAgentRegistry.cs:528–544]
-            │    (not commercial ApprovalBridge)
-            └─ ISelfExtendRunner.RunAsync              [BackgroundAgentRegistry.cs:555–557]
+            │    default Passive when store missing    [BackgroundAgentRegistry.cs:518]
+            ├─ Passive → skip (C)                      [BackgroundAgentRegistry.cs:519–525]
+            ├─ SemiActive → IApprovalGate (deny if null) [BackgroundAgentRegistry.cs:528–544]
+            └─ ISelfExtendRunner.RunAsync(+ agentId)   [BackgroundAgentRegistry.cs:555–557]
                  └─ SelfExtendRunnerAdapter.RunAsync  [SelfExtendRunnerAdapter.cs:74–196]
                       ├─ RepoFsToolboxFactory.CreateWithBuildTest
-                      │    [SelfExtendRunnerAdapter.cs:116–121]
+                      │    [SelfExtendRunnerAdapter.cs:116–131]
                       │    policies: PathAllowlist, MaxWriteSize, BuildTestBudget,
+                      │    SelfProducedBrickCertificationPolicy (A),
+                      │    DataExfiltrationPolicy (B),
                       │    optional ForgeMediatedWritesPolicy
-                      │    [RepoFsToolboxFactory.cs:117–131]
-                      ├─ BuildSnapshot (AgentName, not agentId)
-                      │    [SelfExtendRunnerAdapter.cs:208–304]
+                      │    [RepoFsToolboxFactory.cs:117–145]
+                      ├─ BuildSnapshot (agentId + selfExtendAdmission)
+                      │    [SelfExtendRunnerAdapter.cs:224–232]
                       └─ ToolCallingAgent.RunCycleAsync
                            [SelfExtendRunnerAdapter.cs:149–150]
                            → PolicyEngine.Approve per tool call
@@ -52,51 +55,44 @@ Runtime agent activation (separate from extend cycle):
   UpdateAgentConfigTool → RegisterAsync (re-register) [UpdateAgentConfigTool.cs:75]
 ```
 
-**Not on this path:** `CertificationGate`, `CompositionCertificationGate`, `BackgroundAgentPolicyEngineFactory` / `DataExfiltrationPolicy` (factory is test-only wiring today), `LifecycleManager`, commercial `ApprovalBridge` (Discord playtest fixes).
+**Not on this path:** commercial `ApprovalBridge` (Discord playtest fixes), `LifecycleManager`.
 
 ## Invariant verdicts
 
-| ID | Invariant | Verdict | Executing enforcement (or bypass path) | Test |
-|----|-----------|---------|----------------------------------------|------|
-| A | Cert-gate inheritance | **GAP** | **Bypass:** `SelfExtendRunnerAdapter.RunAsync` → `RepoFsToolboxFactory.CreateWithBuildTest` builds `PolicyEngine` with `PathAllowlist`, `MaxWriteSize`, `BuildTestBudget`, optional `ForgeMediatedWritesPolicy` only — no `ICertificationGate` / `CertificationGate` call on write or register (`RepoFsToolboxFactory.cs:117–131`, `SelfExtendRunnerAdapter.cs:116–150`). `BackgroundAgentRegistry.RegisterAsync` stores config with no cert check (`BackgroundAgentRegistry.cs:191–209`). Zero `CertificationGate` references under `Nexo.BackgroundAgents*` / `HostRunners`. | `SelfExtendInvariantACertGateTests` — 2 characterization PASS, 1 rejection **SKIP (GAP)** |
-| B | Monotonic policy narrowing | **GAP** | **Bypass:** `RegisterAsync` accepts any `ExfiltrationPolicy` on config with no parent subset check (`BackgroundAgentRegistry.cs:191–209`). `ParentId` is copied into spawn spec dependencies only (`BackgroundAgentSpecBuilder.cs:52–57`). Self-extend cycle uses `RepoFsToolboxFactory` policies without `DataExfiltrationPolicy` (`RepoFsToolboxFactory.cs:117–131`). Snapshot sets `AgentName` not `agentId`, so even if `DataExfiltrationPolicy` were present it fail-opens (`SelfExtendRunnerAdapter.cs:220`, `DataExfiltrationPolicy.cs:73–77`). `BackgroundAgentPolicyEngineFactory` is not wired on this path. | `SelfExtendInvariantBPolicyNarrowingTests` — 2 characterization PASS, 1 rejection **SKIP (GAP)** |
-| C | Human admission seam (ApprovalBridge) | **GAP** | **Bypass:** Default aggressiveness is **Active** when mode file missing (`BackgroundAgentRegistry.cs:518`, `FileBasedAggressivenessModeStore.cs:33–34`). Extender runs without approval in Active/Ambient. `EnableAgentTool` → `StartAsync` with no admission token (`EnableAgentTool.cs:49`). Commercial `ApprovalBridge` (Discord emoji → playtest fixes) is not referenced by background agent registration/activation. `IApprovalGate` gates **SemiActive extender cycles** only (`BackgroundAgentRegistry.cs:528–544`); default DI is `NoApprovalGate` (`ServiceCollectionExtensions.cs:56`). | `SelfExtendInvariantCHumanAdmissionTests` — 3 characterization PASS, 1 rejection **SKIP (GAP)** |
-| D | Recursion / runaway ceiling | **GAP** (partial per-cycle caps) | **Partial:** `ToolCallingAgent.DefaultMaxIterations` (=5) and `DefaultPerCycleDeadline` (5 min) bound a single ReAct cycle (`ToolCallingAgent.cs:33–43`). `BuildTestBudget` caps build/test tool calls per cycle (`BuildTestBudget.cs:50–76`, wired in `RepoFsToolboxFactory.cs:121`). **Bypass:** No extender recursion depth counter or cross-cycle rate limit — `ExecuteOnceAsync` / scheduler can invoke extender repeatedly with no refusal (`BackgroundAgentRegistry.cs:555–601`; characterization runs 12 cycles unblocked). | `SelfExtendInvariantDRecursionCeilingTests` — 3 characterization PASS, 1 rejection **SKIP (GAP)** |
+| ID | Invariant | Verdict | Executing enforcement | Test |
+|----|-----------|---------|----------------------|------|
+| A | Cert-gate inheritance | **ENFORCED** | `SelfProducedBrickCertificationPolicy.Approve` on self-extend writes when `selfExtendAdmission=true`; verifies admitted record via `CertificationTrustVerifier` (content-bound) [`SelfProducedBrickCertificationPolicy.cs:24–78`, wired `RepoFsToolboxFactory.cs:137–140`]. Missing store → `FailClosedCertificationRecordStore` denies all brick admissions. Human boot roots unaffected (no self-extend snapshot). | `SelfExtendInvariantACertGateTests` |
+| B | Monotonic policy narrowing | **ENFORCED** | `AgentPolicyNarrowingValidator.ValidateOrThrow` at `RegisterAsync` for `ParentId` children [`BackgroundAgentRegistry.cs:203–206`, `AgentPolicyNarrowingValidator.cs`]. Self-extend snapshot sets `agentId` + wires `DataExfiltrationPolicy` [`SelfExtendRunnerAdapter.cs:224–232`, `RepoFsToolboxFactory.cs:142–145`]. Roots without `ParentId` skip narrowing (trust root). | `SelfExtendInvariantBPolicyNarrowingTests` |
+| C | Fail-closed default | **ENFORCED** | `FileBasedAggressivenessModeStore` missing/corrupt file → **Passive** [`FileBasedAggressivenessModeStore.cs:33–34`, `41–44`]. Registry fallback when mode store absent → **Passive** [`BackgroundAgentRegistry.cs:518`]. SemiActive without `IApprovalGate` → denied [`BackgroundAgentRegistry.cs:528–535`]. Explicit Active or approved SemiActive → runs. | `SelfExtendInvariantCHumanAdmissionTests` |
+| D | Recursion / runaway ceiling | **GAP** (partial per-cycle caps) | Per-cycle: `ToolCallingAgent.DefaultMaxIterations`, `BuildTestBudget`. **No** cross-cycle extender depth/rate refusal. | `SelfExtendInvariantDRecursionCeilingTests` — rejection **SKIP (GAP)** |
 
 ### Invariant A — cert-gate inheritance
 
-**Verdict: GAP**
+**Verdict: ENFORCED**
 
-Self-proposed bricks written via `repo.fs.write` on the extender path are approved by dev filesystem policies only. Nothing on the path calls `CertificationGate.CertifyAsync` or `CertifiedBrickAdmission` before registration or tool execution.
+Self-produced brick writes under `src/Nexo.Bricks*/` on the self-extend admission edge require an admitted, content-bound certification record. Uncertified, missing-record, and tampered content are refused by `SelfProducedBrickCertificationPolicy`.
 
 ### Invariant B — monotonic policy narrowing
 
-**Verdict: GAP**
+**Verdict: ENFORCED**
 
-A child agent config with `BlockExternalLLMs = false`, `RequireLocalOnly = false`, and `MaxAllowedLevel = "Secret"` registers successfully even when the nominal parent carries a stricter envelope. No code compares child `ExfiltrationPolicy` to creator policy at spawn/register time.
+Machine-spawned agents (`ParentId` set) must have an envelope ⊆ creator at registration. Human-authored trust roots (`ParentId` absent) register unchanged. Self-extend cycles key `DataExfiltrationPolicy` on `agentId` in the snapshot.
 
-### Invariant C — human admission seam
+### Invariant C — fail-closed default
 
-**Verdict: GAP**
+**Verdict: ENFORCED**
 
-“Activation” into the live mesh (`StartAsync` / `enable_agent`) does not require commercial `ApprovalBridge` or any human approval token. Default **Active** mode runs extender cycles immediately. SemiActive + `IApprovalGate` is a separate, optional per-cycle gate — not mesh admission — and defaults to deny when unwired.
+Unconfigured aggressiveness defaults to **Passive** — extender cycles do not run until an operator sets Active (or approves SemiActive). This is distinct from mesh `enable_agent` activation; monitors/testers in the boot agent set still start normally.
 
 ### Invariant D — recursion / runaway ceiling
 
-**Verdict: GAP** (with **partial** per-cycle enforcement)
+**Verdict: GAP** (deferred)
 
-Within one cycle, iteration and build/test budgets exist. Across cycles, nothing refuses an extender after N cumulative self-extend invocations or enforces a spawn-depth ceiling for agents created by extenders.
+Within-cycle ReAct and build/test budgets exist. Cross-cycle extender recursion depth is not capped.
 
-## REORDER note
+## REORDER note (post SX-ENFORCE)
 
-**Invariants A and B are GAP — roadmap-changing.**
-
-Before treating self-extend output as production-safe mesh expansion:
-
-1. **Cert gate (A) must precede runnable bricks** — wire `CertificationGate` / composition admission on the propose → write → register edge so uncertified self-proposed bricks are refused, not merely path-allowlisted.
-2. **Policy narrowing (B) must precede spawn** — compare child `ExfiltrationPolicy` and `MaxDataSensitivity` to creator envelope at `RegisterAsync` / spawn-spec validation; wire `DataExfiltrationPolicy` on the self-extend snapshot (`agentId`) if exfiltration teeth are required at tool time.
-
-Human admission (C) and extender recursion ceiling (D) are also GAP but are operational guardrails that can follow A/B in priority — uncertified, over-privileged agents are the higher-severity expansion risk.
+Invariants **A, B, and C** are now enforced on the live path. **D** (cross-cycle extender recursion ceiling) remains the primary deferred safety item before treating unattended multi-cycle self-extension as production-safe.
 
 ## Test index
 
@@ -105,7 +101,7 @@ Human admission (C) and extender recursion ceiling (D) are also GAP but are oper
 | `src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantACertGateTests.cs` | Invariant A |
 | `src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantBPolicyNarrowingTests.cs` | Invariant B |
 | `src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantCHumanAdmissionTests.cs` | Invariant C |
-| `src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs` | Invariant D |
+| `src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs` | Invariant D (GAP) |
 | `src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendAuditTestSupport.cs` | Shared helpers |
 
-Rejection tests use `[Fact(Skip = "GAP: … see docs/SELF-EXTEND-AUDIT.md#…")]` so CI stays green while the gap remains visible in test discovery output.
+Invariant D rejection test retains `[Fact(Skip = "GAP: …")]` until a future sprint adds cross-cycle ceiling enforcement.

--- a/src/Nexo.BackgroundAgents.HostRunners/RepoFsToolboxFactory.cs
+++ b/src/Nexo.BackgroundAgents.HostRunners/RepoFsToolboxFactory.cs
@@ -1,7 +1,11 @@
 using Nexo.Abstractions;
 using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.DataSensitivity;
 using Nexo.BackgroundAgents.Forge;
 using Nexo.BackgroundAgents.Observations;
+using Nexo.BackgroundAgents.Registry;
+using Nexo.BackgroundAgents.Security;
+using Nexo.Core.Application.Certification.Ports;
 using Nexo.Policies.Dev;
 using Nexo.Runtime;
 using Nexo.Tools.Dev;
@@ -64,7 +68,10 @@ internal static class RepoFsToolboxFactory
         string source = "self-extend",
         string? objectiveId = null,
         IChangeProposalStore? proposals = null,
-        IAggressivenessModeStore? modeStore = null)
+        IAggressivenessModeStore? modeStore = null,
+        ICertificationRecordStore? certificationStore = null,
+        IBackgroundAgentRegistry? agentRegistry = null,
+        IDataSensitivityRegistry? sensitivityRegistry = null)
     {
         var tools = new CapabilityRegistry();
         tools.Register(new RepoFsListTool());
@@ -128,6 +135,17 @@ internal static class RepoFsToolboxFactory
             // continue to write directly.
             policyList.Add(new ForgeMediatedWritesPolicy(modeStore));
         }
+
+        if (certificationStore is not null)
+        {
+            policyList.Add(new SelfProducedBrickCertificationPolicy(certificationStore));
+        }
+
+        if (agentRegistry is not null && sensitivityRegistry is not null)
+        {
+            policyList.Add(new DataExfiltrationPolicy(agentRegistry, sensitivityRegistry));
+        }
+
         var policies = new PolicyEngine(policyList.ToArray());
 
         return (tools, policies, budget);

--- a/src/Nexo.BackgroundAgents.HostRunners/RepoFsToolboxFactory.cs
+++ b/src/Nexo.BackgroundAgents.HostRunners/RepoFsToolboxFactory.cs
@@ -136,10 +136,8 @@ internal static class RepoFsToolboxFactory
             policyList.Add(new ForgeMediatedWritesPolicy(modeStore));
         }
 
-        if (certificationStore is not null)
-        {
-            policyList.Add(new SelfProducedBrickCertificationPolicy(certificationStore));
-        }
+        policyList.Add(new SelfProducedBrickCertificationPolicy(
+            certificationStore ?? FailClosedCertificationRecordStore.Instance));
 
         if (agentRegistry is not null && sensitivityRegistry is not null)
         {

--- a/src/Nexo.BackgroundAgents.HostRunners/SelfExtendRunnerAdapter.cs
+++ b/src/Nexo.BackgroundAgents.HostRunners/SelfExtendRunnerAdapter.cs
@@ -2,10 +2,14 @@ using Microsoft.Extensions.Logging;
 using Nexo.Abstractions;
 using Nexo.BackgroundAgents.Agents;
 using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.DataSensitivity;
 using Nexo.BackgroundAgents.Extending;
 using Nexo.BackgroundAgents.Forge;
 using Nexo.BackgroundAgents.Objectives;
 using Nexo.BackgroundAgents.Observations;
+using Nexo.BackgroundAgents.Registry;
+using Nexo.BackgroundAgents.Security;
+using Nexo.Core.Application.Certification.Ports;
 using Nexo.Runtime;
 
 namespace Nexo.BackgroundAgents.HostRunners;
@@ -32,6 +36,9 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
     private readonly IObjectiveStore? _objectives;
     private readonly IChangeProposalStore? _proposals;
     private readonly IAggressivenessModeStore? _modeStore;
+    private readonly ICertificationRecordStore _certificationStore;
+    private readonly IBackgroundAgentRegistry? _agentRegistry;
+    private readonly IDataSensitivityRegistry? _sensitivityRegistry;
 
     public SelfExtendRunnerAdapter(
         IModel model,
@@ -40,7 +47,10 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         IObservationStore? observations = null,
         IObjectiveStore? objectives = null,
         IChangeProposalStore? proposals = null,
-        IAggressivenessModeStore? modeStore = null)
+        IAggressivenessModeStore? modeStore = null,
+        ICertificationRecordStore? certificationStore = null,
+        IBackgroundAgentRegistry? agentRegistry = null,
+        IDataSensitivityRegistry? sensitivityRegistry = null)
     {
         _model = model ?? throw new ArgumentNullException(nameof(model));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -49,6 +59,9 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         _objectives = objectives;
         _proposals = proposals;
         _modeStore = modeStore;
+        _certificationStore = certificationStore ?? FailClosedCertificationRecordStore.Instance;
+        _agentRegistry = agentRegistry;
+        _sensitivityRegistry = sensitivityRegistry;
     }
 
     /// <inheritdoc />
@@ -78,6 +91,20 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         string? modelProvider,
         string? modelName,
         CancellationToken cancellationToken = default)
+        => await RunAsync(repoRoot, objective, agentName, modelProvider, modelName, agentId: null, cancellationToken)
+            .ConfigureAwait(false);
+
+    /// <summary>
+    /// Runs a self-extend cycle with registry agent id for policy enforcement (exfiltration, cert admission).
+    /// </summary>
+    public async Task<SelfExtendRunResult> RunAsync(
+        string repoRoot,
+        string? objective,
+        string? agentName,
+        string? modelProvider,
+        string? modelName,
+        string? agentId,
+        CancellationToken cancellationToken = default)
     {
         if (!BackgroundAgentAdapterValidation.TryResolveDirectory(repoRoot, "RepoRoot", out var errorMessage))
         {
@@ -85,6 +112,7 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         }
 
         var resolvedAgentName = string.IsNullOrWhiteSpace(agentName) ? "self-extend" : agentName!.Trim();
+        var resolvedAgentId = string.IsNullOrWhiteSpace(agentId) ? resolvedAgentName : agentId!.Trim();
 
         // Claim a backlog item for this cycle when an objective store is wired and
         // the caller hasn't pinned an explicit objective string. Without this the
@@ -115,10 +143,13 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         {
             var (tools, policies, budget) = RepoFsToolboxFactory.CreateWithBuildTest(
                 observations: _observations,
-                source: resolvedAgentName,
+                source: resolvedAgentId,
                 objectiveId: claimed?.Id,
                 proposals: _proposals,
-                modeStore: _modeStore);
+                modeStore: _modeStore,
+                certificationStore: _certificationStore,
+                agentRegistry: _agentRegistry,
+                sensitivityRegistry: _sensitivityRegistry);
             budget.Reset();
             // Register objective lifecycle tools only when a store is wired — the
             // tools cannot operate without one and must not be advertised to the LLM
@@ -139,7 +170,14 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
                 modelName);
             var scratchpadPath = ResolveScratchpadPath(repoRoot!, resolvedAgentName);
             var recent = LoadRecentObservations();
-            var snapshot = BuildSnapshot(repoRoot!, resolvedAgentName, effectiveObjective, scratchpadPath, recent, claimed);
+            var snapshot = BuildSnapshot(
+                repoRoot!,
+                resolvedAgentName,
+                resolvedAgentId,
+                effectiveObjective,
+                scratchpadPath,
+                recent,
+                claimed);
 
             // Multi-turn ReAct: agent loops up to MaxIterations, executing tool calls inline
             // through the policy engine and feeding observations back into the conversation.
@@ -208,6 +246,7 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
     private static WorldSnapshot BuildSnapshot(
         string repoRoot,
         string agentName,
+        string agentId,
         string? objective,
         string? scratchpadPath = null,
         IReadOnlyList<RuntimeObservation>? recentObservations = null,
@@ -217,7 +256,9 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         {
             ["RepoRoot"] = repoRoot,
             ["OutputRoot"] = Path.Combine(repoRoot, "out"),
-            ["AgentName"] = agentName
+            ["AgentName"] = agentName,
+            ["agentId"] = agentId,
+            ["selfExtendAdmission"] = true
         };
 
         if (!string.IsNullOrWhiteSpace(objective))

--- a/src/Nexo.BackgroundAgents/Configuration/AgentRegistrationOrigin.cs
+++ b/src/Nexo.BackgroundAgents/Configuration/AgentRegistrationOrigin.cs
@@ -1,0 +1,14 @@
+namespace Nexo.BackgroundAgents.Configuration;
+
+/// <summary>
+/// Provenance of a <see cref="BackgroundAgentRegistry.RegisterAsync"/> call.
+/// Machine-origin registrations must carry a resolvable parent; authored registrations are trust roots.
+/// </summary>
+public enum AgentRegistrationOrigin
+{
+    /// <summary>Human-authored configuration (boot agent_set, reload from config file).</summary>
+    Authored,
+
+    /// <summary>Machine-proposed registration; requires parent resolution and policy narrowing.</summary>
+    Machine
+}

--- a/src/Nexo.BackgroundAgents/Configuration/FileBasedAggressivenessModeStore.cs
+++ b/src/Nexo.BackgroundAgents/Configuration/FileBasedAggressivenessModeStore.cs
@@ -31,7 +31,7 @@ public sealed class FileBasedAggressivenessModeStore : IAggressivenessModeStore
         try
         {
             if (!File.Exists(_path))
-                return BackgroundAgentAggressivenessMode.Active;
+                return BackgroundAgentAggressivenessMode.Passive;
 
             var json = File.ReadAllText(_path);
             var doc = JsonSerializer.Deserialize<ModeDoc>(json);
@@ -40,7 +40,7 @@ public sealed class FileBasedAggressivenessModeStore : IAggressivenessModeStore
         }
         catch
         {
-            return BackgroundAgentAggressivenessMode.Active;
+            return BackgroundAgentAggressivenessMode.Passive;
         }
     }
 

--- a/src/Nexo.BackgroundAgents/Extending/ISelfExtendRunner.cs
+++ b/src/Nexo.BackgroundAgents/Extending/ISelfExtendRunner.cs
@@ -46,5 +46,18 @@ public interface ISelfExtendRunner
         string? modelProvider,
         string? modelName,
         CancellationToken cancellationToken = default)
-        => RunAsync(repoRoot, objective, agentName, cancellationToken);
+        => RunAsync(repoRoot, objective, agentName, modelProvider, modelName, agentId: null, cancellationToken);
+
+    /// <summary>
+    /// Run one self-extend cycle with explicit registry agent id for policy enforcement.
+    /// </summary>
+    Task<SelfExtendRunResult> RunAsync(
+        string repoRoot,
+        string? objective,
+        string? agentName,
+        string? modelProvider,
+        string? modelName,
+        string? agentId,
+        CancellationToken cancellationToken = default)
+        => RunAsync(repoRoot, objective, agentName, modelProvider, modelName, cancellationToken);
 }

--- a/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
+++ b/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
@@ -2,11 +2,13 @@ using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Nexo.Abstractions;
 using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.DataSensitivity;
 using Nexo.BackgroundAgents.Extending;
 using Nexo.BackgroundAgents.Logging;
 using Nexo.BackgroundAgents.Observations;
 using Nexo.BackgroundAgents.Optimization;
 using Nexo.BackgroundAgents.Scheduling;
+using Nexo.BackgroundAgents.Security;
 using Nexo.BackgroundAgents.Telemetry;
 using Nexo.BackgroundAgents.Testing;
 using Nexo.Core.Application.SelfImprovement.Ports;
@@ -134,6 +136,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
     private readonly ISelfImprovementLoop? _selfImprovementLoop;
     private readonly IAggressivenessModeStore? _modeStore;
     private readonly IApprovalGate? _approvalGate;
+    private readonly IDataSensitivityRegistry? _sensitivityRegistry;
     private readonly IDataDecisionAuditLog? _auditLog;
     private readonly CycleEventStore? _cycleEvents;
     private readonly Observations.IObservationStore? _observations;
@@ -165,6 +168,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
         ISelfImprovementLoop? selfImprovementLoop = null,
         IAggressivenessModeStore? modeStore = null,
         IApprovalGate? approvalGate = null,
+        IDataSensitivityRegistry? sensitivityRegistry = null,
         IDataDecisionAuditLog? auditLog = null,
         CycleEventStore? cycleEvents = null,
         Observations.IObservationStore? observations = null,
@@ -179,6 +183,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
         _selfImprovementLoop = selfImprovementLoop;
         _modeStore = modeStore;
         _approvalGate = approvalGate;
+        _sensitivityRegistry = sensitivityRegistry;
         _auditLog = auditLog;
         _cycleEvents = cycleEvents;
         _observations = observations;
@@ -194,6 +199,11 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
             throw new ArgumentNullException(nameof(agent));
         if (config == null)
             throw new ArgumentNullException(nameof(config));
+
+        AgentPolicyNarrowingValidator.ValidateOrThrow(
+            config,
+            parentId => _agents.TryGetValue(parentId, out var parent) ? parent : null,
+            _sensitivityRegistry ?? new DataSensitivityRegistry());
 
         // Create agent instance
         var instance = new BackgroundAgentInstance
@@ -515,7 +525,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
                 _selfExtendRunner != null &&
                 TryGetParameter(instance.Config, new[] { "RepoRoot", "Path" }, out var repoRoot))
             {
-                var mode = _modeStore?.GetMode() ?? BackgroundAgentAggressivenessMode.Active;
+                var mode = _modeStore?.GetMode() ?? BackgroundAgentAggressivenessMode.Passive;
                 if (mode == BackgroundAgentAggressivenessMode.Passive)
                 {
                     _logStore?.Append(agentId, "Info", "Passive mode: skipping extender execution (observe only).");
@@ -553,7 +563,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
                 var modelProvider = string.IsNullOrWhiteSpace(instance.Config.ModelProvider) ? null : instance.Config.ModelProvider;
                 var modelName = string.IsNullOrWhiteSpace(instance.Config.ModelName) ? null : instance.Config.ModelName;
                 var result = await _selfExtendRunner
-                    .RunAsync(repoRoot, objective, agentName, modelProvider, modelName, cancellationToken)
+                    .RunAsync(repoRoot, objective, agentName, modelProvider, modelName, agentId, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (mode == BackgroundAgentAggressivenessMode.Ambient)

--- a/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
+++ b/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
@@ -52,7 +52,15 @@ public interface IBackgroundAgentRegistry
     /// started or executed. Duplicate registration for the same agent ID
     /// overwrites the previous instance.
     /// </summary>
-    Task RegisterAsync(IAgent agent, BackgroundAgentConfig config, CancellationToken cancellationToken = default);
+    /// <param name="origin">
+    /// Registration provenance. Defaults to <see cref="AgentRegistrationOrigin.Machine"/> so
+    /// callers that omit provenance must justify themselves with a resolvable parent.
+    /// </param>
+    Task RegisterAsync(
+        IAgent agent,
+        BackgroundAgentConfig config,
+        AgentRegistrationOrigin origin = AgentRegistrationOrigin.Machine,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Look up a registered agent by ID. Returns <c>null</c> for unknown IDs
@@ -193,7 +201,11 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
     /// <summary>
     /// Register a background agent.
     /// </summary>
-    public Task RegisterAsync(IAgent agent, BackgroundAgentConfig config, CancellationToken cancellationToken = default)
+    public Task RegisterAsync(
+        IAgent agent,
+        BackgroundAgentConfig config,
+        AgentRegistrationOrigin origin = AgentRegistrationOrigin.Machine,
+        CancellationToken cancellationToken = default)
     {
         if (agent == null)
             throw new ArgumentNullException(nameof(agent));
@@ -202,6 +214,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
 
         AgentPolicyNarrowingValidator.ValidateOrThrow(
             config,
+            origin,
             parentId => _agents.TryGetValue(parentId, out var parent) ? parent : null,
             _sensitivityRegistry ?? new DataSensitivityRegistry());
 

--- a/src/Nexo.BackgroundAgents/Security/AgentPolicyNarrowingValidator.cs
+++ b/src/Nexo.BackgroundAgents/Security/AgentPolicyNarrowingValidator.cs
@@ -5,30 +5,37 @@ using Nexo.BackgroundAgents.Registry;
 namespace Nexo.BackgroundAgents.Security;
 
 /// <summary>
-/// Enforces child ⊆ creator exfiltration/sensitivity envelope at machine-spawn registration.
-/// Human-authored roots (no <see cref="BackgroundAgentConfig.ParentId"/>) are trust roots and skip validation.
+/// Enforces child ⊆ creator exfiltration/sensitivity envelope at machine-origin registration.
+/// Authored registrations are trust roots and skip validation.
 /// </summary>
 public static class AgentPolicyNarrowingValidator
 {
     public static void ValidateOrThrow(
         BackgroundAgentConfig child,
+        AgentRegistrationOrigin origin,
         Func<string, BackgroundAgentInstance?> resolveParent,
         IDataSensitivityRegistry sensitivityRegistry)
     {
-        if (string.IsNullOrWhiteSpace(child.ParentId))
+        if (origin == AgentRegistrationOrigin.Authored)
             return;
+
+        if (string.IsNullOrWhiteSpace(child.ParentId))
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-origin agent '{child.Id}': ParentId is required.");
+        }
 
         if (sensitivityRegistry is null)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': sensitivity registry unavailable to verify parent envelope.");
+                $"Refusing machine-origin agent '{child.Id}': sensitivity registry unavailable to verify parent envelope.");
         }
 
         var parentInstance = resolveParent(child.ParentId);
         if (parentInstance is null)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': parent '{child.ParentId}' is not registered.");
+                $"Refusing machine-origin agent '{child.Id}': parent '{child.ParentId}' is not registered.");
         }
 
         var parent = parentInstance.Config;
@@ -38,25 +45,25 @@ public static class AgentPolicyNarrowingValidator
         if (parentPolicy.BlockExternalLLMs && !childPolicy.BlockExternalLLMs)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': BlockExternalLLMs cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': BlockExternalLLMs cannot be relaxed below parent '{parent.Id}'.");
         }
 
         if (parentPolicy.BlockWebSearch && !childPolicy.BlockWebSearch)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': BlockWebSearch cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': BlockWebSearch cannot be relaxed below parent '{parent.Id}'.");
         }
 
         if (parentPolicy.BlockNetworkExports && !childPolicy.BlockNetworkExports)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': BlockNetworkExports cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': BlockNetworkExports cannot be relaxed below parent '{parent.Id}'.");
         }
 
         if (parentPolicy.RequireLocalOnly && !childPolicy.RequireLocalOnly)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': RequireLocalOnly cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': RequireLocalOnly cannot be relaxed below parent '{parent.Id}'.");
         }
 
         EnsureLevelNotBroader(
@@ -86,7 +93,7 @@ public static class AgentPolicyNarrowingValidator
                 if (parentAllowed is not null && !parentAllowed.Contains(levelName))
                 {
                     throw new InvalidOperationException(
-                        $"Refusing machine-spawned agent '{child.Id}': AllowedDataSensitivityLevels contains '{levelName}' outside parent '{parent.Id}' allow-list.");
+                        $"Refusing machine-origin agent '{child.Id}': AllowedDataSensitivityLevels contains '{levelName}' outside parent '{parent.Id}' allow-list.");
                 }
 
                 EnsureLevelNotBroader(
@@ -113,13 +120,13 @@ public static class AgentPolicyNarrowingValidator
         if (parentLevel is null || childLevel is null)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{childId}': unable to resolve {field} sensitivity levels for parent/child comparison.");
+                $"Refusing machine-origin agent '{childId}': unable to resolve {field} sensitivity levels for parent/child comparison.");
         }
 
         if (childLevel.SensitivityValue > parentLevel.SensitivityValue)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{childId}': {field} '{childLevelName}' exceeds parent '{parentId}' envelope '{parentLevelName}'.");
+                $"Refusing machine-origin agent '{childId}': {field} '{childLevelName}' exceeds parent '{parentId}' envelope '{parentLevelName}'.");
         }
     }
 }

--- a/src/Nexo.BackgroundAgents/Security/AgentPolicyNarrowingValidator.cs
+++ b/src/Nexo.BackgroundAgents/Security/AgentPolicyNarrowingValidator.cs
@@ -1,0 +1,125 @@
+using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.DataSensitivity;
+using Nexo.BackgroundAgents.Registry;
+
+namespace Nexo.BackgroundAgents.Security;
+
+/// <summary>
+/// Enforces child ⊆ creator exfiltration/sensitivity envelope at machine-spawn registration.
+/// Human-authored roots (no <see cref="BackgroundAgentConfig.ParentId"/>) are trust roots and skip validation.
+/// </summary>
+public static class AgentPolicyNarrowingValidator
+{
+    public static void ValidateOrThrow(
+        BackgroundAgentConfig child,
+        Func<string, BackgroundAgentInstance?> resolveParent,
+        IDataSensitivityRegistry sensitivityRegistry)
+    {
+        if (string.IsNullOrWhiteSpace(child.ParentId))
+            return;
+
+        if (sensitivityRegistry is null)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{child.Id}': sensitivity registry unavailable to verify parent envelope.");
+        }
+
+        var parentInstance = resolveParent(child.ParentId);
+        if (parentInstance is null)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{child.Id}': parent '{child.ParentId}' is not registered.");
+        }
+
+        var parent = parentInstance.Config;
+        var parentPolicy = parent.ExfiltrationPolicy ?? new ExfiltrationPolicy();
+        var childPolicy = child.ExfiltrationPolicy ?? new ExfiltrationPolicy();
+
+        if (parentPolicy.BlockExternalLLMs && !childPolicy.BlockExternalLLMs)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{child.Id}': BlockExternalLLMs cannot be relaxed below parent '{parent.Id}'.");
+        }
+
+        if (parentPolicy.BlockWebSearch && !childPolicy.BlockWebSearch)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{child.Id}': BlockWebSearch cannot be relaxed below parent '{parent.Id}'.");
+        }
+
+        if (parentPolicy.BlockNetworkExports && !childPolicy.BlockNetworkExports)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{child.Id}': BlockNetworkExports cannot be relaxed below parent '{parent.Id}'.");
+        }
+
+        if (parentPolicy.RequireLocalOnly && !childPolicy.RequireLocalOnly)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{child.Id}': RequireLocalOnly cannot be relaxed below parent '{parent.Id}'.");
+        }
+
+        EnsureLevelNotBroader(
+            child.Id,
+            parent.Id,
+            "MaxAllowedLevel",
+            parentPolicy.MaxAllowedLevel ?? parent.MaxDataSensitivity,
+            childPolicy.MaxAllowedLevel ?? child.MaxDataSensitivity,
+            sensitivityRegistry);
+
+        EnsureLevelNotBroader(
+            child.Id,
+            parent.Id,
+            "MaxDataSensitivity",
+            parent.MaxDataSensitivity,
+            child.MaxDataSensitivity,
+            sensitivityRegistry);
+
+        if (child.AllowedDataSensitivityLevels is { Count: > 0 })
+        {
+            var parentAllowed = parent.AllowedDataSensitivityLevels is { Count: > 0 }
+                ? new HashSet<string>(parent.AllowedDataSensitivityLevels, StringComparer.OrdinalIgnoreCase)
+                : null;
+
+            foreach (var levelName in child.AllowedDataSensitivityLevels)
+            {
+                if (parentAllowed is not null && !parentAllowed.Contains(levelName))
+                {
+                    throw new InvalidOperationException(
+                        $"Refusing machine-spawned agent '{child.Id}': AllowedDataSensitivityLevels contains '{levelName}' outside parent '{parent.Id}' allow-list.");
+                }
+
+                EnsureLevelNotBroader(
+                    child.Id,
+                    parent.Id,
+                    "AllowedDataSensitivityLevels",
+                    parentPolicy.MaxAllowedLevel ?? parent.MaxDataSensitivity,
+                    levelName,
+                    sensitivityRegistry);
+            }
+        }
+    }
+
+    private static void EnsureLevelNotBroader(
+        string childId,
+        string parentId,
+        string field,
+        string parentLevelName,
+        string childLevelName,
+        IDataSensitivityRegistry sensitivityRegistry)
+    {
+        var parentLevel = sensitivityRegistry.GetByName(parentLevelName);
+        var childLevel = sensitivityRegistry.GetByName(childLevelName);
+        if (parentLevel is null || childLevel is null)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{childId}': unable to resolve {field} sensitivity levels for parent/child comparison.");
+        }
+
+        if (childLevel.SensitivityValue > parentLevel.SensitivityValue)
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-spawned agent '{childId}': {field} '{childLevelName}' exceeds parent '{parentId}' envelope '{parentLevelName}'.");
+        }
+    }
+}

--- a/src/Nexo.BackgroundAgents/Security/BrickAdmissionPathHelper.cs
+++ b/src/Nexo.BackgroundAgents/Security/BrickAdmissionPathHelper.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+
+namespace Nexo.BackgroundAgents.Security;
+
+/// <summary>
+/// Classifies self-extend write targets and infers brick ids for certification admission checks.
+/// </summary>
+public static class BrickAdmissionPathHelper
+{
+    private static readonly Regex BrickClassRegex = new(
+        @"class\s+(\w+Brick)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static bool IsRunnableBrickPath(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+            return false;
+
+        var rel = relativePath.Replace('\\', '/').TrimStart('/');
+        return rel.StartsWith("src/Nexo.Bricks", StringComparison.OrdinalIgnoreCase)
+               && rel.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string? InferBrickId(string relativePath, string? sourceContent)
+    {
+        if (!string.IsNullOrWhiteSpace(sourceContent))
+        {
+            var match = BrickClassRegex.Match(sourceContent);
+            if (match.Success)
+                return ClassNameToBrickId(match.Groups[1].Value);
+        }
+
+        var fileName = Path.GetFileNameWithoutExtension(relativePath.Replace('\\', '/'));
+        return string.IsNullOrWhiteSpace(fileName) ? null : ClassNameToBrickId(fileName);
+    }
+
+    public static string ClassNameToBrickId(string className)
+    {
+        var name = className;
+        if (name.EndsWith("Brick", StringComparison.Ordinal))
+            name = name[..^"Brick".Length];
+
+        if (string.IsNullOrEmpty(name))
+            return className.ToLowerInvariant();
+
+        var chars = new List<char>(name.Length + 8);
+        for (var i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (char.IsUpper(c) && chars.Count > 0 && chars[^1] != '-')
+                chars.Add('-');
+            chars.Add(char.ToLowerInvariant(c));
+        }
+
+        var kebab = new string(chars.ToArray());
+        return kebab.EndsWith("-brick", StringComparison.Ordinal) ? kebab : $"{kebab}-brick";
+    }
+}

--- a/src/Nexo.BackgroundAgents/Security/FailClosedCertificationRecordStore.cs
+++ b/src/Nexo.BackgroundAgents/Security/FailClosedCertificationRecordStore.cs
@@ -1,0 +1,22 @@
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+
+namespace Nexo.BackgroundAgents.Security;
+
+/// <summary>
+/// Fail-closed certification store used when no <see cref="ICertificationRecordStore"/> is wired.
+/// All brick admission checks deny.
+/// </summary>
+public sealed class FailClosedCertificationRecordStore : ICertificationRecordStore
+{
+    public static readonly FailClosedCertificationRecordStore Instance = new();
+
+    private FailClosedCertificationRecordStore() { }
+
+    public CertificationRecord? Get(string brickId) => null;
+
+    public bool IsAdmitted(string brickId) => false;
+
+    public void Save(CertificationRecord record) =>
+        throw new InvalidOperationException("Fail-closed certification store cannot persist records.");
+}

--- a/src/Nexo.BackgroundAgents/Security/SelfProducedBrickCertificationPolicy.cs
+++ b/src/Nexo.BackgroundAgents/Security/SelfProducedBrickCertificationPolicy.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using Nexo.Abstractions;
+using Nexo.Certification.Contracts;
+using Nexo.Core.Application.Certification.Ports;
+using Nexo.Infrastructure.Certification;
+
+namespace Nexo.BackgroundAgents.Security;
+
+/// <summary>
+/// Fail-closed certification gate for brick writes on the self-extend admission edge.
+/// Applies only when <c>WorldSnapshot.Data["selfExtendAdmission"]</c> is true.
+/// </summary>
+public sealed class SelfProducedBrickCertificationPolicy : IPolicy
+{
+    private readonly ICertificationRecordStore _certificationStore;
+
+    public SelfProducedBrickCertificationPolicy(ICertificationRecordStore certificationStore)
+    {
+        _certificationStore = certificationStore ?? throw new ArgumentNullException(nameof(certificationStore));
+    }
+
+    public bool Approve(ToolCall call, WorldSnapshot s, out string reason)
+    {
+        reason = "OK";
+        if (!IsSelfExtendAdmission(s))
+            return true;
+
+        if (call.Id is not ("repo.fs.write" or "repo.fs.search_replace"))
+            return true;
+
+        if (!TryGetPathAndContent(call, out var relativePath, out var content))
+            return true;
+
+        if (!BrickAdmissionPathHelper.IsRunnableBrickPath(relativePath))
+            return true;
+
+        var brickId = BrickAdmissionPathHelper.InferBrickId(relativePath, content);
+        if (string.IsNullOrWhiteSpace(brickId))
+        {
+            reason = "Self-produced brick admission refused: unable to infer brick id";
+            return false;
+        }
+
+        var record = _certificationStore.Get(brickId);
+        if (record is null)
+        {
+            reason = $"Self-produced brick admission refused: no certification record for '{brickId}'";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            reason = $"Self-produced brick admission refused: missing source content for '{brickId}'";
+            return false;
+        }
+
+        var trust = CertificationTrustVerifier.Verify(
+            CertificationRecordMapper.ToData(record),
+            content);
+        if (!trust.Trusted)
+        {
+            reason = $"Self-produced brick admission refused for '{brickId}': {trust.FailureCode} — {trust.Reason}";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsSelfExtendAdmission(WorldSnapshot snapshot) =>
+        snapshot.Data.TryGetValue("selfExtendAdmission", out var flag)
+        && flag is true;
+
+    private static bool TryGetPathAndContent(ToolCall call, out string relativePath, out string? content)
+    {
+        relativePath = string.Empty;
+        content = null;
+        if (call.Arguments.ValueKind != JsonValueKind.Object)
+            return false;
+
+        if (!call.Arguments.TryGetProperty("path", out var pathEl) || pathEl.ValueKind != JsonValueKind.String)
+            return false;
+
+        relativePath = pathEl.GetString() ?? string.Empty;
+        if (call.Arguments.TryGetProperty("content", out var contentEl) && contentEl.ValueKind == JsonValueKind.String)
+            content = contentEl.GetString();
+        else if (call.Arguments.TryGetProperty("newContent", out var newContentEl) && newContentEl.ValueKind == JsonValueKind.String)
+            content = newContentEl.GetString();
+
+        return !string.IsNullOrWhiteSpace(relativePath);
+    }
+}

--- a/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
+++ b/src/Nexo.BackgroundAgents/ServiceCollectionExtensions.cs
@@ -103,10 +103,11 @@ public static class ServiceCollectionExtensions
             var selfImprovementLoop = sp.GetService<Nexo.Core.Application.SelfImprovement.Ports.ISelfImprovementLoop>();
             var modeStore = sp.GetService<IAggressivenessModeStore>();
             var approvalGate = sp.GetService<IApprovalGate>();
+            var sensitivityRegistry = sp.GetService<IDataSensitivityRegistry>();
             var auditLog = sp.GetService<IDataDecisionAuditLog>();
             var cycleEvents = sp.GetService<CycleEventStore>();
             var observations = sp.GetService<IObservationStore>();
-            return new BackgroundAgentRegistry(scheduler, logger, logStore, codeAnalysisRunner, testRunRunner, selfExtendRunner, selfImprovementLoop, modeStore, approvalGate, auditLog, cycleEvents, observations);
+            return new BackgroundAgentRegistry(scheduler, logger, logStore, codeAnalysisRunner, testRunRunner, selfExtendRunner, selfImprovementLoop, modeStore, approvalGate, sensitivityRegistry, auditLog, cycleEvents, observations);
         });
         services.TryAddSingleton<BackgroundAgentConfigLoader>();
         services.TryAddSingleton<BackgroundAgentSpecBuilder>();

--- a/src/Nexo.BackgroundAgents/Services/BackgroundAgentService.cs
+++ b/src/Nexo.BackgroundAgents/Services/BackgroundAgentService.cs
@@ -126,7 +126,7 @@ public class BackgroundAgentService : BackgroundService
         var agent = _agentFactory.CreateAgent(spec);
 
         // Register with registry
-        await _registry.RegisterAsync(agent, config, cancellationToken);
+        await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, cancellationToken);
 
         _logger.LogInformation("Created and registered background agent: {AgentId}", config.Id);
     }

--- a/src/Nexo.BackgroundAgents/Tools/UpdateAgentConfigTool.cs
+++ b/src/Nexo.BackgroundAgents/Tools/UpdateAgentConfigTool.cs
@@ -72,7 +72,7 @@ public sealed class UpdateAgentConfigTool : ITool
             }
             var spec = _specBuilder.BuildSpec(config);
             var agent = _agentFactory.CreateAgent(spec);
-            await _registry.RegisterAsync(agent, config, ct).ConfigureAwait(false);
+            await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, ct).ConfigureAwait(false);
             var okLog = new[] { $"Re-registered background agent from config: {agentId}" };
             var okDelta = new ActionDelta(s.Tick, s.Tick + 1, okLog);
             return new ToolResult(okDelta, new { ok = true, agentId, action = "updated" });

--- a/src/Nexo.Tests.BackgroundAgents/Configuration/AggressivenessModeTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Configuration/AggressivenessModeTests.cs
@@ -14,6 +14,7 @@ using Nexo.Core.Application.Trust.Models;
 using Nexo.Core.Application.Trust.Ports;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Configuration;
 
@@ -62,7 +63,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-passive", default);
 
@@ -111,7 +112,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-active", default);
 
@@ -215,7 +216,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive", default);
 
@@ -265,7 +266,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive-denied", default);
 
@@ -315,7 +316,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive-timeout", default);
 
@@ -365,7 +366,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive-approved", default);
 
@@ -412,7 +413,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-ambient", default);
 
@@ -462,7 +463,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-ambient-audit", default);
 

--- a/src/Nexo.Tests.BackgroundAgents/Configuration/FileBasedAggressivenessModeStoreGapCoverageTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Configuration/FileBasedAggressivenessModeStoreGapCoverageTests.cs
@@ -8,23 +8,23 @@ namespace Nexo.Tests.BackgroundAgents.Configuration;
 public sealed class FileBasedAggressivenessModeStoreGapCoverageTests
 {
     [Fact]
-    public void GetMode_missing_file_returns_active()
+    public void GetMode_missing_file_returns_passive()
     {
         var path = Path.Combine(Path.GetTempPath(), "nexo-mode-missing-" + Guid.NewGuid().ToString("N") + ".json");
         var store = new FileBasedAggressivenessModeStore(path);
 
-        store.GetMode().Should().Be(BackgroundAgentAggressivenessMode.Active);
+        store.GetMode().Should().Be(BackgroundAgentAggressivenessMode.Passive);
     }
 
     [Fact]
-    public void GetMode_corrupt_json_returns_active()
+    public void GetMode_corrupt_json_returns_passive()
     {
         var path = Path.Combine(Path.GetTempPath(), "nexo-mode-corrupt-" + Guid.NewGuid().ToString("N") + ".json");
         File.WriteAllText(path, "{not-json");
         try
         {
             var store = new FileBasedAggressivenessModeStore(path);
-            store.GetMode().Should().Be(BackgroundAgentAggressivenessMode.Active);
+            store.GetMode().Should().Be(BackgroundAgentAggressivenessMode.Passive);
         }
         finally
         {

--- a/src/Nexo.Tests.BackgroundAgents/Integration/BackgroundAgentsE2ETests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Integration/BackgroundAgentsE2ETests.cs
@@ -11,6 +11,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Integration;
 
@@ -58,7 +59,7 @@ public class BackgroundAgentsE2ETests
         var spec = specBuilder.BuildSpec(agentConfig);
         var logger = sp.GetRequiredService<ILogger<GenericAgent>>();
         var agent = new GenericAgent(spec, logger);
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("e2e-agent", default);
 

--- a/src/Nexo.Tests.BackgroundAgents/Performance/ExecuteOncePerformanceTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Performance/ExecuteOncePerformanceTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Performance;
 
@@ -82,7 +83,7 @@ public class ExecuteOncePerformanceTests
         var spec = specBuilder.BuildSpec(agentConfig);
         var logger = sp.GetRequiredService<ILogger<GenericAgent>>();
         var agent = new GenericAgent(spec, logger);
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
         return (registry, agentConfig.Id);
     }
 }

--- a/src/Nexo.Tests.BackgroundAgents/Performance/LoadTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Performance/LoadTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Performance;
 
@@ -122,7 +123,7 @@ public class LoadTests
         {
             var spec = specBuilder.BuildSpec(agentConfig);
             var agent = new GenericAgent(spec, logger);
-            await registry.RegisterAsync(agent, agentConfig, default);
+            await registry.RegisterAuthoredAsync(agent, agentConfig);
             agentIds.Add(agentConfig.Id);
         }
         return (registry, agentIds);

--- a/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryGapCoverageTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryGapCoverageTests.cs
@@ -430,6 +430,9 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         IApprovalGate? approvalGate = null,
         TimeSpan? shutdownGracePeriod = null)
     {
+        if (selfExtendRunner is not null && modeStore is null)
+            modeStore = new InMemoryAggressivenessModeStore();
+
         var scheduler = new AgentScheduler(new ScheduleExecutor(), NullLogger<AgentScheduler>.Instance);
         return new BackgroundAgentRegistry(
             scheduler,
@@ -440,6 +443,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             selfImprovementLoop: selfImprovementLoop,
             modeStore: modeStore,
             approvalGate: approvalGate,
+            sensitivityRegistry: new DataSensitivityRegistry(),
             cycleEvents: cycleEvents,
             observations: observations,
             shutdownGracePeriod: shutdownGracePeriod);

--- a/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryGapCoverageTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryGapCoverageTests.cs
@@ -16,6 +16,7 @@ using Nexo.Core.Application.SelfImprovement.Ports;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -27,8 +28,8 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry();
         var config = MonitorConfig("dup-agent");
 
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         registry.GetAll().Should().ContainSingle(a => a.Config.Id == "dup-agent");
     }
@@ -51,7 +52,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry();
         var config = MonitorConfig("running-agent");
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.StartAsync(config.Id);
         await registry.StartAsync(config.Id);
@@ -64,7 +65,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry();
         var config = MonitorConfig("idle-agent");
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.StopAsync(config.Id);
 
@@ -94,7 +95,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             Enabled = true,
         };
 
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -122,7 +123,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry(testRunRunner: new ThrowingTestRunner());
         var config = new BackgroundAgentConfig { Id = "failing-tester", Role = "tester", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.ExecuteOnceAsync(config.Id);
 
@@ -145,7 +146,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry(selfExtendRunner: runner, observations: store);
 
         var config = ExtenderConfig("extender-obs", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var obs = store.All.Should().ContainSingle().Subject;
@@ -168,7 +169,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry(selfExtendRunner: runner, observations: store);
 
         var config = ExtenderConfig("extender-fail", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         store.All.Should().ContainSingle().Which.severity.Should().Be(ObservationSeverity.Warn);
@@ -191,7 +192,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var config = ExtenderConfig("extender-telem", Environment.CurrentDirectory);
         config.ModelProvider = "ollama";
         config.ModelName = "llama3";
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var evt = cycleEvents.Read().Should().ContainSingle().Subject;
@@ -215,7 +216,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
 
         var registry = BuildRegistry(selfImprovementLoop: loop.Object, modeStore: modeStore.Object);
         var config = new BackgroundAgentConfig { Id = "self-improver-semi", Role = "self-improver", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -244,7 +245,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             modeStore: modeStore.Object,
             approvalGate: new AlwaysApprovalGate());
         var config = new BackgroundAgentConfig { Id = "self-improver-run", Role = "self-improver", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -265,7 +266,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             modeStore: modeStore.Object,
             approvalGate: new AlwaysApprovalGate());
         var config = new BackgroundAgentConfig { Id = "self-improver-null-report", Role = "self-improver", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -277,7 +278,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry(codeAnalysisRunner: new FakeCodeAnalysisRunner(true, "unused", 0));
         var config = new BackgroundAgentConfig { Id = "optimizer-default", Role = "optimizer", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         registry.GetAgent(config.Id)!.SuccessCount.Should().Be(1);
@@ -293,7 +294,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             shutdownGracePeriod: TimeSpan.FromSeconds(2));
 
         var config = ExtenderConfig("drain-agent", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         var cycle = registry.ExecuteOnceAsync(config.Id);
         await Task.Delay(50);
@@ -315,7 +316,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             shutdownGracePeriod: TimeSpan.FromMilliseconds(50));
 
         var config = ExtenderConfig("slow-agent", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         var cycle = registry.ExecuteOnceAsync(config.Id);
         await Task.Delay(30);
@@ -331,7 +332,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var runner = new DelaySelfExtendRunner(TimeSpan.FromSeconds(5));
         var registry = BuildRegistry(selfExtendRunner: runner);
         var config = ExtenderConfig("cancel-agent", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
@@ -349,7 +350,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
 
         var registry = BuildRegistry(selfExtendRunner: runner, modeStore: modeStore.Object);
         var config = ExtenderConfig("extender-passive", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         registry.GetAgent(config.Id)!.SuccessCount.Should().Be(1);
@@ -368,7 +369,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             Enabled = true,
             Parameters = new Dictionary<string, object> { ["Path"] = Environment.CurrentDirectory },
         };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         runner.LastRepoRoot.Should().Be(Environment.CurrentDirectory);
@@ -380,7 +381,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var runner = new RecordingSelfExtendRunner();
         var registry = BuildRegistry(selfExtendRunner: runner);
         var config = new BackgroundAgentConfig { Id = "extender-no-path", Role = "extender", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         runner.LastRepoRoot.Should().BeNull();
@@ -392,7 +393,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry();
         var config = MonitorConfig("start-all-agent");
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.StartAllAsync();
 
@@ -408,7 +409,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry(testRunRunner: new ThrowingTestRunner(), cycleEvents: cycleEvents);
 
         var config = new BackgroundAgentConfig { Id = "fail-telem", Role = "tester", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var evt = cycleEvents.Read().Should().ContainSingle().Subject;

--- a/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryTestExtensions.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryTestExtensions.cs
@@ -1,0 +1,18 @@
+using Nexo.Abstractions;
+using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.Registry;
+
+namespace Nexo.Tests.BackgroundAgents.Registry;
+
+/// <summary>
+/// Test helpers for boot-simulation registrations that mirror human-authored paths.
+/// </summary>
+internal static class BackgroundAgentRegistryTestExtensions
+{
+    internal static Task RegisterAuthoredAsync(
+        this IBackgroundAgentRegistry registry,
+        IAgent agent,
+        BackgroundAgentConfig config,
+        CancellationToken cancellationToken = default) =>
+        registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, cancellationToken);
+}

--- a/src/Nexo.Tests.BackgroundAgents/Registry/IgnoredLlmConfigWarningTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/IgnoredLlmConfigWarningTests.cs
@@ -7,6 +7,7 @@ using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -44,7 +45,7 @@ public sealed class IgnoredLlmConfigWarningTests
         };
 
         var spec = new BackgroundAgentSpecBuilder(new DataSensitivityRegistry(), null).BuildSpec(config);
-        await registry.RegisterAsync(new GenericAgent(spec, NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(spec, NullLogger<GenericAgent>.Instance), config);
 
         if (expectWarning)
             captured.Should().Contain(m => m.Contains("IGNORED", StringComparison.Ordinal) && m.Contains("agent-x"));

--- a/src/Nexo.Tests.BackgroundAgents/Registry/ObservationsPublishingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/ObservationsPublishingTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.BackgroundAgents.Testing;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -37,7 +38,7 @@ public sealed class ObservationsPublishingTests
             Parameters = new Dictionary<string, object> { ["Filter"] = "PathAllowlist" }
         };
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
         await registry.ExecuteOnceAsync(config.Id);
 
         store.All.Should().ContainSingle();
@@ -64,7 +65,7 @@ public sealed class ObservationsPublishingTests
             Role = "tester",
             Enabled = true
         };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         store.All.Should().ContainSingle().Which.severity.Should().Be(ObservationSeverity.Info);
@@ -85,7 +86,7 @@ public sealed class ObservationsPublishingTests
             Enabled = true,
             Parameters = new Dictionary<string, object> { ["Path"] = "src/Nexo.Core" }
         };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var obs = store.All.Should().ContainSingle().Subject;
@@ -106,7 +107,7 @@ public sealed class ObservationsPublishingTests
             observations: null);
 
         var config = new BackgroundAgentConfig { Id = "tester-3", Role = "tester", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         var act = async () => await registry.ExecuteOnceAsync(config.Id);
         await act.Should().NotThrowAsync();

--- a/src/Nexo.Tests.BackgroundAgents/Registry/SelfExtendParameterFlowTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/SelfExtendParameterFlowTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.Abstractions;
 using Nexo.BackgroundAgents.Configuration;
 using Nexo.BackgroundAgents.DataSensitivity;
 using Nexo.BackgroundAgents.Extending;
@@ -56,6 +57,7 @@ public sealed class SelfExtendParameterFlowTests
         call.AgentName.Should().Be("runtime-planner");
         call.ModelProvider.Should().Be("ollama");
         call.ModelName.Should().Be("llama3.1:latest");
+        call.AgentId.Should().Be("planner-1");
     }
 
     [Fact]
@@ -83,6 +85,7 @@ public sealed class SelfExtendParameterFlowTests
 
         var call = fakeRunner.Calls.Single();
         call.AgentName.Should().Be("planner-2");
+        call.AgentId.Should().Be("planner-2");
         call.Objective.Should().BeNull();
     }
 
@@ -116,6 +119,8 @@ public sealed class SelfExtendParameterFlowTests
 
     private static IBackgroundAgentRegistry BuildRegistry(ISelfExtendRunner runner)
     {
+        var modeStore = new InMemoryAggressivenessModeStore();
+        modeStore.SetMode(BackgroundAgentAggressivenessMode.Active);
         var scheduler = new AgentScheduler(new ScheduleExecutor(), NullLogger<AgentScheduler>.Instance);
         return new BackgroundAgentRegistry(
             scheduler,
@@ -124,7 +129,9 @@ public sealed class SelfExtendParameterFlowTests
             codeAnalysisRunner: null,
             testRunRunner: null,
             selfExtendRunner: runner,
-            selfImprovementLoop: null);
+            selfImprovementLoop: null,
+            modeStore: modeStore,
+            sensitivityRegistry: new DataSensitivityRegistry());
     }
 
     private static Orchestration.Architect.Models.AgentSpawnSpec BuildSpec(BackgroundAgentConfig c)
@@ -167,11 +174,25 @@ public sealed class SelfExtendParameterFlowTests
             return Task.FromResult(new SelfExtendRunResult(true, 0, 0, "noop"));
         }
 
+        public Task<SelfExtendRunResult> RunAsync(
+            string repoRoot,
+            string? objective,
+            string? agentName,
+            string? modelProvider,
+            string? modelName,
+            string? agentId,
+            CancellationToken cancellationToken = default)
+        {
+            Calls.Add(new RecordedCall(repoRoot, objective, agentName, modelProvider, modelName, agentId));
+            return Task.FromResult(new SelfExtendRunResult(true, 0, 0, "noop"));
+        }
+
         public sealed record RecordedCall(
             string RepoRoot,
             string? Objective,
             string? AgentName,
             string? ModelProvider,
-            string? ModelName);
+            string? ModelName,
+            string? AgentId = null);
     }
 }

--- a/src/Nexo.Tests.BackgroundAgents/Registry/SelfExtendParameterFlowTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/SelfExtendParameterFlowTests.cs
@@ -9,6 +9,7 @@ using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -46,7 +47,7 @@ public sealed class SelfExtendParameterFlowTests
         };
 
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
 
         await registry.ExecuteOnceAsync(config.Id);
 
@@ -80,7 +81,7 @@ public sealed class SelfExtendParameterFlowTests
         };
 
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var call = fakeRunner.Calls.Single();
@@ -109,7 +110,7 @@ public sealed class SelfExtendParameterFlowTests
             }
         };
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var call = fakeRunner.Calls.Single();

--- a/src/Nexo.Tests.BackgroundAgents/Resilience/RegistryResilienceTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Resilience/RegistryResilienceTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Resilience;
 
@@ -152,7 +153,7 @@ public class RegistryResilienceTests
         {
             var spec = specBuilder.BuildSpec(agentConfig);
             var agent = new GenericAgent(spec, logger);
-            await registry.RegisterAsync(agent, agentConfig, default);
+            await registry.RegisterAuthoredAsync(agent, agentConfig);
             agentIds.Add(agentConfig.Id);
         }
         return (registry, agentIds);

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendAuditTestSupport.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendAuditTestSupport.cs
@@ -6,6 +6,10 @@ using Nexo.BackgroundAgents.DataSensitivity;
 using Nexo.BackgroundAgents.Extending;
 using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Scheduling;
+using Nexo.Certification.Contracts;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+using Nexo.Infrastructure.Certification;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Nexo.Runtime;
@@ -13,7 +17,7 @@ using Nexo.Runtime;
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
 /// <summary>
-/// Shared helpers for SX-AUDIT invariant characterization tests.
+/// Shared helpers for SX-AUDIT / SX-ENFORCE invariant characterization tests.
 /// </summary>
 internal static class SelfExtendAuditTestSupport
 {
@@ -26,7 +30,8 @@ internal static class SelfExtendAuditTestSupport
     internal static BackgroundAgentRegistry CreateRegistry(
         ISelfExtendRunner? selfExtendRunner = null,
         IAggressivenessModeStore? modeStore = null,
-        IApprovalGate? approvalGate = null)
+        IApprovalGate? approvalGate = null,
+        IDataSensitivityRegistry? sensitivityRegistry = null)
     {
         var scheduler = new AgentScheduler(new ScheduleExecutor(), NullLogger<AgentScheduler>.Instance);
         return new BackgroundAgentRegistry(
@@ -34,7 +39,15 @@ internal static class SelfExtendAuditTestSupport
             NullLogger<BackgroundAgentRegistry>.Instance,
             selfExtendRunner: selfExtendRunner,
             modeStore: modeStore,
-            approvalGate: approvalGate);
+            approvalGate: approvalGate,
+            sensitivityRegistry: sensitivityRegistry ?? new DataSensitivityRegistry());
+    }
+
+    internal static InMemoryAggressivenessModeStore ActiveModeStore()
+    {
+        var store = new InMemoryAggressivenessModeStore();
+        store.SetMode(BackgroundAgentAggressivenessMode.Active);
+        return store;
     }
 
     internal static AgentSpawnSpec BuildSpec(BackgroundAgentConfig config) =>
@@ -50,6 +63,41 @@ internal static class SelfExtendAuditTestSupport
         Parameters = new Dictionary<string, object> { ["RepoRoot"] = repoRoot },
         Schedule = new BackgroundAgentSchedule { Type = ScheduleType.Interval, Interval = TimeSpan.FromMinutes(1) },
     };
+
+    internal static (ICertificationRecordStore store, string brickId, string source) SeedCertifiedBrickAdmission(
+        string className,
+        string? namespaceName = "Nexo.Bricks.AuditGap")
+    {
+        var source = $"namespace {namespaceName}; public sealed class {className} {{ }}";
+        var brickId = Nexo.BackgroundAgents.Security.BrickAdmissionPathHelper.ClassNameToBrickId(className);
+        var hash = BrickContentHasher.ComputeSha256(source);
+        var data = new CertificationRecordData
+        {
+            Status = "PASS",
+            Stage = "admit",
+            Admitted = true,
+            Signed = true,
+            Timestamp = DateTimeOffset.UtcNow,
+            BrickId = brickId,
+            ContentHash = hash
+        };
+        data = data with { Signature = CertificationRecordSigning.Sign(data) };
+
+        var store = new InMemoryCertificationRecordStore();
+        store.Save(new CertificationRecord
+        {
+            Status = data.Status,
+            Stage = data.Stage,
+            Admitted = data.Admitted,
+            Signed = data.Signed,
+            Timestamp = data.Timestamp,
+            BrickId = data.BrickId,
+            ContentHash = data.ContentHash,
+            Signature = data.Signature
+        });
+
+        return (store, brickId, source);
+    }
 
     internal sealed class CountingSelfExtendRunner : ISelfExtendRunner
     {
@@ -67,6 +115,16 @@ internal static class SelfExtendAuditTestSupport
             string? agentName,
             string? modelProvider,
             string? modelName,
+            CancellationToken cancellationToken = default) =>
+            RunAsync(repoRoot, cancellationToken);
+
+        public Task<SelfExtendRunResult> RunAsync(
+            string repoRoot,
+            string? objective,
+            string? agentName,
+            string? modelProvider,
+            string? modelName,
+            string? agentId,
             CancellationToken cancellationToken = default) =>
             RunAsync(repoRoot, cancellationToken);
     }

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendHardeningFinding1Tests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendHardeningFinding1Tests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.Registry;
+using Nexo.Orchestration.Agents;
+using Nexo.Tests.BackgroundAgents.Registry;
+using Xunit;
+
+namespace Nexo.Tests.BackgroundAgents.SelfExtend;
+
+/// <summary>
+/// SX-HARDEN finding 1 — machine-origin registration must carry a resolvable parent.
+/// </summary>
+public sealed class SelfExtendHardeningFinding1Tests
+{
+    [Fact]
+    public async Task Rejection_machine_origin_with_blank_parent_is_refused()
+    {
+        var registry = SelfExtendAuditTestSupport.CreateRegistry();
+        var config = RootConfig("orphan-machine-agent");
+
+        var act = () => registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ParentId is required*");
+    }
+
+    [Fact]
+    public async Task Rejection_machine_origin_with_unregistered_parent_is_refused()
+    {
+        var registry = SelfExtendAuditTestSupport.CreateRegistry();
+        var config = new BackgroundAgentConfig
+        {
+            Id = "missing-parent-child",
+            ParentId = "not-registered-parent",
+            Role = "extender",
+            Enabled = true,
+            MaxDataSensitivity = "Public",
+            Commands = ["extend"],
+        };
+
+        var act = () => registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not registered*");
+    }
+
+    [Fact]
+    public async Task Admission_authored_origin_with_blank_parent_registers()
+    {
+        var registry = SelfExtendAuditTestSupport.CreateRegistry();
+        var config = RootConfig("balance-watcher");
+
+        await registry.RegisterAuthoredAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+
+        registry.GetAgent("balance-watcher").Should().NotBeNull();
+    }
+
+    private static BackgroundAgentConfig RootConfig(string id) => new()
+    {
+        Id = id,
+        Role = "monitor",
+        Enabled = true,
+        MaxDataSensitivity = "Public",
+        Commands = ["ping"],
+    };
+}

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantACertGateTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantACertGateTests.cs
@@ -2,72 +2,94 @@ using System.Text.Json;
 using FluentAssertions;
 using Nexo.Abstractions;
 using Nexo.BackgroundAgents.HostRunners;
+using Nexo.BackgroundAgents.Security;
 using Nexo.Runtime;
 using Xunit;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
 /// <summary>
-/// SX-AUDIT invariant A — cert-gate inheritance on the self-extend path.
-/// See <c>docs/SELF-EXTEND-AUDIT.md#invariant-a-cert-gate-inheritance</c>.
+/// SX-ENFORCE invariant A — cert-gate inheritance on the self-extend path.
 /// </summary>
 public sealed class SelfExtendInvariantACertGateTests
 {
+    private const string BrickClassName = "UncertifiedSelfProposedBrick";
+    private const string BrickRelativePath = "src/Nexo.Bricks.AuditGap/UncertifiedSelfProposedBrick.cs";
+    private const string BrickSource =
+        "namespace Nexo.Bricks.AuditGap; public sealed class UncertifiedSelfProposedBrick { }";
+
     [Fact]
-    public void Characterization_selfExtend_policy_chain_excludes_certification_gate()
+    public void Characterization_selfExtend_policy_chain_includes_certification_gate_when_store_wired()
     {
-        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest();
+        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest(
+            certificationStore: new Nexo.Infrastructure.Certification.InMemoryCertificationRecordStore());
 
         var policyTypes = SelfExtendAuditTestSupport.GetPolicies(policies)
-            .Select(p => p.GetType().FullName ?? p.GetType().Name)
+            .Select(p => p.GetType().Name)
             .ToList();
 
-        policyTypes.Should().NotContain(t => t.Contains("Certification", StringComparison.Ordinal),
-            "self-extend must not silently include a cert gate — presence would need an explicit executing call site");
-        policyTypes.Should().NotContain(t => t.Contains("DataExfiltrationPolicy", StringComparison.Ordinal),
-            "exfiltration policy is not wired on the self-extend toolbox path");
+        policyTypes.Should().Contain(nameof(SelfProducedBrickCertificationPolicy));
     }
 
     [Fact]
-    public void Characterization_uncertified_brick_write_is_approved_by_self_extend_policies()
+    public void Rejection_uncertified_self_proposed_brick_is_refused_at_registration_or_use()
     {
-        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest();
+        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest(
+            certificationStore: new Nexo.Infrastructure.Certification.InMemoryCertificationRecordStore());
+
         var call = new ToolCall(
             "repo.fs.write",
-            JsonSerializer.SerializeToElement(new
-            {
-                path = "src/Nexo.Bricks.AuditGap/UncertifiedSelfProposedBrick.cs",
-                content = "namespace Nexo.Bricks.AuditGap; public sealed class UncertifiedSelfProposedBrick { }"
-            }));
+            JsonSerializer.SerializeToElement(new { path = BrickRelativePath, content = BrickSource }));
 
         var snapshot = new WorldSnapshot(0, new Dictionary<string, object?>
         {
             ["RepoRoot"] = "/workspace",
-            ["AgentName"] = "self-extend"
+            ["selfExtendAdmission"] = true
+        });
+
+        policies.Approve(call, snapshot, out var reason).Should().BeFalse();
+        reason.Should().Contain("no certification record");
+    }
+
+    [Fact]
+    public void Admission_certified_self_proposed_brick_with_matching_content_hash_is_allowed()
+    {
+        var (store, brickId, source) = SelfExtendAuditTestSupport.SeedCertifiedBrickAdmission(BrickClassName);
+        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest(certificationStore: store);
+
+        var call = new ToolCall(
+            "repo.fs.write",
+            JsonSerializer.SerializeToElement(new { path = BrickRelativePath, content = source }));
+
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?>
+        {
+            ["RepoRoot"] = "/workspace",
+            ["selfExtendAdmission"] = true
         });
 
         policies.Approve(call, snapshot, out var reason).Should().BeTrue(
-            "only PathAllowlist/MaxWriteSize/BuildTestBudget apply — no CertificationGate executes");
+            $"certified brick '{brickId}' with content-bound record should be admitted");
         reason.Should().Be("OK");
     }
 
-    /// <summary>
-    /// Rejection test for invariant A. Skipped because the live path does not refuse uncertified bricks.
-    /// </summary>
-    [Fact(Skip = "GAP: Self-extend registration/write path never calls CertificationGate — see docs/SELF-EXTEND-AUDIT.md#invariant-a-cert-gate-inheritance")]
-    public void Rejection_uncertified_self_proposed_brick_is_refused_at_registration_or_use()
+    [Fact]
+    public void Rejection_tampered_self_proposed_brick_content_is_refused()
     {
-        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest();
+        var (store, _, source) = SelfExtendAuditTestSupport.SeedCertifiedBrickAdmission(BrickClassName);
+        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest(certificationStore: store);
+        var tampered = source.Replace("{ }", "{ public int X => 1; }");
+
         var call = new ToolCall(
             "repo.fs.write",
-            JsonSerializer.SerializeToElement(new
-            {
-                path = "src/Nexo.Bricks.AuditGap/UncertifiedSelfProposedBrick.cs",
-                content = "namespace Nexo.Bricks.AuditGap; public sealed class UncertifiedSelfProposedBrick { }"
-            }));
-        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?> { ["RepoRoot"] = "/workspace" });
+            JsonSerializer.SerializeToElement(new { path = BrickRelativePath, content = tampered }));
 
-        policies.Approve(call, snapshot, out _).Should().BeFalse(
-            "invariant A requires absent/failing certification to be REFUSED, not runnable");
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?>
+        {
+            ["RepoRoot"] = "/workspace",
+            ["selfExtendAdmission"] = true
+        });
+
+        policies.Approve(call, snapshot, out var reason).Should().BeFalse();
+        reason.Should().Contain("content-hash-mismatch");
     }
 }

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantACertGateTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantACertGateTests.cs
@@ -32,6 +32,30 @@ public sealed class SelfExtendInvariantACertGateTests
     }
 
     [Fact]
+    public void Rejection_default_factory_without_explicit_cert_store_refuses_uncertified_brick()
+    {
+        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest();
+
+        var policyTypes = SelfExtendAuditTestSupport.GetPolicies(policies)
+            .Select(p => p.GetType().Name)
+            .ToList();
+        policyTypes.Should().Contain(nameof(SelfProducedBrickCertificationPolicy));
+
+        var call = new ToolCall(
+            "repo.fs.write",
+            JsonSerializer.SerializeToElement(new { path = BrickRelativePath, content = BrickSource }));
+
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?>
+        {
+            ["RepoRoot"] = "/workspace",
+            ["selfExtendAdmission"] = true
+        });
+
+        policies.Approve(call, snapshot, out var reason).Should().BeFalse();
+        reason.Should().Contain("no certification record");
+    }
+
+    [Fact]
     public void Rejection_uncertified_self_proposed_brick_is_refused_at_registration_or_use()
     {
         var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest(

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantBPolicyNarrowingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantBPolicyNarrowingTests.cs
@@ -9,17 +9,32 @@ using Xunit;
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
 /// <summary>
-/// SX-AUDIT invariant B — monotonic policy narrowing for self-created agents.
-/// See <c>docs/SELF-EXTEND-AUDIT.md#invariant-b-monotonic-policy-narrowing</c>.
+/// SX-ENFORCE invariant B — monotonic policy narrowing for machine-spawned agents.
 /// </summary>
 public sealed class SelfExtendInvariantBPolicyNarrowingTests
 {
     [Fact]
-    public async Task Characterization_register_async_accepts_child_with_broader_exfiltration_than_parent()
+    public async Task Admission_equal_or_stricter_child_envelope_registers_successfully()
     {
         var registry = SelfExtendAuditTestSupport.CreateRegistry();
         var parent = RestrictiveConfig("creator-parent", parentId: null);
-        var child = BroadenedChildConfig("creator-child", parentId: "creator-parent");
+        var child = new BackgroundAgentConfig
+        {
+            Id = "creator-child",
+            ParentId = "creator-parent",
+            Role = "extender",
+            Enabled = true,
+            MaxDataSensitivity = "Public",
+            Commands = ["extend"],
+            ExfiltrationPolicy = new ExfiltrationPolicy
+            {
+                MaxAllowedLevel = "Public",
+                BlockExternalLLMs = true,
+                BlockWebSearch = true,
+                BlockNetworkExports = true,
+                RequireLocalOnly = true
+            }
+        };
 
         await registry.RegisterAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(parent), NullLogger<GenericAgent>.Instance),
@@ -28,31 +43,25 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(child), NullLogger<GenericAgent>.Instance),
             child);
 
-        var stored = registry.GetAgent("creator-child");
-        stored.Should().NotBeNull();
-        stored!.Config.ExfiltrationPolicy.BlockExternalLLMs.Should().BeFalse();
-        stored.Config.ExfiltrationPolicy.RequireLocalOnly.Should().BeFalse();
-        stored.Config.ExfiltrationPolicy.MaxAllowedLevel.Should().Be("Secret");
+        registry.GetAgent("creator-child").Should().NotBeNull();
     }
 
     [Fact]
-    public void Characterization_self_extend_snapshot_omits_agentId_so_data_exfiltration_policy_fail_open()
+    public void Characterization_self_extend_snapshot_includes_agentId_for_exfiltration_policy()
     {
         var snapshot = new WorldSnapshot(0, new Dictionary<string, object?>
         {
             ["RepoRoot"] = "/workspace",
-            ["AgentName"] = "runtime-planner"
+            ["AgentName"] = "runtime-planner",
+            ["agentId"] = "runtime-planner",
+            ["selfExtendAdmission"] = true
         });
 
-        snapshot.Data.Should().ContainKey("AgentName");
-        snapshot.Data.Should().NotContainKey("agentId",
-            "SelfExtendRunnerAdapter.BuildSnapshot sets AgentName only — DataExfiltrationPolicy.Approve fail-opens without agentId");
+        snapshot.Data.Should().ContainKey("agentId");
+        snapshot.Data["agentId"].Should().Be("runtime-planner");
     }
 
-    /// <summary>
-    /// Rejection test for invariant B. Skipped because spawn/registration does not compare child vs parent envelope.
-    /// </summary>
-    [Fact(Skip = "GAP: RegisterAsync stores broader ExfiltrationPolicy with no subset check vs creator — see docs/SELF-EXTEND-AUDIT.md#invariant-b-monotonic-policy-narrowing")]
+    [Fact]
     public async Task Rejection_spawn_spec_with_broader_envelope_than_creator_is_refused()
     {
         var registry = SelfExtendAuditTestSupport.CreateRegistry();
@@ -67,8 +76,21 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(child), NullLogger<GenericAgent>.Instance),
             child);
 
-        await act.Should().ThrowAsync<InvalidOperationException>(
-            "invariant B requires broader MaxAllowedLevel or relaxed BlockExternalLLMs/RequireLocalOnly to be REFUSED");
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*BlockExternalLLMs*");
+    }
+
+    [Fact]
+    public async Task Admission_human_authored_root_without_parent_registers_without_narrowing_check()
+    {
+        var registry = SelfExtendAuditTestSupport.CreateRegistry();
+        var root = BroadenedChildConfig("balance-watcher", parentId: null);
+
+        await registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(root), NullLogger<GenericAgent>.Instance),
+            root);
+
+        registry.GetAgent("balance-watcher")!.Config.ExfiltrationPolicy.BlockExternalLLMs.Should().BeFalse();
     }
 
     private static BackgroundAgentConfig RestrictiveConfig(string id, string? parentId) => new()
@@ -89,7 +111,7 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
         }
     };
 
-    private static BackgroundAgentConfig BroadenedChildConfig(string id, string parentId) => new()
+    private static BackgroundAgentConfig BroadenedChildConfig(string id, string? parentId) => new()
     {
         Id = id,
         ParentId = parentId,

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantBPolicyNarrowingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantBPolicyNarrowingTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Nexo.BackgroundAgents.Configuration;
 using Nexo.BackgroundAgents.Registry;
 using Nexo.Orchestration.Agents;
+using Nexo.Tests.BackgroundAgents.Registry;
 using Xunit;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
@@ -36,7 +37,7 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
             }
         };
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(parent), NullLogger<GenericAgent>.Instance),
             parent);
         await registry.RegisterAsync(
@@ -68,7 +69,7 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
         var parent = RestrictiveConfig("creator-parent", parentId: null);
         var child = BroadenedChildConfig("creator-child", parentId: "creator-parent");
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(parent), NullLogger<GenericAgent>.Instance),
             parent);
 
@@ -86,7 +87,7 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
         var registry = SelfExtendAuditTestSupport.CreateRegistry();
         var root = BroadenedChildConfig("balance-watcher", parentId: null);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(root), NullLogger<GenericAgent>.Instance),
             root);
 

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantCHumanAdmissionTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantCHumanAdmissionTests.cs
@@ -6,70 +6,103 @@ using Nexo.BackgroundAgents.Configuration;
 using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Tools;
 using Nexo.Orchestration.Agents;
-using Nexo.Runtime;
 using Xunit;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
 /// <summary>
-/// SX-AUDIT invariant C — human admission seam (ApprovalBridge) before live mesh activation.
-/// See <c>docs/SELF-EXTEND-AUDIT.md#invariant-c-human-admission-seam</c>.
+/// SX-ENFORCE invariant C — fail-closed default aggressiveness for extender cycles.
 /// </summary>
 public sealed class SelfExtendInvariantCHumanAdmissionTests
 {
     [Fact]
-    public async Task Characterization_enable_agent_starts_registered_agent_without_approval_bridge()
-    {
-        var registry = SelfExtendAuditTestSupport.CreateRegistry();
-        var config = SelfExtendAuditTestSupport.ExtenderConfig("pending-extender", Environment.CurrentDirectory);
-        await registry.RegisterAsync(
-            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
-            config);
-
-        var tool = new EnableAgentTool(registry);
-        var result = await tool.InvokeAsync(
-            new ToolCall("enable_agent", System.Text.Json.JsonSerializer.SerializeToElement(new { agentId = config.Id })),
-            new WorldSnapshot(0, new Dictionary<string, object?>()),
-            CancellationToken.None);
-
-        result.Payload.Should().BeAssignableTo<object>();
-        registry.GetAgent(config.Id)!.State.Should().Be(BackgroundAgentState.Running,
-            "EnableAgentTool calls StartAsync directly — no ApprovalBridge token is consulted");
-    }
-
-    [Fact]
-    public async Task Characterization_extender_default_active_mode_runs_without_human_approval_gate()
+    public async Task Rejection_unconfigured_extender_does_not_run_self_extend_cycle()
     {
         var runner = new SelfExtendAuditTestSupport.CountingSelfExtendRunner();
-        var registry = SelfExtendAuditTestSupport.CreateRegistry(selfExtendRunner: runner);
-        var config = SelfExtendAuditTestSupport.ExtenderConfig("auto-active-extender", Environment.CurrentDirectory);
+        var registry = SelfExtendAuditTestSupport.CreateRegistry(
+            selfExtendRunner: runner,
+            modeStore: null);
+        var config = SelfExtendAuditTestSupport.ExtenderConfig("passive-default-extender", Environment.CurrentDirectory);
 
         await registry.RegisterAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
 
-        runner.CallCount.Should().Be(1,
-            "missing mode store defaults to Active — extender executes without SemiActive IApprovalGate or ApprovalBridge");
+        runner.CallCount.Should().Be(0,
+            "missing mode store defaults to Passive — extender must not self-extend");
     }
 
     [Fact]
-    public void Characterization_semi_active_gate_is_IApprovalGate_not_mesh_admission_bridge()
+    public async Task Admission_explicitly_active_mode_runs_extender_cycle()
     {
-        typeof(IApprovalGate).Namespace.Should().Be("Nexo.BackgroundAgents.Configuration",
-            "SemiActive extender cycles consult IApprovalGate only — not commercial Discord ApprovalBridge");
-        typeof(NoApprovalGate).Name.Should().Be("NoApprovalGate",
-            "default DI registration denies SemiActive cycles when no real gate is wired");
+        var runner = new SelfExtendAuditTestSupport.CountingSelfExtendRunner();
+        var registry = SelfExtendAuditTestSupport.CreateRegistry(
+            selfExtendRunner: runner,
+            modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
+        var config = SelfExtendAuditTestSupport.ExtenderConfig("active-extender", Environment.CurrentDirectory);
+
+        await registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+        await registry.ExecuteOnceAsync(config.Id);
+
+        runner.CallCount.Should().Be(1);
     }
 
-    /// <summary>
-    /// Rejection test for invariant C. Skipped because activation does not require ApprovalBridge human admission.
-    /// </summary>
-    [Fact(Skip = "GAP: Newly registered agents activate via StartAsync/enable_agent without ApprovalBridge — see docs/SELF-EXTEND-AUDIT.md#invariant-c-human-admission-seam")]
-    public async Task Rejection_self_created_agent_auto_enable_without_approval_token_remains_disabled()
+    [Fact]
+    public async Task Admission_semi_active_with_approval_runs_extender_cycle()
+    {
+        var runner = new SelfExtendAuditTestSupport.CountingSelfExtendRunner();
+        var modeStore = new InMemoryAggressivenessModeStore();
+        modeStore.SetMode(BackgroundAgentAggressivenessMode.SemiActive);
+        var registry = SelfExtendAuditTestSupport.CreateRegistry(
+            selfExtendRunner: runner,
+            modeStore: modeStore,
+            approvalGate: new AlwaysApprovalGate());
+        var config = SelfExtendAuditTestSupport.ExtenderConfig("semi-active-extender", Environment.CurrentDirectory);
+
+        await registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+        await registry.ExecuteOnceAsync(config.Id);
+
+        runner.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Rejection_semi_active_without_approval_does_not_run_extender_cycle()
+    {
+        var runner = new SelfExtendAuditTestSupport.CountingSelfExtendRunner();
+        var modeStore = new InMemoryAggressivenessModeStore();
+        modeStore.SetMode(BackgroundAgentAggressivenessMode.SemiActive);
+        var registry = SelfExtendAuditTestSupport.CreateRegistry(
+            selfExtendRunner: runner,
+            modeStore: modeStore,
+            approvalGate: null);
+        var config = SelfExtendAuditTestSupport.ExtenderConfig("semi-active-denied", Environment.CurrentDirectory);
+
+        await registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+        await registry.ExecuteOnceAsync(config.Id);
+
+        runner.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Characterization_enable_agent_starts_registered_monitor_without_extender_gate()
     {
         var registry = SelfExtendAuditTestSupport.CreateRegistry();
-        var config = SelfExtendAuditTestSupport.ExtenderConfig("must-stay-disabled", Environment.CurrentDirectory);
+        var config = new BackgroundAgentConfig
+        {
+            Id = "map-validator",
+            Role = "monitor",
+            Enabled = true,
+            MaxDataSensitivity = "Public",
+            Commands = ["ping"],
+            Schedule = new BackgroundAgentSchedule { Type = ScheduleType.Interval, Interval = TimeSpan.FromMinutes(1) },
+        };
         await registry.RegisterAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
@@ -80,7 +113,6 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             new WorldSnapshot(0, new Dictionary<string, object?>()),
             CancellationToken.None);
 
-        registry.GetAgent(config.Id)!.State.Should().Be(BackgroundAgentState.Idle,
-            "invariant C requires explicit human ApprovalBridge admission before live execution");
+        registry.GetAgent(config.Id)!.State.Should().Be(BackgroundAgentState.Running);
     }
 }

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantCHumanAdmissionTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantCHumanAdmissionTests.cs
@@ -7,6 +7,7 @@ using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Tools;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
@@ -24,7 +25,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             modeStore: null);
         var config = SelfExtendAuditTestSupport.ExtenderConfig("passive-default-extender", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -42,7 +43,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("active-extender", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -62,7 +63,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             approvalGate: new AlwaysApprovalGate());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("semi-active-extender", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -82,7 +83,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             approvalGate: null);
         var config = SelfExtendAuditTestSupport.ExtenderConfig("semi-active-denied", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -103,7 +104,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             Commands = ["ping"],
             Schedule = new BackgroundAgentSchedule { Type = ScheduleType.Interval, Interval = TimeSpan.FromMinutes(1) },
         };
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
 

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs
@@ -5,6 +5,7 @@ using Nexo.BackgroundAgents.Agents;
 using Nexo.Orchestration.Agents;
 using Nexo.Policies.Dev;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
@@ -45,7 +46,7 @@ public sealed class SelfExtendInvariantDRecursionCeilingTests
             selfExtendRunner: runner,
             modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("deep-extender", Environment.CurrentDirectory);
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
 
@@ -68,7 +69,7 @@ public sealed class SelfExtendInvariantDRecursionCeilingTests
             selfExtendRunner: runner,
             modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("ceiling-extender", Environment.CurrentDirectory);
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
 

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs
@@ -41,7 +41,9 @@ public sealed class SelfExtendInvariantDRecursionCeilingTests
     public async Task Characterization_no_cross_cycle_extender_depth_ceiling()
     {
         var runner = new SelfExtendAuditTestSupport.CountingSelfExtendRunner();
-        var registry = SelfExtendAuditTestSupport.CreateRegistry(selfExtendRunner: runner);
+        var registry = SelfExtendAuditTestSupport.CreateRegistry(
+            selfExtendRunner: runner,
+            modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("deep-extender", Environment.CurrentDirectory);
         await registry.RegisterAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
@@ -62,7 +64,9 @@ public sealed class SelfExtendInvariantDRecursionCeilingTests
     public async Task Rejection_extension_past_configured_recursion_ceiling_is_refused()
     {
         var runner = new SelfExtendAuditTestSupport.CountingSelfExtendRunner();
-        var registry = SelfExtendAuditTestSupport.CreateRegistry(selfExtendRunner: runner);
+        var registry = SelfExtendAuditTestSupport.CreateRegistry(
+            selfExtendRunner: runner,
+            modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("ceiling-extender", Environment.CurrentDirectory);
         await registry.RegisterAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),

--- a/src/Nexo.Tests.BackgroundAgents/Services/BackgroundAgentServiceTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Services/BackgroundAgentServiceTests.cs
@@ -33,7 +33,7 @@ public sealed class BackgroundAgentServiceTests
     public async Task ExecuteAsync_registers_enabled_agents_and_starts_registry()
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
-        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()))
+        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         registry.Setup(r => r.StartAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -50,6 +50,7 @@ public sealed class BackgroundAgentServiceTests
         registry.Verify(r => r.RegisterAsync(
             It.IsAny<IAgent>(),
             It.Is<BackgroundAgentConfig>(c => c.Id == "enabled-agent"),
+            AgentRegistrationOrigin.Authored,
             It.IsAny<CancellationToken>()), Times.Once);
         registry.Verify(r => r.StartAllAsync(It.IsAny<CancellationToken>()), Times.Once);
         registry.Verify(r => r.StopAllAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -59,7 +60,7 @@ public sealed class BackgroundAgentServiceTests
     public async Task ExecuteAsync_skips_disabled_agents()
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
-        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()))
+        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         registry.Setup(r => r.StartAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -87,7 +88,7 @@ public sealed class BackgroundAgentServiceTests
         await service.StopAsync(CancellationToken.None);
 
         registry.Verify(
-            r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()),
+            r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -96,10 +97,10 @@ public sealed class BackgroundAgentServiceTests
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
         registry
-            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "bad-agent"), It.IsAny<CancellationToken>()))
+            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "bad-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("register failed"));
         registry
-            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), It.IsAny<CancellationToken>()))
+            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         registry.Setup(r => r.StartAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -135,7 +136,7 @@ public sealed class BackgroundAgentServiceTests
         await service.StopAsync(CancellationToken.None);
 
         registry.Verify(
-            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), It.IsAny<CancellationToken>()),
+            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/src/Nexo.Tests.BackgroundAgents/Tools/UpdateAgentConfigToolTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Tools/UpdateAgentConfigToolTests.cs
@@ -65,7 +65,7 @@ public sealed class UpdateAgentConfigToolTests
     public async Task InvokeAsync_re_registers_agent_from_config()
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
-        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()))
+        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var tool = CreateTool(registry.Object, CreateConfigLoader());
@@ -76,7 +76,7 @@ public sealed class UpdateAgentConfigToolTests
 
         result.Delta.Log.Should().Contain(l => l.Contains("Re-registered"));
         registry.Verify(
-            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "cfg-agent"), It.IsAny<CancellationToken>()),
+            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "cfg-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
@@ -75,7 +75,7 @@ public sealed class BackgroundAgentLifecycleE2ETests
         var configs = await configLoader.LoadAsync(default);
         var spec = specBuilder.BuildSpec(configs[0]);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, configs[0], default);
+        await registry.RegisterAsync(agent, configs[0], AgentRegistrationOrigin.Authored);
         return agent;
     }
 

--- a/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
@@ -40,7 +40,9 @@ public sealed class BackgroundAgentLifecycleE2ETests
         var scheduler = new AgentScheduler(scheduleExecutor, null);
         var registry = new BackgroundAgentRegistry(
             scheduler, null, logStore, null, null,
-            extendRunner, selfImprovementLoop: null, modeStore, approvalGate, auditLog);
+            extendRunner, selfImprovementLoop: null, modeStore, approvalGate,
+            sensitivityRegistry: new DataSensitivityRegistry(),
+            auditLog: auditLog);
         return (registry, logStore);
     }
 
@@ -89,7 +91,8 @@ public sealed class BackgroundAgentLifecycleE2ETests
         var scheduler = new AgentScheduler(new ScheduleExecutor(), null);
         var registry = new BackgroundAgentRegistry(
             scheduler, null, logStore, null, null,
-            mockExtend, selfImprovementLoop: null, modeStore);
+            mockExtend, selfImprovementLoop: null, modeStore,
+            sensitivityRegistry: new DataSensitivityRegistry());
 
         await RegisterExtenderAgent(registry, "transition-test");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SX-ENFORCE closes the three high-severity self-extension gaps documented in SX-AUDIT by wiring existing certification + policy machinery fail-closed. Invariant **D** remains deferred.

## Enforcement

| Invariant | Change |
|-----------|--------|
| **A** Cert-gate | `SelfProducedBrickCertificationPolicy` on self-extend toolbox path; `CertificationTrustVerifier` content-bound checks; `FailClosedCertificationRecordStore` when unwired |
| **B** Policy narrowing | `AgentPolicyNarrowingValidator` at `RegisterAsync` for `ParentId` children; snapshot `agentId` + `DataExfiltrationPolicy` on self-extend path |
| **C** Fail-closed default | `FileBasedAggressivenessModeStore` + registry fallback → **Passive**; SemiActive without approval denies |

## Tests

```bash
dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj --filter "FullyQualifiedName~SelfExtendInvariant"
```

- **16 passed, 1 skipped (D GAP)** — A/B/C rejection tests un-Skipped and passing
- Full `Nexo.Tests.BackgroundAgents`: **399 tests green** (net8 + net9)

## Boot agent set

Human-authored roots (`ParentId` absent) skip policy narrowing. Monitors (`map-validator`) still `enable_agent` → `Running`. Extenders require explicit `Active` mode (or approved SemiActive) to self-extend.

## Docs

`docs/SELF-EXTEND-AUDIT.md` updated — A/B/C **ENFORCED** with executing line citations; D **GAP/deferred**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

