### PR TITLE
feat(sx): SX-HARDEN — close fail-open seams (origin + cert gate defaults)

### DIFF
--- a/application/src/Nexo.CLI/Commands/BackgroundAgent/BackgroundAgentCommand.cs
+++ b/application/src/Nexo.CLI/Commands/BackgroundAgent/BackgroundAgentCommand.cs
@@ -321,7 +321,7 @@ public class BackgroundAgentCommand
                     var autoConfig = CloneForAutoscale(template, autoId);
                     var spec = _specBuilder.BuildSpec(autoConfig);
                     var agent = _agentFactory.CreateAgent(spec);
-                    await _registry.RegisterAsync(agent, autoConfig, ct);
+                    await _registry.RegisterAsync(agent, autoConfig, cancellationToken: ct);
                     await _registry.StartAsync(autoId, ct);
                     created.Add(autoId);
                     started.Add(autoId);
@@ -405,7 +405,7 @@ public class BackgroundAgentCommand
             ?? throw new InvalidOperationException($"Agent '{id}' not found in configuration");
         var spec = _specBuilder.BuildSpec(config);
         var agent = _agentFactory.CreateAgent(spec);
-        await _registry.RegisterAsync(agent, config, ct);
+        await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, ct);
     }
 
     public static int CalculateDesiredAgentCount(int demand, int minAgents, int maxAgents, int unitsPerAgent)

--- a/application/src/Nexo.CLI/Commands/BackgroundAgent/ExecuteBackgroundAgentCommand.cs
+++ b/application/src/Nexo.CLI/Commands/BackgroundAgent/ExecuteBackgroundAgentCommand.cs
@@ -75,6 +75,6 @@ public class ExecuteBackgroundAgentCommand
             ?? throw new InvalidOperationException($"Agent '{id}' not found in configuration");
         var spec = _specBuilder.BuildSpec(config);
         var agent = _agentFactory.CreateAgent(spec);
-        await _registry.RegisterAsync(agent, config, ct).ConfigureAwait(false);
+        await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, ct).ConfigureAwait(false);
     }
 }

--- a/src/Nexo.BackgroundAgents.HostRunners/RepoFsToolboxFactory.cs
+++ b/src/Nexo.BackgroundAgents.HostRunners/RepoFsToolboxFactory.cs
@@ -136,10 +136,8 @@ internal static class RepoFsToolboxFactory
             policyList.Add(new ForgeMediatedWritesPolicy(modeStore));
         }
 
-        if (certificationStore is not null)
-        {
-            policyList.Add(new SelfProducedBrickCertificationPolicy(certificationStore));
-        }
+        policyList.Add(new SelfProducedBrickCertificationPolicy(
+            certificationStore ?? FailClosedCertificationRecordStore.Instance));
 
         if (agentRegistry is not null && sensitivityRegistry is not null)
         {

--- a/src/Nexo.BackgroundAgents/Configuration/AgentRegistrationOrigin.cs
+++ b/src/Nexo.BackgroundAgents/Configuration/AgentRegistrationOrigin.cs
@@ -1,0 +1,14 @@
+namespace Nexo.BackgroundAgents.Configuration;
+
+/// <summary>
+/// Provenance of a <see cref="BackgroundAgentRegistry.RegisterAsync"/> call.
+/// Machine-origin registrations must carry a resolvable parent; authored registrations are trust roots.
+/// </summary>
+public enum AgentRegistrationOrigin
+{
+    /// <summary>Human-authored configuration (boot agent_set, reload from config file).</summary>
+    Authored,
+
+    /// <summary>Machine-proposed registration; requires parent resolution and policy narrowing.</summary>
+    Machine
+}

--- a/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
+++ b/src/Nexo.BackgroundAgents/Registry/BackgroundAgentRegistry.cs
@@ -52,7 +52,15 @@ public interface IBackgroundAgentRegistry
     /// started or executed. Duplicate registration for the same agent ID
     /// overwrites the previous instance.
     /// </summary>
-    Task RegisterAsync(IAgent agent, BackgroundAgentConfig config, CancellationToken cancellationToken = default);
+    /// <param name="origin">
+    /// Registration provenance. Defaults to <see cref="AgentRegistrationOrigin.Machine"/> so
+    /// callers that omit provenance must justify themselves with a resolvable parent.
+    /// </param>
+    Task RegisterAsync(
+        IAgent agent,
+        BackgroundAgentConfig config,
+        AgentRegistrationOrigin origin = AgentRegistrationOrigin.Machine,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Look up a registered agent by ID. Returns <c>null</c> for unknown IDs
@@ -193,7 +201,11 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
     /// <summary>
     /// Register a background agent.
     /// </summary>
-    public Task RegisterAsync(IAgent agent, BackgroundAgentConfig config, CancellationToken cancellationToken = default)
+    public Task RegisterAsync(
+        IAgent agent,
+        BackgroundAgentConfig config,
+        AgentRegistrationOrigin origin = AgentRegistrationOrigin.Machine,
+        CancellationToken cancellationToken = default)
     {
         if (agent == null)
             throw new ArgumentNullException(nameof(agent));
@@ -202,6 +214,7 @@ public sealed class BackgroundAgentRegistry : IBackgroundAgentRegistry
 
         AgentPolicyNarrowingValidator.ValidateOrThrow(
             config,
+            origin,
             parentId => _agents.TryGetValue(parentId, out var parent) ? parent : null,
             _sensitivityRegistry ?? new DataSensitivityRegistry());
 

--- a/src/Nexo.BackgroundAgents/Security/AgentPolicyNarrowingValidator.cs
+++ b/src/Nexo.BackgroundAgents/Security/AgentPolicyNarrowingValidator.cs
@@ -5,30 +5,37 @@ using Nexo.BackgroundAgents.Registry;
 namespace Nexo.BackgroundAgents.Security;
 
 /// <summary>
-/// Enforces child ⊆ creator exfiltration/sensitivity envelope at machine-spawn registration.
-/// Human-authored roots (no <see cref="BackgroundAgentConfig.ParentId"/>) are trust roots and skip validation.
+/// Enforces child ⊆ creator exfiltration/sensitivity envelope at machine-origin registration.
+/// Authored registrations are trust roots and skip validation.
 /// </summary>
 public static class AgentPolicyNarrowingValidator
 {
     public static void ValidateOrThrow(
         BackgroundAgentConfig child,
+        AgentRegistrationOrigin origin,
         Func<string, BackgroundAgentInstance?> resolveParent,
         IDataSensitivityRegistry sensitivityRegistry)
     {
-        if (string.IsNullOrWhiteSpace(child.ParentId))
+        if (origin == AgentRegistrationOrigin.Authored)
             return;
+
+        if (string.IsNullOrWhiteSpace(child.ParentId))
+        {
+            throw new InvalidOperationException(
+                $"Refusing machine-origin agent '{child.Id}': ParentId is required.");
+        }
 
         if (sensitivityRegistry is null)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': sensitivity registry unavailable to verify parent envelope.");
+                $"Refusing machine-origin agent '{child.Id}': sensitivity registry unavailable to verify parent envelope.");
         }
 
         var parentInstance = resolveParent(child.ParentId);
         if (parentInstance is null)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': parent '{child.ParentId}' is not registered.");
+                $"Refusing machine-origin agent '{child.Id}': parent '{child.ParentId}' is not registered.");
         }
 
         var parent = parentInstance.Config;
@@ -38,25 +45,25 @@ public static class AgentPolicyNarrowingValidator
         if (parentPolicy.BlockExternalLLMs && !childPolicy.BlockExternalLLMs)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': BlockExternalLLMs cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': BlockExternalLLMs cannot be relaxed below parent '{parent.Id}'.");
         }
 
         if (parentPolicy.BlockWebSearch && !childPolicy.BlockWebSearch)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': BlockWebSearch cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': BlockWebSearch cannot be relaxed below parent '{parent.Id}'.");
         }
 
         if (parentPolicy.BlockNetworkExports && !childPolicy.BlockNetworkExports)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': BlockNetworkExports cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': BlockNetworkExports cannot be relaxed below parent '{parent.Id}'.");
         }
 
         if (parentPolicy.RequireLocalOnly && !childPolicy.RequireLocalOnly)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{child.Id}': RequireLocalOnly cannot be relaxed below parent '{parent.Id}'.");
+                $"Refusing machine-origin agent '{child.Id}': RequireLocalOnly cannot be relaxed below parent '{parent.Id}'.");
         }
 
         EnsureLevelNotBroader(
@@ -86,7 +93,7 @@ public static class AgentPolicyNarrowingValidator
                 if (parentAllowed is not null && !parentAllowed.Contains(levelName))
                 {
                     throw new InvalidOperationException(
-                        $"Refusing machine-spawned agent '{child.Id}': AllowedDataSensitivityLevels contains '{levelName}' outside parent '{parent.Id}' allow-list.");
+                        $"Refusing machine-origin agent '{child.Id}': AllowedDataSensitivityLevels contains '{levelName}' outside parent '{parent.Id}' allow-list.");
                 }
 
                 EnsureLevelNotBroader(
@@ -113,13 +120,13 @@ public static class AgentPolicyNarrowingValidator
         if (parentLevel is null || childLevel is null)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{childId}': unable to resolve {field} sensitivity levels for parent/child comparison.");
+                $"Refusing machine-origin agent '{childId}': unable to resolve {field} sensitivity levels for parent/child comparison.");
         }
 
         if (childLevel.SensitivityValue > parentLevel.SensitivityValue)
         {
             throw new InvalidOperationException(
-                $"Refusing machine-spawned agent '{childId}': {field} '{childLevelName}' exceeds parent '{parentId}' envelope '{parentLevelName}'.");
+                $"Refusing machine-origin agent '{childId}': {field} '{childLevelName}' exceeds parent '{parentId}' envelope '{parentLevelName}'.");
         }
     }
 }

--- a/src/Nexo.BackgroundAgents/Services/BackgroundAgentService.cs
+++ b/src/Nexo.BackgroundAgents/Services/BackgroundAgentService.cs
@@ -126,7 +126,7 @@ public class BackgroundAgentService : BackgroundService
         var agent = _agentFactory.CreateAgent(spec);
 
         // Register with registry
-        await _registry.RegisterAsync(agent, config, cancellationToken);
+        await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, cancellationToken);
 
         _logger.LogInformation("Created and registered background agent: {AgentId}", config.Id);
     }

--- a/src/Nexo.BackgroundAgents/Tools/UpdateAgentConfigTool.cs
+++ b/src/Nexo.BackgroundAgents/Tools/UpdateAgentConfigTool.cs
@@ -72,7 +72,7 @@ public sealed class UpdateAgentConfigTool : ITool
             }
             var spec = _specBuilder.BuildSpec(config);
             var agent = _agentFactory.CreateAgent(spec);
-            await _registry.RegisterAsync(agent, config, ct).ConfigureAwait(false);
+            await _registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, ct).ConfigureAwait(false);
             var okLog = new[] { $"Re-registered background agent from config: {agentId}" };
             var okDelta = new ActionDelta(s.Tick, s.Tick + 1, okLog);
             return new ToolResult(okDelta, new { ok = true, agentId, action = "updated" });

--- a/src/Nexo.Tests.BackgroundAgents/Configuration/AggressivenessModeTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Configuration/AggressivenessModeTests.cs
@@ -14,6 +14,7 @@ using Nexo.Core.Application.Trust.Models;
 using Nexo.Core.Application.Trust.Ports;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Configuration;
 
@@ -62,7 +63,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-passive", default);
 
@@ -111,7 +112,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-active", default);
 
@@ -215,7 +216,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive", default);
 
@@ -265,7 +266,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive-denied", default);
 
@@ -315,7 +316,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive-timeout", default);
 
@@ -365,7 +366,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-semiactive-approved", default);
 
@@ -412,7 +413,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-ambient", default);
 
@@ -462,7 +463,7 @@ public sealed class AggressivenessModeTests
         var agentConfig = configs[0];
         var spec = specBuilder.BuildSpec(agentConfig);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("extender-ambient-audit", default);
 

--- a/src/Nexo.Tests.BackgroundAgents/Integration/BackgroundAgentsE2ETests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Integration/BackgroundAgentsE2ETests.cs
@@ -11,6 +11,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Integration;
 
@@ -58,7 +59,7 @@ public class BackgroundAgentsE2ETests
         var spec = specBuilder.BuildSpec(agentConfig);
         var logger = sp.GetRequiredService<ILogger<GenericAgent>>();
         var agent = new GenericAgent(spec, logger);
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
 
         await registry.ExecuteOnceAsync("e2e-agent", default);
 

--- a/src/Nexo.Tests.BackgroundAgents/Performance/ExecuteOncePerformanceTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Performance/ExecuteOncePerformanceTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Performance;
 
@@ -82,7 +83,7 @@ public class ExecuteOncePerformanceTests
         var spec = specBuilder.BuildSpec(agentConfig);
         var logger = sp.GetRequiredService<ILogger<GenericAgent>>();
         var agent = new GenericAgent(spec, logger);
-        await registry.RegisterAsync(agent, agentConfig, default);
+        await registry.RegisterAuthoredAsync(agent, agentConfig);
         return (registry, agentConfig.Id);
     }
 }

--- a/src/Nexo.Tests.BackgroundAgents/Performance/LoadTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Performance/LoadTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Performance;
 
@@ -122,7 +123,7 @@ public class LoadTests
         {
             var spec = specBuilder.BuildSpec(agentConfig);
             var agent = new GenericAgent(spec, logger);
-            await registry.RegisterAsync(agent, agentConfig, default);
+            await registry.RegisterAuthoredAsync(agent, agentConfig);
             agentIds.Add(agentConfig.Id);
         }
         return (registry, agentIds);

--- a/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryGapCoverageTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryGapCoverageTests.cs
@@ -16,6 +16,7 @@ using Nexo.Core.Application.SelfImprovement.Ports;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -27,8 +28,8 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry();
         var config = MonitorConfig("dup-agent");
 
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         registry.GetAll().Should().ContainSingle(a => a.Config.Id == "dup-agent");
     }
@@ -51,7 +52,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry();
         var config = MonitorConfig("running-agent");
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.StartAsync(config.Id);
         await registry.StartAsync(config.Id);
@@ -64,7 +65,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry();
         var config = MonitorConfig("idle-agent");
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.StopAsync(config.Id);
 
@@ -94,7 +95,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             Enabled = true,
         };
 
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -122,7 +123,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry(testRunRunner: new ThrowingTestRunner());
         var config = new BackgroundAgentConfig { Id = "failing-tester", Role = "tester", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.ExecuteOnceAsync(config.Id);
 
@@ -145,7 +146,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry(selfExtendRunner: runner, observations: store);
 
         var config = ExtenderConfig("extender-obs", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var obs = store.All.Should().ContainSingle().Subject;
@@ -168,7 +169,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry(selfExtendRunner: runner, observations: store);
 
         var config = ExtenderConfig("extender-fail", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         store.All.Should().ContainSingle().Which.severity.Should().Be(ObservationSeverity.Warn);
@@ -191,7 +192,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var config = ExtenderConfig("extender-telem", Environment.CurrentDirectory);
         config.ModelProvider = "ollama";
         config.ModelName = "llama3";
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var evt = cycleEvents.Read().Should().ContainSingle().Subject;
@@ -215,7 +216,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
 
         var registry = BuildRegistry(selfImprovementLoop: loop.Object, modeStore: modeStore.Object);
         var config = new BackgroundAgentConfig { Id = "self-improver-semi", Role = "self-improver", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -244,7 +245,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             modeStore: modeStore.Object,
             approvalGate: new AlwaysApprovalGate());
         var config = new BackgroundAgentConfig { Id = "self-improver-run", Role = "self-improver", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -265,7 +266,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             modeStore: modeStore.Object,
             approvalGate: new AlwaysApprovalGate());
         var config = new BackgroundAgentConfig { Id = "self-improver-null-report", Role = "self-improver", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         loop.Verify(l => l.RunOnceAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -277,7 +278,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry(codeAnalysisRunner: new FakeCodeAnalysisRunner(true, "unused", 0));
         var config = new BackgroundAgentConfig { Id = "optimizer-default", Role = "optimizer", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         registry.GetAgent(config.Id)!.SuccessCount.Should().Be(1);
@@ -293,7 +294,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             shutdownGracePeriod: TimeSpan.FromSeconds(2));
 
         var config = ExtenderConfig("drain-agent", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         var cycle = registry.ExecuteOnceAsync(config.Id);
         await Task.Delay(50);
@@ -315,7 +316,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             shutdownGracePeriod: TimeSpan.FromMilliseconds(50));
 
         var config = ExtenderConfig("slow-agent", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         var cycle = registry.ExecuteOnceAsync(config.Id);
         await Task.Delay(30);
@@ -331,7 +332,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var runner = new DelaySelfExtendRunner(TimeSpan.FromSeconds(5));
         var registry = BuildRegistry(selfExtendRunner: runner);
         var config = ExtenderConfig("cancel-agent", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
@@ -349,7 +350,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
 
         var registry = BuildRegistry(selfExtendRunner: runner, modeStore: modeStore.Object);
         var config = ExtenderConfig("extender-passive", Environment.CurrentDirectory);
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         registry.GetAgent(config.Id)!.SuccessCount.Should().Be(1);
@@ -368,7 +369,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
             Enabled = true,
             Parameters = new Dictionary<string, object> { ["Path"] = Environment.CurrentDirectory },
         };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         runner.LastRepoRoot.Should().Be(Environment.CurrentDirectory);
@@ -380,7 +381,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var runner = new RecordingSelfExtendRunner();
         var registry = BuildRegistry(selfExtendRunner: runner);
         var config = new BackgroundAgentConfig { Id = "extender-no-path", Role = "extender", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         runner.LastRepoRoot.Should().BeNull();
@@ -392,7 +393,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
     {
         var registry = BuildRegistry();
         var config = MonitorConfig("start-all-agent");
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         await registry.StartAllAsync();
 
@@ -408,7 +409,7 @@ public sealed class BackgroundAgentRegistryGapCoverageTests
         var registry = BuildRegistry(testRunRunner: new ThrowingTestRunner(), cycleEvents: cycleEvents);
 
         var config = new BackgroundAgentConfig { Id = "fail-telem", Role = "tester", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var evt = cycleEvents.Read().Should().ContainSingle().Subject;

--- a/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryTestExtensions.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/BackgroundAgentRegistryTestExtensions.cs
@@ -1,0 +1,18 @@
+using Nexo.Abstractions;
+using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.Registry;
+
+namespace Nexo.Tests.BackgroundAgents.Registry;
+
+/// <summary>
+/// Test helpers for boot-simulation registrations that mirror human-authored paths.
+/// </summary>
+internal static class BackgroundAgentRegistryTestExtensions
+{
+    internal static Task RegisterAuthoredAsync(
+        this IBackgroundAgentRegistry registry,
+        IAgent agent,
+        BackgroundAgentConfig config,
+        CancellationToken cancellationToken = default) =>
+        registry.RegisterAsync(agent, config, AgentRegistrationOrigin.Authored, cancellationToken);
+}

--- a/src/Nexo.Tests.BackgroundAgents/Registry/IgnoredLlmConfigWarningTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/IgnoredLlmConfigWarningTests.cs
@@ -7,6 +7,7 @@ using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -44,7 +45,7 @@ public sealed class IgnoredLlmConfigWarningTests
         };
 
         var spec = new BackgroundAgentSpecBuilder(new DataSensitivityRegistry(), null).BuildSpec(config);
-        await registry.RegisterAsync(new GenericAgent(spec, NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(spec, NullLogger<GenericAgent>.Instance), config);
 
         if (expectWarning)
             captured.Should().Contain(m => m.Contains("IGNORED", StringComparison.Ordinal) && m.Contains("agent-x"));

--- a/src/Nexo.Tests.BackgroundAgents/Registry/ObservationsPublishingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/ObservationsPublishingTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.BackgroundAgents.Testing;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -37,7 +38,7 @@ public sealed class ObservationsPublishingTests
             Parameters = new Dictionary<string, object> { ["Filter"] = "PathAllowlist" }
         };
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
         await registry.ExecuteOnceAsync(config.Id);
 
         store.All.Should().ContainSingle();
@@ -64,7 +65,7 @@ public sealed class ObservationsPublishingTests
             Role = "tester",
             Enabled = true
         };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         store.All.Should().ContainSingle().Which.severity.Should().Be(ObservationSeverity.Info);
@@ -85,7 +86,7 @@ public sealed class ObservationsPublishingTests
             Enabled = true,
             Parameters = new Dictionary<string, object> { ["Path"] = "src/Nexo.Core" }
         };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var obs = store.All.Should().ContainSingle().Subject;
@@ -106,7 +107,7 @@ public sealed class ObservationsPublishingTests
             observations: null);
 
         var config = new BackgroundAgentConfig { Id = "tester-3", Role = "tester", Enabled = true };
-        await registry.RegisterAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
+        await registry.RegisterAuthoredAsync(new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance), config);
 
         var act = async () => await registry.ExecuteOnceAsync(config.Id);
         await act.Should().NotThrowAsync();

--- a/src/Nexo.Tests.BackgroundAgents/Registry/SelfExtendParameterFlowTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Registry/SelfExtendParameterFlowTests.cs
@@ -9,6 +9,7 @@ using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Registry;
 
@@ -46,7 +47,7 @@ public sealed class SelfExtendParameterFlowTests
         };
 
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
 
         await registry.ExecuteOnceAsync(config.Id);
 
@@ -80,7 +81,7 @@ public sealed class SelfExtendParameterFlowTests
         };
 
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var call = fakeRunner.Calls.Single();
@@ -109,7 +110,7 @@ public sealed class SelfExtendParameterFlowTests
             }
         };
         var agent = new GenericAgent(BuildSpec(config), NullLogger<GenericAgent>.Instance);
-        await registry.RegisterAsync(agent, config);
+        await registry.RegisterAuthoredAsync(agent, config);
         await registry.ExecuteOnceAsync(config.Id);
 
         var call = fakeRunner.Calls.Single();

--- a/src/Nexo.Tests.BackgroundAgents/Resilience/RegistryResilienceTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Resilience/RegistryResilienceTests.cs
@@ -10,6 +10,7 @@ using Nexo.BackgroundAgents.Scheduling;
 using Nexo.Orchestration.Agents;
 using Nexo.Orchestration.Architect.Models;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.Resilience;
 
@@ -152,7 +153,7 @@ public class RegistryResilienceTests
         {
             var spec = specBuilder.BuildSpec(agentConfig);
             var agent = new GenericAgent(spec, logger);
-            await registry.RegisterAsync(agent, agentConfig, default);
+            await registry.RegisterAuthoredAsync(agent, agentConfig);
             agentIds.Add(agentConfig.Id);
         }
         return (registry, agentIds);

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendHardeningFinding1Tests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendHardeningFinding1Tests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.BackgroundAgents.Configuration;
+using Nexo.BackgroundAgents.Registry;
+using Nexo.Orchestration.Agents;
+using Nexo.Tests.BackgroundAgents.Registry;
+using Xunit;
+
+namespace Nexo.Tests.BackgroundAgents.SelfExtend;
+
+/// <summary>
+/// SX-HARDEN finding 1 — machine-origin registration must carry a resolvable parent.
+/// </summary>
+public sealed class SelfExtendHardeningFinding1Tests
+{
+    [Fact]
+    public async Task Rejection_machine_origin_with_blank_parent_is_refused()
+    {
+        var registry = SelfExtendAuditTestSupport.CreateRegistry();
+        var config = RootConfig("orphan-machine-agent");
+
+        var act = () => registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ParentId is required*");
+    }
+
+    [Fact]
+    public async Task Rejection_machine_origin_with_unregistered_parent_is_refused()
+    {
+        var registry = SelfExtendAuditTestSupport.CreateRegistry();
+        var config = new BackgroundAgentConfig
+        {
+            Id = "missing-parent-child",
+            ParentId = "not-registered-parent",
+            Role = "extender",
+            Enabled = true,
+            MaxDataSensitivity = "Public",
+            Commands = ["extend"],
+        };
+
+        var act = () => registry.RegisterAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not registered*");
+    }
+
+    [Fact]
+    public async Task Admission_authored_origin_with_blank_parent_registers()
+    {
+        var registry = SelfExtendAuditTestSupport.CreateRegistry();
+        var config = RootConfig("balance-watcher");
+
+        await registry.RegisterAuthoredAsync(
+            new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
+            config);
+
+        registry.GetAgent("balance-watcher").Should().NotBeNull();
+    }
+
+    private static BackgroundAgentConfig RootConfig(string id) => new()
+    {
+        Id = id,
+        Role = "monitor",
+        Enabled = true,
+        MaxDataSensitivity = "Public",
+        Commands = ["ping"],
+    };
+}

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantACertGateTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantACertGateTests.cs
@@ -32,6 +32,30 @@ public sealed class SelfExtendInvariantACertGateTests
     }
 
     [Fact]
+    public void Rejection_default_factory_without_explicit_cert_store_refuses_uncertified_brick()
+    {
+        var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest();
+
+        var policyTypes = SelfExtendAuditTestSupport.GetPolicies(policies)
+            .Select(p => p.GetType().Name)
+            .ToList();
+        policyTypes.Should().Contain(nameof(SelfProducedBrickCertificationPolicy));
+
+        var call = new ToolCall(
+            "repo.fs.write",
+            JsonSerializer.SerializeToElement(new { path = BrickRelativePath, content = BrickSource }));
+
+        var snapshot = new WorldSnapshot(0, new Dictionary<string, object?>
+        {
+            ["RepoRoot"] = "/workspace",
+            ["selfExtendAdmission"] = true
+        });
+
+        policies.Approve(call, snapshot, out var reason).Should().BeFalse();
+        reason.Should().Contain("no certification record");
+    }
+
+    [Fact]
     public void Rejection_uncertified_self_proposed_brick_is_refused_at_registration_or_use()
     {
         var (_, policies, _) = RepoFsToolboxFactory.CreateWithBuildTest(

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantBPolicyNarrowingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantBPolicyNarrowingTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Nexo.BackgroundAgents.Configuration;
 using Nexo.BackgroundAgents.Registry;
 using Nexo.Orchestration.Agents;
+using Nexo.Tests.BackgroundAgents.Registry;
 using Xunit;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
@@ -36,7 +37,7 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
             }
         };
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(parent), NullLogger<GenericAgent>.Instance),
             parent);
         await registry.RegisterAsync(
@@ -68,7 +69,7 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
         var parent = RestrictiveConfig("creator-parent", parentId: null);
         var child = BroadenedChildConfig("creator-child", parentId: "creator-parent");
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(parent), NullLogger<GenericAgent>.Instance),
             parent);
 
@@ -86,7 +87,7 @@ public sealed class SelfExtendInvariantBPolicyNarrowingTests
         var registry = SelfExtendAuditTestSupport.CreateRegistry();
         var root = BroadenedChildConfig("balance-watcher", parentId: null);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(root), NullLogger<GenericAgent>.Instance),
             root);
 

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantCHumanAdmissionTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantCHumanAdmissionTests.cs
@@ -7,6 +7,7 @@ using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Tools;
 using Nexo.Orchestration.Agents;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
@@ -24,7 +25,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             modeStore: null);
         var config = SelfExtendAuditTestSupport.ExtenderConfig("passive-default-extender", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -42,7 +43,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("active-extender", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -62,7 +63,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             approvalGate: new AlwaysApprovalGate());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("semi-active-extender", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -82,7 +83,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             approvalGate: null);
         var config = SelfExtendAuditTestSupport.ExtenderConfig("semi-active-denied", Environment.CurrentDirectory);
 
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
         await registry.ExecuteOnceAsync(config.Id);
@@ -103,7 +104,7 @@ public sealed class SelfExtendInvariantCHumanAdmissionTests
             Commands = ["ping"],
             Schedule = new BackgroundAgentSchedule { Type = ScheduleType.Interval, Interval = TimeSpan.FromMinutes(1) },
         };
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
 

--- a/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/SelfExtend/SelfExtendInvariantDRecursionCeilingTests.cs
@@ -5,6 +5,7 @@ using Nexo.BackgroundAgents.Agents;
 using Nexo.Orchestration.Agents;
 using Nexo.Policies.Dev;
 using Xunit;
+using Nexo.Tests.BackgroundAgents.Registry;
 
 namespace Nexo.Tests.BackgroundAgents.SelfExtend;
 
@@ -45,7 +46,7 @@ public sealed class SelfExtendInvariantDRecursionCeilingTests
             selfExtendRunner: runner,
             modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("deep-extender", Environment.CurrentDirectory);
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
 
@@ -68,7 +69,7 @@ public sealed class SelfExtendInvariantDRecursionCeilingTests
             selfExtendRunner: runner,
             modeStore: SelfExtendAuditTestSupport.ActiveModeStore());
         var config = SelfExtendAuditTestSupport.ExtenderConfig("ceiling-extender", Environment.CurrentDirectory);
-        await registry.RegisterAsync(
+        await registry.RegisterAuthoredAsync(
             new GenericAgent(SelfExtendAuditTestSupport.BuildSpec(config), NullLogger<GenericAgent>.Instance),
             config);
 

--- a/src/Nexo.Tests.BackgroundAgents/Services/BackgroundAgentServiceTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Services/BackgroundAgentServiceTests.cs
@@ -33,7 +33,7 @@ public sealed class BackgroundAgentServiceTests
     public async Task ExecuteAsync_registers_enabled_agents_and_starts_registry()
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
-        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()))
+        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         registry.Setup(r => r.StartAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -50,6 +50,7 @@ public sealed class BackgroundAgentServiceTests
         registry.Verify(r => r.RegisterAsync(
             It.IsAny<IAgent>(),
             It.Is<BackgroundAgentConfig>(c => c.Id == "enabled-agent"),
+            AgentRegistrationOrigin.Authored,
             It.IsAny<CancellationToken>()), Times.Once);
         registry.Verify(r => r.StartAllAsync(It.IsAny<CancellationToken>()), Times.Once);
         registry.Verify(r => r.StopAllAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -59,7 +60,7 @@ public sealed class BackgroundAgentServiceTests
     public async Task ExecuteAsync_skips_disabled_agents()
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
-        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()))
+        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         registry.Setup(r => r.StartAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -87,7 +88,7 @@ public sealed class BackgroundAgentServiceTests
         await service.StopAsync(CancellationToken.None);
 
         registry.Verify(
-            r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()),
+            r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -96,10 +97,10 @@ public sealed class BackgroundAgentServiceTests
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
         registry
-            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "bad-agent"), It.IsAny<CancellationToken>()))
+            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "bad-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("register failed"));
         registry
-            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), It.IsAny<CancellationToken>()))
+            .Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         registry.Setup(r => r.StartAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -135,7 +136,7 @@ public sealed class BackgroundAgentServiceTests
         await service.StopAsync(CancellationToken.None);
 
         registry.Verify(
-            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), It.IsAny<CancellationToken>()),
+            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "good-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/src/Nexo.Tests.BackgroundAgents/Tools/UpdateAgentConfigToolTests.cs
+++ b/src/Nexo.Tests.BackgroundAgents/Tools/UpdateAgentConfigToolTests.cs
@@ -65,7 +65,7 @@ public sealed class UpdateAgentConfigToolTests
     public async Task InvokeAsync_re_registers_agent_from_config()
     {
         var registry = new Mock<IBackgroundAgentRegistry>();
-        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), It.IsAny<CancellationToken>()))
+        registry.Setup(r => r.RegisterAsync(It.IsAny<IAgent>(), It.IsAny<BackgroundAgentConfig>(), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var tool = CreateTool(registry.Object, CreateConfigLoader());
@@ -76,7 +76,7 @@ public sealed class UpdateAgentConfigToolTests
 
         result.Delta.Log.Should().Contain(l => l.Contains("Re-registered"));
         registry.Verify(
-            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "cfg-agent"), It.IsAny<CancellationToken>()),
+            r => r.RegisterAsync(It.IsAny<IAgent>(), It.Is<BackgroundAgentConfig>(c => c.Id == "cfg-agent"), AgentRegistrationOrigin.Authored, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
@@ -75,7 +75,7 @@ public sealed class BackgroundAgentLifecycleE2ETests
         var configs = await configLoader.LoadAsync(default);
         var spec = specBuilder.BuildSpec(configs[0]);
         var agent = new GenericAgent(spec, services.GetRequiredService<ILogger<GenericAgent>>());
-        await registry.RegisterAsync(agent, configs[0], default);
+        await registry.RegisterAsync(agent, configs[0], AgentRegistrationOrigin.Authored);
         return agent;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the two residual fail-open seams from the SX-ENFORCE review so A/B teeth cannot be bypassed by omission. Absence denies: machine-origin registrations must justify themselves with a resolvable parent, and every `CreateWithBuildTest` toolbox carries the cert gate by default.

## Changes

- **Finding 1 — registration origin:** Introduced `AgentRegistrationOrigin { Authored, Machine }` threaded into `RegisterAsync` (default `Machine`). `AgentPolicyNarrowingValidator` exempts `Authored` trust roots; `Machine` requires a resolvable `ParentId` and existing child⊆parent narrowing.
- **Authored paths:** Boot registration (`BackgroundAgentService`), config reload (`UpdateAgentConfigTool`), and CLI config-loader paths pass `Authored`. Autoscale clones keep default `Machine` with explicit `ParentId`.
- **Finding 2 — cert gate not omittable:** `RepoFsToolboxFactory.CreateWithBuildTest` always adds `SelfProducedBrickCertificationPolicy`; omitted/null cert store coalesces to `FailClosedCertificationRecordStore.Instance`.
- **Tests:** `SelfExtendHardeningFinding1Tests` (Machine blank/unregistered parent → REFUSED; Authored blank parent → REGISTERS). Invariant A adds default-factory uncertified-brick rejection. Existing A/B/C tests updated for authored boot simulation; D unchanged (still SKIP).

## Testing

```bash
dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj --filter "FullyQualifiedName~SelfExtend"
dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj
```

- SelfExtend suite: **42 passed**, 1 skipped (invariant D)
- Full `Nexo.Tests.BackgroundAgents`: **405 passed**, 1 skipped

### Testing strategy (blast radius)

| Change type | Minimum proof |
|-------------|---------------|
| Background agent registry / security policies | Focused SelfExtend invariant + hardening tests · full BackgroundAgents test project |

- [ ] `make kernel-coverage-gate` (not required — no Core.Domain/Infrastructure adapter changes beyond E2E registration arg)
- [ ] `make kernel-gate` (not required)
- [ ] `make test-prod-style` (not required)

## Checklist

- [x] Targeted tests pass locally (`Nexo.Tests.BackgroundAgents`)
- [ ] Documentation updated (not required for this sprint)
- [x] No unresolved `TODO` / `NotImplementedException`
- [x] No breaking public API beyond intentional `RegisterAsync` signature extension (optional `origin` param defaults safe)

## Release

- [x] Not a versioned release — skip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcbf2d1b-9e8f-46cf-bf69-564e4efe6118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

