### PR TITLE
docs: preserve arc audit trail reports on master

### DIFF
--- a/LAND-PLAN.md
+++ b/LAND-PLAN.md
@@ -1,0 +1,235 @@
+# LAND-PLAN — Phase-3 + Self-Extend stacks (master `bc4e0e1`)
+
+**Generated:** 2026-06-24  
+**Authority:** GitHub PR / check-runs API (not local runs, not committed run-links)  
+**Master:** `bc4e0e1c` — **unchanged** by this sprint  
+**Dry-run branch:** `integration/land-dryrun` (local only, deleted after this doc)
+
+---
+
+## 1. Stack topology
+
+Both stacks branch from `master` @ `bc4e0e1`. Git ancestry within each stack is linear (each tip contains all ancestors).
+
+### Phase-3 (Certification.Composition)
+
+```
+master (bc4e0e1)
+  └── cursor/agent-composer-proposer-6118      PR #195  (P3-S1)
+        └── cursor/real-model-composer-6118    PR #196  (P3-S2)
+              └── cursor/acceptance-rate-measurement-6118  PR #197  (P3-S3)
+                    └── cursor/repo-hygiene-cleanup-6118   PR #198  (P3-CLEANUP) ← TIP
+```
+
+**GitHub base:** all four PRs target **`master`** (not parent-branch chained). Merging the tip (`repo-hygiene-cleanup`) lands S1–S3 + cleanup in one shot; PRs #195–#197 must be **closed manually** (or merged base-up if you want per-sprint PR closure).
+
+### Self-extend (BackgroundAgents)
+
+```
+master (bc4e0e1)
+  └── cursor/self-extend-audit-6118          PR #199
+        └── cursor/self-extend-enforce-6118    PR #200
+              └── cursor/self-extend-harden-6118  PR #201 ← TIP
+```
+
+**GitHub base:** properly stacked (child → parent). Landing requires merging **bottom-up** (#201 → #200 → #199) so each PR's base branch absorbs the next layer before the final merge to `master`.
+
+### Shared touch-point
+
+| File | Phase-3 | Self-extend | Dry-run conflict |
+|------|---------|-------------|------------------|
+| `scripts/cert-gate-config.sh` | **Modified** (P3 test inventory comments) | Unchanged | **None** |
+
+Trees are otherwise disjoint (`Certification.Composition` vs `BackgroundAgents`).
+
+---
+
+## 2. PR topology + check-runs (API)
+
+**Workflow mapping (stack-relevant gates):**
+
+| Gate | Workflow | Covers |
+|------|----------|--------|
+| `cert-gate` | `.github/workflows/cert-gate.yml` → `scripts/run-cert-gate.sh` | Phase-3 composition tests + all certification hermetic tests |
+| `kernel-gate` | `.github/workflows/kernel-gate.yml` → `make kernel-gate` | Kernel/hosting/pipeline (not BackgroundAgents directly) |
+| `application-gate` | `.github/workflows/application-gate.yml` | Application/CLI/integration tier (includes BackgroundAgents paths on SX PRs) |
+| `cross-platform-tests` | `.github/workflows/cross-platform-tests.yml` | BackgroundAgents cross-platform (informational on several PRs; not stack-blocking below) |
+
+| PR | Branch | Base | Head | Mergeable | GH state | cert-gate | kernel-gate | application-gate | Stack gate verdict |
+|----|--------|------|------|-----------|----------|-----------|-------------|------------------|-------------------|
+| [#195](https://github.com/IanFrelinger/Nexo/pull/195) | `cursor/agent-composer-proposer-6118` | `master` | `dbd87e79` | MERGEABLE | BLOCKED† | **success** | **success** | n/a | ✅ **GREEN** (cert-gate) |
+| [#196](https://github.com/IanFrelinger/Nexo/pull/196) | `cursor/real-model-composer-6118` | `master` | `aecda581` | MERGEABLE | BLOCKED† | **success** | **success** | n/a | ✅ **GREEN** (cert-gate) |
+| [#197](https://github.com/IanFrelinger/Nexo/pull/197) | `cursor/acceptance-rate-measurement-6118` | `master` | `31f5a945` | MERGEABLE | BLOCKED† | **success** | **success** | n/a | ✅ **GREEN** (cert-gate) |
+| [#198](https://github.com/IanFrelinger/Nexo/pull/198) | `cursor/repo-hygiene-cleanup-6118` | `master` | `9420747d` | MERGEABLE | BLOCKED† | **success** | **success** | n/a | ✅ **GREEN** (cert-gate) |
+| [#199](https://github.com/IanFrelinger/Nexo/pull/199) | `cursor/self-extend-audit-6118` | `master` | `a8491640` | MERGEABLE | BLOCKED† | **success** | n/a | n/a | ✅ **GREEN** (cert-gate) |
+| [#200](https://github.com/IanFrelinger/Nexo/pull/200) | `cursor/self-extend-enforce-6118` | `self-extend-audit-6118` | `24d0fbb5` | MERGEABLE | UNSTABLE‡ | **success** | **success** | n/a | ✅ **GREEN** (cert-gate + kernel-gate) |
+| [#201](https://github.com/IanFrelinger/Nexo/pull/201) | `cursor/self-extend-harden-6118` | `self-extend-enforce-6118` | `e9438994` | MERGEABLE | UNSTABLE‡ | **success** | **success** | **success** | ✅ **GREEN** (all three) |
+
+† **BLOCKED** on Phase-3 / audit PRs: non-stack checks failing (`lychee`, `Pack script vs Nexo.Hosting graph`, `Standalone brick authoring scaffold`, cross-platform `Linux/macOS/Windows — setup`, etc.). **Stack gates (`cert-gate`) are green on all seven PRs.**
+
+‡ **UNSTABLE** on enforce/harden: `kernel-coverage` failure + assorted informational workflow failures. **Stack gates (`cert-gate`, `kernel-gate`, `application-gate` on #201) are green.**
+
+> Branch-protection required-context list was not readable via API (403). Gate selection above follows sprint scope: `cert-gate` for Phase-3; `cert-gate` + `kernel-gate` + `application-gate` for self-extend production changes.
+
+---
+
+## 3. Dry-run integration result
+
+**Branch:** `integration/land-dryrun` off `origin/master` (`bc4e0e1`)  
+**Strategy:** merge-commit (not squash) — preserves per-sprint history
+
+```bash
+git checkout -B integration/land-dryrun origin/master
+git merge --no-edit origin/cursor/repo-hygiene-cleanup-6118    # Phase-3 tip — fast-forward
+git merge --no-edit origin/cursor/self-extend-harden-6118      # Self-extend tip — merge commit 72bf5df7
+```
+
+| Step | Result |
+|------|--------|
+| Conflicts | **None** (`cert-gate-config.sh` touched only by Phase-3; clean 3-way merge) |
+| `bash scripts/run-cert-gate.sh` | **PASS** — 41/41 tests, exit 0 |
+| `dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj -f net8.0` | **PASS** — 423 passed, 1 skipped (invariant D), 0 failed |
+| Combined diff vs master | 72 files, +3579 / −194 lines |
+
+**Verdict: ✅ INTEGRATION CLEAN + GREEN** — safe to prescribe landing both stacks.
+
+---
+
+## 4. Recommended merge order
+
+Land **Phase-3 first**, then **self-extend** (matches dry-run; disjoint trees; either order should work, but this is proven).
+
+### 4A. Phase-3 → `master` (pick one strategy)
+
+**Option A — Tip merge (one PR, fastest):** merge only PR #198; manually close #195–#197 as superseded.
+
+**Option B — Base-up (four PRs, per-sprint PR closure):** merge #195 → #196 → #197 → #198 in order (each into `master`).
+
+Both are equivalent git content when branches are stacked as verified.
+
+### 4B. Self-extend → `master` (must be base-up)
+
+Merge #201 into `enforce` → #200 into `audit` → #199 into `master`. Merging only the harden tip directly to `master` (bypassing stacked PRs) works git-wise but leaves #199/#200 open and skips the intended review chain.
+
+---
+
+## 5. Human-runnable command sequence
+
+> **Legend:** lines marked **⛔ IRREVERSIBLE** mutate remote shared state.
+
+### Step 0 — Preflight (read-only)
+
+```bash
+git fetch origin
+git rev-parse origin/master   # expect bc4e0e1c9a6ba4b6f212311bc5d7f5e601aea413
+gh pr checks 198 --repo IanFrelinger/Nexo | grep cert-gate
+gh pr checks 201 --repo IanFrelinger/Nexo | grep -E 'cert-gate|kernel-gate|application-gate'
+```
+
+### Step 1 — Land Phase-3 (choose A or B)
+
+#### Option A: tip merge (recommended)
+
+```bash
+gh pr merge 198 --repo IanFrelinger/Nexo --merge --subject "Merge Phase-3 composition stack (S1–S3 + cleanup)"  # ⛔ IRREVERSIBLE — writes master
+# Close superseded PRs without merging (commits already on master):
+gh pr close 195 --repo IanFrelinger/Nexo --comment "Superseded by #198 tip merge"
+gh pr close 196 --repo IanFrelinger/Nexo --comment "Superseded by #198 tip merge"
+gh pr close 197 --repo IanFrelinger/Nexo --comment "Superseded by #198 tip merge"
+```
+
+#### Option B: base-up (four merge commits on master)
+
+```bash
+gh pr merge 195 --repo IanFrelinger/Nexo --merge   # ⛔ IRREVERSIBLE
+gh pr merge 196 --repo IanFrelinger/Nexo --merge   # ⛔ IRREVERSIBLE
+gh pr merge 197 --repo IanFrelinger/Nexo --merge   # ⛔ IRREVERSIBLE
+gh pr merge 198 --repo IanFrelinger/Nexo --merge   # ⛔ IRREVERSIBLE
+```
+
+### Step 2 — Land self-extend (stacked, base-up)
+
+```bash
+gh pr merge 201 --repo IanFrelinger/Nexo --merge --subject "Merge SX-HARDEN into enforce"   # ⛔ IRREVERSIBLE (updates enforce branch)
+gh pr merge 200 --repo IanFrelinger/Nexo --merge --subject "Merge SX-ENFORCE into audit"    # ⛔ IRREVERSIBLE (updates audit branch)
+gh pr merge 199 --repo IanFrelinger/Nexo --merge --subject "Merge self-extend stack to master"  # ⛔ IRREVERSIBLE — writes master
+```
+
+After step 2, `master` contains both stacks. GitHub auto-closes #200 and #201 when their commits reach `master` via the chain.
+
+### Step 3 — Post-land verification
+
+```bash
+git fetch origin
+git checkout master && git pull origin master
+bash scripts/run-cert-gate.sh
+dotnet test src/Nexo.Tests.BackgroundAgents/Nexo.Tests.BackgroundAgents.csproj -f net8.0
+```
+
+### Step 4 — Branch protection + auto-delete (GitHub UI or API)
+
+**Settings → Branches → `master` → Branch protection:**
+
+1. Require status checks: add **`cert-gate`** (minimum for composition land).
+2. Optionally add **`kernel-gate`** and **`application-gate`** now that BackgroundAgents enforcement is on master.
+3. Enable **“Automatically delete head branches”** after merge.
+
+```bash
+# If using gh api (requires admin PAT):
+# gh api repos/IanFrelinger/Nexo/branches/master/protection ...   # ⛔ IRREVERSIBLE — changes branch policy
+```
+
+### Step 5 — Archive tags (before any branch deletion)
+
+Run **before** deleting any cursor branch. Archive tags are cheap insurance against squash-merge ancestry loss.
+
+```bash
+git fetch origin
+
+for b in \
+  cursor/agent-composer-proposer-6118 \
+  cursor/real-model-composer-6118 \
+  cursor/acceptance-rate-measurement-6118 \
+  cursor/repo-hygiene-cleanup-6118 \
+  cursor/self-extend-audit-6118 \
+  cursor/self-extend-enforce-6118 \
+  cursor/self-extend-harden-6118
+do
+  tag="archive/landed-${b#cursor/}"
+  git tag "$tag" "origin/$b"
+  git push origin "refs/tags/$tag"    # ⛔ IRREVERSIBLE — creates remote tag (safe; not destructive)
+done
+```
+
+### Step 6 — Branch cleanup (separate human step; do NOT run until archive tags exist)
+
+```bash
+# Only after archive tags pushed and PRs confirmed merged/closed:
+git push origin --delete cursor/agent-composer-proposer-6118      # ⛔ IRREVERSIBLE
+git push origin --delete cursor/real-model-composer-6118        # ⛔ IRREVERSIBLE
+git push origin --delete cursor/acceptance-rate-measurement-6118  # ⛔ IRREVERSIBLE
+git push origin --delete cursor/repo-hygiene-cleanup-6118       # ⛔ IRREVERSIBLE
+git push origin --delete cursor/self-extend-audit-6118          # ⛔ IRREVERSIBLE
+git push origin --delete cursor/self-extend-enforce-6118        # ⛔ IRREVERSIBLE
+git push origin --delete cursor/self-extend-harden-6118         # ⛔ IRREVERSIBLE
+```
+
+---
+
+## 6. What this sprint did NOT do
+
+- Did **not** merge, rebase, or force-push `master` (still `bc4e0e1`)
+- Did **not** push `integration/land-dryrun` to origin
+- Did **not** delete any remote branch
+- Did **not** resolve conflicts by discarding either stack (none existed)
+
+---
+
+## 7. Dry-run cleanup (agent)
+
+```bash
+git checkout cursor/self-extend-harden-6118   # or master
+git branch -D integration/land-dryrun         # local scratch only
+```
+
+`integration/land-dryrun` was never pushed.

--- a/TIDY-REPORT.md
+++ b/TIDY-REPORT.md
@@ -1,0 +1,181 @@
+# TIDY-REPORT — Post-landing cleanup (6118 arc)
+
+**Generated:** 2026-06-25  
+**Repo:** [IanFrelinger/Nexo](https://github.com/IanFrelinger/Nexo)  
+**Master HEAD:** `f3be445848e24785b64ea5f7580998884647ea5a` — `chore(repo): P3-CLEANUP hygiene pass — test doubles relocated, evidence consolidated (#198)`
+
+---
+
+## 1. Master-green gate (HARD STOP)
+
+| Field | Value |
+|-------|-------|
+| Commit | `f3be445848e24785b64ea5f7580998884647ea5a` |
+| API | `GET /repos/IanFrelinger/Nexo/commits/f3be445848e24785b64ea5f7580998884647ea5a/check-runs?check_name=cert-gate` |
+| **cert-gate `total_count`** | **0** |
+| **cert-gate `conclusion`** | **ABSENT** (no check run registered on master HEAD) |
+| **Gate result** | **FAIL — sprint stopped; no branches pruned** |
+
+### Why cert-gate is absent on master
+
+The `Cert gate` workflow (`.github/workflows/cert-gate.yml`) triggers only on `pull_request` and `workflow_dispatch` — **not** on `push` to `master`. After squash-merge of PR #198, no `cert-gate` check run was created on the merge commit `f3be445`.
+
+**Nearest green cert-gate evidence (PR head, not master):**
+
+| Field | Value |
+|-------|-------|
+| PR #198 head | `04ffd8cccab7b60a9fce9a50c844ce4fc0839df2` |
+| cert-gate conclusion | `success` |
+| Run | [actions/runs/28137102010](https://github.com/IanFrelinger/Nexo/actions/runs/28137102010/job/83326229005) |
+
+### Required human action before pruning
+
+Dispatch cert-gate on master (or add `push: branches: [master]` to the workflow), then re-run this tidy sprint:
+
+```bash
+# Option A — one-off workflow dispatch on master
+gh workflow run cert-gate.yml --ref master
+
+# Option B — after dispatch completes, verify:
+gh api 'repos/IanFrelinger/Nexo/commits/$(gh api repos/IanFrelinger/Nexo/commits/master --jq .sha)/check-runs?check_name=cert-gate' \
+  --jq '.check_runs[] | {name, conclusion, status}'
+```
+
+Until `cert-gate` reports `conclusion: success` on master HEAD, **do not delete arc branches**.
+
+---
+
+## 2. Per-branch verification table
+
+Evidence method: GitHub PR API (`merged` field) + `refs/tags/archive/landed-<name>-6118` pointing at branch tip (`object.type == commit`, SHA match). No `git branch --merged` / `git cherry` used.
+
+| Branch | PR# | PR merged? | Archive tag? | Tag = tip? | DECISION |
+|--------|-----|------------|--------------|------------|----------|
+| `cursor/agent-composer-proposer-6118` | #195 | **no** (closed, `merged: false`) | yes (`archive/landed-agent-composer-proposer-6118` → `dbd87e79`) | yes | **SKIP** — PR not merged per API |
+| `cursor/real-model-composer-6118` | #196 | **no** (closed, `merged: false`) | yes (`archive/landed-real-model-composer-6118` → `aecda581`) | yes | **SKIP** — PR not merged per API |
+| `cursor/acceptance-rate-measurement-6118` | #197 | **no** (closed, `merged: false`) | yes (`archive/landed-acceptance-rate-measurement-6118` → `31f5a945`) | yes | **SKIP** — PR not merged per API |
+| `cursor/repo-hygiene-cleanup-6118` | #198 | **yes** (`merged: true`, merge `f3be445`) | yes (`archive/landed-repo-hygiene-cleanup-6118` → `04ffd8cc`) | yes | **BLOCKED** — master gate fail (would DELETE when green) |
+| `cursor/self-extend-audit-6118` | #199 | **yes** (`merged: true`, merge `74c473f7`) | yes (`archive/landed-self-extend-audit-6118` → `19ae0b93`) | yes | **BLOCKED** — master gate fail (would DELETE when green) |
+| `cursor/self-extend-enforce-6118` | #200 | **yes** (`merged: true`, merge `19ae0b93`) | yes (`archive/landed-self-extend-enforce-6118` → `d1897628`) | yes | **BLOCKED** — master gate fail (would DELETE when green) |
+| `cursor/self-extend-harden-6118` | #201 | **yes** (`merged: true`, merge `d1897628`) | yes (`archive/landed-self-extend-harden-6118` → `e9438994`) | yes | **BLOCKED** — master gate fail (would DELETE when green) |
+
+### Deletions performed
+
+**None.** Master-green gate failed before any `git push origin --delete` commands were issued.
+
+### Post-gate delete commands (for human re-run)
+
+When cert-gate is green on master HEAD, run only the four branches that pass both checks:
+
+```bash
+gh api -X DELETE repos/IanFrelinger/Nexo/git/refs/heads/cursor/repo-hygiene-cleanup-6118
+gh api -X DELETE repos/IanFrelinger/Nexo/git/refs/heads/cursor/self-extend-audit-6118
+gh api -X DELETE repos/IanFrelinger/Nexo/git/refs/heads/cursor/self-extend-enforce-6118
+gh api -X DELETE repos/IanFrelinger/Nexo/git/refs/heads/cursor/self-extend-harden-6118
+```
+
+**Do not delete** PRs #195–#197 branches until their PRs show `merged: true` via the API (archive tags alone are insufficient).
+
+---
+
+## 3. `cursor/land-plan-6118` — special case
+
+| Field | Value |
+|-------|-------|
+| Branch tip | `b506a51a1846c47c264f5a96e380ec57614719c9` |
+| PR | none |
+| Archive tag | none |
+| `LAND-PLAN.md` on master | **no** |
+| Action taken | **NOT deleted** (per sprint constraints) |
+
+### Human choice (default: leave untouched)
+
+| Option | Action |
+|--------|--------|
+| **A — Keep as record (recommended if doc has value)** | Open a small PR from `cursor/land-plan-6118` merging only `LAND-PLAN.md` to `master` as a landing audit trail. |
+| **B — Discard later** | Create `archive/landed-land-plan-6118` tag at `b506a51a`, then delete the branch when ready. |
+
+**Default:** leave branch and tag untouched; flag for maintainer decision.
+
+---
+
+## 4. Repo settings (branch protection + auto-delete)
+
+Agent token lacks admin access to branch-protection endpoints (`403 Resource not accessible by integration`). Settings read back where possible; prescriptions below are **PENDING-HUMAN**.
+
+### (a) Branch protection on `master` — require `cert-gate`
+
+| Field | State |
+|-------|-------|
+| API read | `GET /repos/IanFrelinger/Nexo/branches/master/protection` → **403** |
+| Rulesets | `GET /repos/IanFrelinger/Nexo/rulesets` → `[]` (empty) |
+| **Status** | **PENDING-HUMAN** |
+
+```bash
+# Requires repo admin. Enables protection and requires cert-gate status check.
+gh api -X PUT repos/IanFrelinger/Nexo/branches/master/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {"context": "cert-gate", "app_id": null}
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false
+}
+EOF
+
+# Verify:
+gh api repos/IanFrelinger/Nexo/branches/master/protection \
+  --jq '.required_status_checks.checks[] | select(.context == "cert-gate")'
+```
+
+> **Note:** Consider also adding `push` trigger to `cert-gate.yml` on `master` so the required check can actually run post-merge.
+
+### (b) Auto-delete head branches on merge
+
+| Field | State |
+|-------|-------|
+| API read | `GET /repos/IanFrelinger/Nexo` → `delete_branch_on_merge: false` |
+| **Status** | **PENDING-HUMAN** (confirmed off, not yet enabled) |
+
+```bash
+gh api -X PATCH repos/IanFrelinger/Nexo \
+  -f delete_branch_on_merge=true
+
+# Verify:
+gh api repos/IanFrelinger/Nexo --jq '.delete_branch_on_merge'
+# Expected: true
+```
+
+---
+
+## 5. Untouched (per constraints)
+
+- `master` content — unchanged
+- All existing tags — unchanged (including `archive/landed-*`)
+- `dependabot/*` branches — not queried, not touched
+- `cursor/phase2-cross-project-reuse-6118` — not in arc delete list, not touched
+- `cursor/land-plan-6118` — retained, flagged above
+- PRs #195–#197 branches — retained (PR not merged per API)
+
+---
+
+## 6. Summary
+
+| Criterion | Result |
+|-----------|--------|
+| cert-gate on master `f3be445` recorded from API | **ABSENT** (`total_count: 0`) — sprint stopped |
+| Branches deleted | **0** |
+| Every would-be delete had merged PR + archive tag | 4 candidates identified; 0 deleted (gate blocked) |
+| `land-plan-6118` preserved + decision surfaced | yes |
+| Settings confirmed or PENDING-HUMAN | both **PENDING-HUMAN** |
+| Non-arc / dependabot / tags untouched | yes |


### PR DESCRIPTION
## Summary

- Add `LAND-PLAN.md` from `cursor/land-plan-6118` (Option A — keep as audit trail on master).
- Add `TIDY-REPORT.md` from `cursor/sprint-tidy-report-b151` (same).

No other files changed. Source sprint branches can be deleted after merge.

## Test plan

- [ ] cert-gate passes on this PR