### PR TITLE
ci(cert-gate): trigger on push to master so HEAD always carries the gate

### DIFF
--- a/.github/workflows/cert-gate.yml
+++ b/.github/workflows/cert-gate.yml
@@ -2,7 +2,13 @@ name: Cert gate
 
 on:
   pull_request:
+  push:
+    branches: [master]
   workflow_dispatch:
+
+concurrency:
+  group: cert-gate-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   cert-gate:


### PR DESCRIPTION
## Summary

- Add `push: branches: [master]` to `.github/workflows/cert-gate.yml` so every master HEAD carries an evidentiary cert-gate run (not just PR heads).
- Retain existing `pull_request` (preventive) and `workflow_dispatch` triggers unchanged.
- Add concurrency group keyed by ref with `cancel-in-progress: false` so master runs are never cancelled.

## Why

Squash-merging PR #198 left master HEAD (`f3be445`) with zero cert-gate check runs — the PR was green, but that green never attached to master. This closes the trigger-level hole.

## Test plan

- [x] `actionlint .github/workflows/cert-gate.yml` passes
- [x] Diff confined to `on:` + optional `concurrency:` blocks only
- [ ] PR cert-gate check passes on this branch

## Human verification (Part 2)

**This PR's own squash-merge will fire the first push-triggered cert-gate run on master HEAD; that run is the human verification in the follow-up runbook.**

Do not enable required-status-check protection or prune branches until that master push run reports `conclusion: success`.