### PR TITLE
feat(certification): state binding phase 2 — portable resolver, wire format, project C

### DIFF
--- a/docs/certification-evidence.md
+++ b/docs/certification-evidence.md
@@ -142,6 +142,25 @@ Pack/export: `scripts/pack-certified-brick-reuse.sh` → local feed + `certifica
 
 **v0 trust model:** same-owner cross-project reuse via shared dev HMAC key (`NEXO_CERT_DEV_HMAC_KEY`). Cross-organization trust requires PKI (out of scope).
 
+## State log binding (foundation + portable substrate)
+
+Attested state log binding: certify transition **rules/schema** and bind mutable state via hash-chained provenance (`Nexo.Certification.State`). Tier-1 structural verification via `StateLogVerifier`; Tier-2 replay via optional `ITransitionReplayer` seam.
+
+| Proof | Result |
+|-------|--------|
+| `AttestedStateLogBindingTests` R1–R8 | **REFUSE** — distinct codes: `behavior-cert-unresolved`, `behavior-cert-untrusted`, `schema-violation`, `chain-prev-entry-break`, `chain-gap`, `chain-reorder`, `injected-behavior-cert-unresolved`, `replay-mismatch` |
+| `A1_FullyValidLog_IsTrusted` | **TRUSTED** — `VerifiedTransitions == 3` |
+| `A2_FullyValidLogWithReplay_IsTrusted` | **TRUSTED** — Tier-2 admission with fake replayer |
+| `G1_ZeroMutantGuard_VerifiedTransitionCountMatchesLogLength` | **PASS** — count > 0 and equals N |
+| `CrossProjectStateLogReuseTests` | **PASS** — Project C bundled JSON + file catalog, no Infrastructure in consumer csproj |
+| `AttestedStateLogWireFormatTests` | **PASS** — bundled sample deserializes and trusts Tier-1 |
+| `CertifiedBehaviorCatalogTests` | **PASS** — file catalog resolves trusted behaviors |
+| `AttestedStateLogTrustGateTests` | **PASS** — DI trust gate trusts bundled sample |
+
+Project C (`samples/certified-state-log-reuse/ProjectC`) references only `Nexo.Certification.State` + `Nexo.Certification.Contracts`. Bundled artifacts under `Nexo.Certified.PhaseWitness/` (`state-schema.json`, `attested-state-log.json`, behavior sidecars). Pack: `scripts/pack-certified-state-log-reuse.sh`.
+
+**Tier split:** Tier-1 catches cert provenance, schema format, hash-chain integrity (R1–R7). Tier-2 replay required for swapped-valid-cert / out-of-band state tamper (R8, A2).
+
 ## Agent-composer (proposer seam → real model → acceptance rate)
 
 Cumulative evidence from P3-S1 (controlled proposer), P3-S2 (real-model record/replay), and P3-S3 (acceptance-rate measurement). cert-gate: **41 tests** @ [run 28067778575](https://github.com/IanFrelinger/Nexo/actions/runs/28067778575) (`conclusion: success` @ `7f9cbdc3`).

--- a/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/attested-state-log.json
+++ b/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/attested-state-log.json
@@ -1,0 +1,28 @@
+{
+  "transitions": [
+    {
+      "priorStateHash": "2KOfL3zrreBAe0/Mr85eJvLI1GPF3yomE4QhRWj9yLQ=",
+      "action": "phase:advance",
+      "behaviorCertContentHash": "pzH6yOaelThGaRnxr4q/rZobTsC6G1UJfMZsjs4IV88=",
+      "resultingStateHash": "ET4RHNdGvXr7mRXuhjPmcAgdxwdJq1znr5nC7M2a8lM=",
+      "prevEntryHash": "",
+      "entryHash": "FmKPyo1eIEwtnMJuTaiDGqBR65DyG4HZ9ooGaGcK37I="
+    },
+    {
+      "priorStateHash": "ET4RHNdGvXr7mRXuhjPmcAgdxwdJq1znr5nC7M2a8lM=",
+      "action": "phase:advance",
+      "behaviorCertContentHash": "pzH6yOaelThGaRnxr4q/rZobTsC6G1UJfMZsjs4IV88=",
+      "resultingStateHash": "paSbhBxKgMzuAqZJ6Wn6Jdo2fEn19fcgU7zCiUkCIqc=",
+      "prevEntryHash": "FmKPyo1eIEwtnMJuTaiDGqBR65DyG4HZ9ooGaGcK37I=",
+      "entryHash": "kkuvy3ApsaZidE16X2jLKLkwvry2BFkDp/Ey5aDLON0="
+    },
+    {
+      "priorStateHash": "paSbhBxKgMzuAqZJ6Wn6Jdo2fEn19fcgU7zCiUkCIqc=",
+      "action": "phase:release",
+      "behaviorCertContentHash": "WJXniDN3WL7HzFxZp3i89hlgYpgbCypcHowp\u002B6lyg8g=",
+      "resultingStateHash": "7hXz0Whljdm28W8jG0Ua3Qfg59DrJXYDuyVDVis8nN0=",
+      "prevEntryHash": "kkuvy3ApsaZidE16X2jLKLkwvry2BFkDp/Ey5aDLON0=",
+      "entryHash": "d9xYY1wX71JPoIcN5CS3uZO\u002BjExQ8NoBzkQ59bbuL7o="
+    }
+  ]
+}

--- a/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/WJXniDN3WL7HzFxZp3i89hlgYpgbCypcHowp+6lyg8g=/record.json
+++ b/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/WJXniDN3WL7HzFxZp3i89hlgYpgbCypcHowp+6lyg8g=/record.json
@@ -1,0 +1,19 @@
+{
+  "status": "PASS",
+  "stage": "witness",
+  "admitted": true,
+  "signed": true,
+  "timestamp": "2026-01-01T00:00:00+00:00",
+  "brickId": "behavior-beta",
+  "contentHash": "WJXniDN3WL7HzFxZp3i89hlgYpgbCypcHowp\u002B6lyg8g=",
+  "escapeRate": 0,
+  "totalMutants": 1,
+  "survivingMutants": 0,
+  "killedMutants": [
+    "m1"
+  ],
+  "survivingMutantIds": [],
+  "signature": "Pp8r57wxCk9tJ2TUvlATEnELDYCkwnSlj1/NjzuHyHU=",
+  "reason": null,
+  "gate": null
+}

--- a/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/WJXniDN3WL7HzFxZp3i89hlgYpgbCypcHowp+6lyg8g=/source.txt
+++ b/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/WJXniDN3WL7HzFxZp3i89hlgYpgbCypcHowp+6lyg8g=/source.txt
@@ -1,0 +1,1 @@
+certified-behavior-beta-v1

--- a/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/pzH6yOaelThGaRnxr4q/rZobTsC6G1UJfMZsjs4IV88=/record.json
+++ b/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/pzH6yOaelThGaRnxr4q/rZobTsC6G1UJfMZsjs4IV88=/record.json
@@ -1,0 +1,19 @@
+{
+  "status": "PASS",
+  "stage": "witness",
+  "admitted": true,
+  "signed": true,
+  "timestamp": "2026-01-01T00:00:00+00:00",
+  "brickId": "behavior-alpha",
+  "contentHash": "pzH6yOaelThGaRnxr4q/rZobTsC6G1UJfMZsjs4IV88=",
+  "escapeRate": 0,
+  "totalMutants": 1,
+  "survivingMutants": 0,
+  "killedMutants": [
+    "m1"
+  ],
+  "survivingMutantIds": [],
+  "signature": "NDDj2\u002BH2t8KXcppuceQqsY3cqoSsRnUxkaraPtJ0vNI=",
+  "reason": null,
+  "gate": null
+}

--- a/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/pzH6yOaelThGaRnxr4q/rZobTsC6G1UJfMZsjs4IV88=/source.txt
+++ b/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/behaviors/pzH6yOaelThGaRnxr4q/rZobTsC6G1UJfMZsjs4IV88=/source.txt
@@ -1,0 +1,1 @@
+certified-behavior-alpha-v1

--- a/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/state-schema.json
+++ b/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/state-schema.json
@@ -1,0 +1,1 @@
+{"version":1,"stateBinding":{"version":"witness-v1","hashLength":44}}

--- a/samples/certified-state-log-reuse/ProjectC/Program.cs
+++ b/samples/certified-state-log-reuse/ProjectC/Program.cs
@@ -1,0 +1,96 @@
+using Nexo.Certification.State;
+using CertifiedStateLogReuse.ProjectC;
+
+return await ProgramEntry.RunAsync(args);
+
+namespace CertifiedStateLogReuse.ProjectC;
+
+internal static class ProgramEntry
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var artifactRoot = args.ElementAtOrDefault(0)
+            ?? throw new InvalidOperationException(
+                "Usage: ProjectC <path-to-Nexo.Certified.PhaseWitness> [hmac-key]");
+
+        var hmacKey = args.ElementAtOrDefault(1) ?? "attested-state-log-test-hmac";
+        var trust = ProjectCStateLogConsumer.VerifyBundledArtifacts(artifactRoot, hmacKey);
+
+        if (!trust.Trusted)
+        {
+            await Console.Error.WriteLineAsync($"UNTRUSTED: {trust.FailureCode} — {trust.Reason}").ConfigureAwait(false);
+            return 2;
+        }
+
+        await Console.Out.WriteLineAsync($"TRUSTED verifiedTransitions={trust.VerifiedTransitions}").ConfigureAwait(false);
+        return 0;
+    }
+}
+
+internal static class ProjectCStateLogConsumer
+{
+    public static StateLogTrustResult VerifyBundledArtifacts(string artifactRoot, string? hmacKey = null)
+    {
+        var schemaPath = Path.Combine(artifactRoot, "state-schema.json");
+        var logPath = Path.Combine(artifactRoot, "attested-state-log.json");
+        var behaviorRoot = Path.Combine(artifactRoot, "behaviors");
+
+        var schema = AttestedStateLogWireFormat.DeserializeSchema(File.ReadAllText(schemaPath));
+        var log = AttestedStateLogWireFormat.DeserializeLog(File.ReadAllText(logPath));
+        var catalog = new FileBundledBehaviorCatalog(behaviorRoot);
+        var resolver = new CatalogCertificateResolver(catalog);
+
+        return StateLogVerifier.Verify(log, schema, resolver, hmacKey);
+    }
+
+    public static void AssertProjectCProjectHasNoGateOrInfrastructureReferences(string projectCcsprojPath)
+    {
+        var text = File.ReadAllText(projectCcsprojPath);
+        if (text.Contains("Nexo.Infrastructure", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Project C must not reference Nexo.Infrastructure.");
+        if (text.Contains("Adaptation.Generation", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Project C must not reference the generator.");
+    }
+}
+
+internal sealed class FileBundledBehaviorCatalog
+{
+    private readonly string _directory;
+
+    public FileBundledBehaviorCatalog(string directory) => _directory = directory;
+
+    public bool TryGet(string contentHash, out Nexo.Certification.Contracts.CertificationRecordData record, out string source)
+    {
+        record = null!;
+        source = null!;
+
+        var behaviorDir = Path.Combine(_directory, contentHash);
+        var recordPath = Path.Combine(behaviorDir, "record.json");
+        var sourcePath = Path.Combine(behaviorDir, "source.txt");
+        if (!File.Exists(recordPath) || !File.Exists(sourcePath))
+            return false;
+
+        record = System.Text.Json.JsonSerializer.Deserialize<Nexo.Certification.Contracts.CertificationRecordData>(
+            File.ReadAllText(recordPath),
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+            ?? throw new InvalidOperationException("Invalid certification record JSON.");
+
+        source = File.ReadAllText(sourcePath);
+        return true;
+    }
+}
+
+internal sealed class CatalogCertificateResolver : ICertificateResolver
+{
+    private readonly FileBundledBehaviorCatalog _catalog;
+
+    public CatalogCertificateResolver(FileBundledBehaviorCatalog catalog) => _catalog = catalog;
+
+    public CertificateResolveResult Resolve(string behaviorCertContentHash)
+    {
+        if (_catalog.TryGet(behaviorCertContentHash, out var record, out var source))
+            return new CertificateResolveResult(true, record, source);
+
+        return new CertificateResolveResult(false, null, null);
+    }
+}

--- a/samples/certified-state-log-reuse/ProjectC/ProjectC.csproj
+++ b/samples/certified-state-log-reuse/ProjectC/ProjectC.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CertifiedStateLogReuse.ProjectC</RootNamespace>
+    <AssemblyName>CertifiedStateLogReuse.ProjectC</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nexo.Certification.Contracts" Version="0.1.0" />
+    <PackageReference Include="Nexo.Certification.State" Version="0.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/cert-gate-config.sh
+++ b/scripts/cert-gate-config.sh
@@ -18,7 +18,11 @@ readonly CERT_GATE_FILTER='FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Ce
 #   RealModelCompositionProposerDogfoodTests: 2
 #   CompositionAcceptanceRateMeasurementTests: 3
 #   CompositionAcceptanceRateProtocolTests: 1
-#   AttestedStateLogBindingTests: 10
+#   AttestedStateLogBindingTests: 11
+#   AttestedStateLogWireFormatTests: 2
+#   CertifiedBehaviorCatalogTests: 2
+#   CrossProjectStateLogReuseTests: 3
+#   AttestedStateLogTrustGateTests: 1
 # Excluded from cert-gate filter: LocalFixtures.CompositionAcceptanceRateBatchFixtureGeneratorTests (local fixture regen only)
 
 cert_gate_list_tests() {

--- a/scripts/pack-certified-state-log-reuse.sh
+++ b/scripts/pack-certified-state-log-reuse.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Pack certified state log contracts + phase-witness bundle for Project C reuse.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${NEXO_CERTIFIED_STATE_REUSE_VERSION:-0.1.0}"
+FEED="${NEXO_CERTIFIED_STATE_REUSE_FEED:-${ROOT}/artifacts/certified-state-log-feed}"
+WITNESS_DIR="${ROOT}/samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness"
+CFG="${FEED}/NuGet.Config"
+
+mkdir -p "${FEED}"
+
+pack() {
+  dotnet pack "${ROOT}/${1}" -c Release -o "${FEED}" \
+    -p:PackageVersion="${VERSION}" \
+    -p:IncludeTestProjectReferences=false \
+    -p:UseProjectReferences=false \
+    -v minimal
+}
+
+echo "==> Pack state binding contracts to ${FEED}"
+pack src/Nexo.Certification.Contracts/Nexo.Certification.Contracts.csproj
+pack src/Nexo.Certification.State/Nexo.Certification.State.csproj
+
+cat > "${CFG}" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="certified-state-feed" value="${FEED}" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+EOF
+
+echo "==> Regenerate bundled phase-witness artifacts"
+dotnet run --project "${ROOT}/tools/GenStateLogFixtures/GenStateLogFixtures.csproj" -- "${WITNESS_DIR}"
+
+echo "==> Feed ready at ${FEED} (NuGet.Config=${CFG})"
+echo "Project C consumes Nexo.Certification.State + bundled JSON under ${WITNESS_DIR}"

--- a/src/Nexo.Certification.State/AttestedStateLogWireFormat.cs
+++ b/src/Nexo.Certification.State/AttestedStateLogWireFormat.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nexo.Certification.State;
+
+/// <summary>
+/// Portable JSON wire format for attested state logs and schemas.
+/// </summary>
+public static class AttestedStateLogWireFormat
+{
+    public static string SerializeSchema(StateSchema schema) =>
+        schema.CanonicalForm;
+
+    public static StateSchema DeserializeSchema(string canonicalForm) =>
+        new(canonicalForm);
+
+    public static string SerializeLog(AttestedStateLog log)
+    {
+        var dto = new AttestedStateLogDto
+        {
+            Transitions = log.Transitions
+                .Select(transition => new CertifiedTransitionDto
+                {
+                    PriorStateHash = transition.PriorStateHash,
+                    Action = transition.Action,
+                    BehaviorCertContentHash = transition.BehaviorCertContentHash,
+                    ResultingStateHash = transition.ResultingStateHash,
+                    PrevEntryHash = transition.PrevEntryHash,
+                    EntryHash = transition.EntryHash
+                })
+                .ToArray()
+        };
+
+        return JsonSerializer.Serialize(dto, JsonOptions);
+    }
+
+    public static AttestedStateLog DeserializeLog(string json)
+    {
+        var dto = JsonSerializer.Deserialize<AttestedStateLogDto>(json, JsonOptions)
+            ?? throw new JsonException("Attested state log JSON is invalid.");
+
+        var transitions = dto.Transitions
+            .Select(item => new CertifiedTransition
+            {
+                PriorStateHash = item.PriorStateHash,
+                Action = item.Action,
+                BehaviorCertContentHash = item.BehaviorCertContentHash,
+                ResultingStateHash = item.ResultingStateHash,
+                PrevEntryHash = item.PrevEntryHash,
+                EntryHash = item.EntryHash
+            })
+            .ToArray();
+
+        return new AttestedStateLog(transitions);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true
+    };
+
+    private sealed class AttestedStateLogDto
+    {
+        public CertifiedTransitionDto[] Transitions { get; set; } = Array.Empty<CertifiedTransitionDto>();
+    }
+
+    private sealed class CertifiedTransitionDto
+    {
+        public string PriorStateHash { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public string BehaviorCertContentHash { get; set; } = string.Empty;
+        public string ResultingStateHash { get; set; } = string.Empty;
+        public string PrevEntryHash { get; set; } = string.Empty;
+        public string EntryHash { get; set; } = string.Empty;
+    }
+}

--- a/src/Nexo.Core.Application/Certification/Models/CertifiedBehaviorEntry.cs
+++ b/src/Nexo.Core.Application/Certification/Models/CertifiedBehaviorEntry.cs
@@ -1,0 +1,13 @@
+using Nexo.Certification.Contracts;
+
+namespace Nexo.Core.Application.Certification.Models;
+
+/// <summary>
+/// Certified behavior resolved by content hash for attested state log verification.
+/// </summary>
+public sealed class CertifiedBehaviorEntry
+{
+    public required string ContentHash { get; init; }
+    public required CertificationRecordData Record { get; init; }
+    public required string Source { get; init; }
+}

--- a/src/Nexo.Core.Application/Certification/Ports/IAttestedStateLogTrustGate.cs
+++ b/src/Nexo.Core.Application/Certification/Ports/IAttestedStateLogTrustGate.cs
@@ -1,0 +1,15 @@
+using Nexo.Certification.State;
+
+namespace Nexo.Core.Application.Certification.Ports;
+
+/// <summary>
+/// Application trust boundary for attested state logs (delegates to <see cref="StateLogVerifier"/>).
+/// </summary>
+public interface IAttestedStateLogTrustGate
+{
+    StateLogTrustResult Verify(
+        AttestedStateLog log,
+        StateSchema schema,
+        string? hmacKey = null,
+        ITransitionReplayer? replayer = null);
+}

--- a/src/Nexo.Core.Application/Certification/Ports/ICertifiedBehaviorCatalog.cs
+++ b/src/Nexo.Core.Application/Certification/Ports/ICertifiedBehaviorCatalog.cs
@@ -1,0 +1,25 @@
+using Nexo.Core.Application.Certification.Models;
+
+namespace Nexo.Core.Application.Certification.Ports;
+
+/// <summary>
+/// Content-hash keyed catalog of certified behaviors (record + source) for state log verification.
+/// </summary>
+public interface ICertifiedBehaviorCatalog
+{
+    CertifiedBehaviorCatalogLookup Lookup(string behaviorCertContentHash);
+}
+
+/// <summary>
+/// Result of looking up a certified behavior by content hash.
+/// </summary>
+public sealed class CertifiedBehaviorCatalogLookup
+{
+    public bool Found { get; init; }
+    public CertifiedBehaviorEntry? Entry { get; init; }
+
+    public static CertifiedBehaviorCatalogLookup Miss() => new() { Found = false };
+
+    public static CertifiedBehaviorCatalogLookup Hit(CertifiedBehaviorEntry entry) =>
+        new() { Found = true, Entry = entry };
+}

--- a/src/Nexo.Core.Application/Nexo.Core.Application.csproj
+++ b/src/Nexo.Core.Application/Nexo.Core.Application.csproj
@@ -14,6 +14,8 @@
     <ItemGroup>
         <ProjectReference Include="..\Nexo.Core.Domain\Nexo.Core.Domain.csproj" />
         <ProjectReference Include="..\Nexo.Core\Nexo.Core.csproj" />
+        <ProjectReference Include="..\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj" />
+        <ProjectReference Include="..\Nexo.Certification.State\Nexo.Certification.State.csproj" />
     </ItemGroup>
 
     <!-- Package references -->

--- a/src/Nexo.Infrastructure/Certification/AttestedStateLogTrustGate.cs
+++ b/src/Nexo.Infrastructure/Certification/AttestedStateLogTrustGate.cs
@@ -1,0 +1,27 @@
+using Nexo.Certification.State;
+using Nexo.Core.Application.Certification.Ports;
+
+namespace Nexo.Infrastructure.Certification;
+
+/// <summary>
+/// Fail-closed trust gate for attested state logs using an injected behavior catalog.
+/// </summary>
+public sealed class AttestedStateLogTrustGate : IAttestedStateLogTrustGate
+{
+    private readonly ICertificateResolver _resolver;
+
+    public AttestedStateLogTrustGate(ICertifiedBehaviorCatalog catalog)
+    {
+        if (catalog is null)
+            throw new ArgumentNullException(nameof(catalog));
+
+        _resolver = new CertifiedBehaviorCertificateResolver(catalog);
+    }
+
+    public StateLogTrustResult Verify(
+        AttestedStateLog log,
+        StateSchema schema,
+        string? hmacKey = null,
+        ITransitionReplayer? replayer = null) =>
+        StateLogVerifier.Verify(log, schema, _resolver, hmacKey, replayer);
+}

--- a/src/Nexo.Infrastructure/Certification/CertifiedBehaviorCertificateResolver.cs
+++ b/src/Nexo.Infrastructure/Certification/CertifiedBehaviorCertificateResolver.cs
@@ -1,0 +1,26 @@
+using Nexo.Certification.State;
+using Nexo.Core.Application.Certification.Ports;
+
+namespace Nexo.Infrastructure.Certification;
+
+/// <summary>
+/// Adapts <see cref="ICertifiedBehaviorCatalog"/> to <see cref="ICertificateResolver"/>.
+/// </summary>
+public sealed class CertifiedBehaviorCertificateResolver : ICertificateResolver
+{
+    private readonly ICertifiedBehaviorCatalog _catalog;
+
+    public CertifiedBehaviorCertificateResolver(ICertifiedBehaviorCatalog catalog)
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+    }
+
+    public CertificateResolveResult Resolve(string behaviorCertContentHash)
+    {
+        var lookup = _catalog.Lookup(behaviorCertContentHash);
+        if (!lookup.Found || lookup.Entry is null)
+            return new CertificateResolveResult(false, null, null);
+
+        return new CertificateResolveResult(true, lookup.Entry.Record, lookup.Entry.Source);
+    }
+}

--- a/src/Nexo.Infrastructure/Certification/FileCertifiedBehaviorCatalog.cs
+++ b/src/Nexo.Infrastructure/Certification/FileCertifiedBehaviorCatalog.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using Nexo.Certification.Contracts;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+
+namespace Nexo.Infrastructure.Certification;
+
+/// <summary>
+/// File-backed certified behavior catalog. Each behavior lives in
+/// <c>{contentHash}/record.json</c> + <c>{contentHash}/source.txt</c>.
+/// </summary>
+public sealed class FileCertifiedBehaviorCatalog : ICertifiedBehaviorCatalog
+{
+    private readonly string _directory;
+
+    public FileCertifiedBehaviorCatalog(string directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory))
+            throw new ArgumentException("Catalog directory is required.", nameof(directory));
+
+        _directory = directory;
+    }
+
+    public CertifiedBehaviorCatalogLookup Lookup(string behaviorCertContentHash)
+    {
+        if (string.IsNullOrWhiteSpace(behaviorCertContentHash))
+            return CertifiedBehaviorCatalogLookup.Miss();
+
+        var behaviorDir = Path.Combine(_directory, behaviorCertContentHash);
+        var recordPath = Path.Combine(behaviorDir, "record.json");
+        var sourcePath = Path.Combine(behaviorDir, "source.txt");
+
+        if (!File.Exists(recordPath) || !File.Exists(sourcePath))
+            return CertifiedBehaviorCatalogLookup.Miss();
+
+        var record = JsonSerializer.Deserialize<CertificationRecordData>(
+            File.ReadAllText(recordPath),
+            JsonOptions);
+
+        if (record is null || string.IsNullOrWhiteSpace(record.ContentHash))
+            return CertifiedBehaviorCatalogLookup.Miss();
+
+        if (!string.Equals(record.ContentHash, behaviorCertContentHash, StringComparison.Ordinal))
+            return CertifiedBehaviorCatalogLookup.Miss();
+
+        var source = File.ReadAllText(sourcePath);
+        return CertifiedBehaviorCatalogLookup.Hit(new CertifiedBehaviorEntry
+        {
+            ContentHash = behaviorCertContentHash,
+            Record = record,
+            Source = source
+        });
+    }
+
+    public static void WriteEntry(string directory, CertifiedBehaviorEntry entry)
+    {
+        var behaviorDir = Path.Combine(directory, entry.ContentHash);
+        Directory.CreateDirectory(behaviorDir);
+        File.WriteAllText(
+            Path.Combine(behaviorDir, "record.json"),
+            JsonSerializer.Serialize(entry.Record, JsonOptions));
+        File.WriteAllText(Path.Combine(behaviorDir, "source.txt"), entry.Source);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+}

--- a/src/Nexo.Infrastructure/Certification/InMemoryCertifiedBehaviorCatalog.cs
+++ b/src/Nexo.Infrastructure/Certification/InMemoryCertifiedBehaviorCatalog.cs
@@ -1,0 +1,25 @@
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+
+namespace Nexo.Infrastructure.Certification;
+
+/// <summary>
+/// In-memory certified behavior catalog keyed by content hash.
+/// </summary>
+public sealed class InMemoryCertifiedBehaviorCatalog : ICertifiedBehaviorCatalog
+{
+    private readonly Dictionary<string, CertifiedBehaviorEntry> _entries;
+
+    public InMemoryCertifiedBehaviorCatalog(IEnumerable<CertifiedBehaviorEntry> entries)
+    {
+        _entries = entries.ToDictionary(entry => entry.ContentHash, StringComparer.Ordinal);
+    }
+
+    public CertifiedBehaviorCatalogLookup Lookup(string behaviorCertContentHash)
+    {
+        if (_entries.TryGetValue(behaviorCertContentHash, out var entry))
+            return CertifiedBehaviorCatalogLookup.Hit(entry);
+
+        return CertifiedBehaviorCatalogLookup.Miss();
+    }
+}

--- a/src/Nexo.Infrastructure/Certification/Sdk/Extensions/CertificationServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Certification/Sdk/Extensions/CertificationServiceCollectionExtensions.cs
@@ -28,4 +28,13 @@ public static class CertificationServiceCollectionExtensions
             sp.GetRequiredService<CertifiedBrickRegistry>());
         return services;
     }
+
+    public static IServiceCollection AddAttestedStateLogTrust(
+        this IServiceCollection services,
+        ICertifiedBehaviorCatalog catalog)
+    {
+        services.AddSingleton(catalog);
+        services.AddSingleton<IAttestedStateLogTrustGate, AttestedStateLogTrustGate>();
+        return services;
+    }
 }

--- a/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+++ b/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj" />
+    <ProjectReference Include="..\Nexo.Certification.State\Nexo.Certification.State.csproj" />
     <ProjectReference Include="..\Nexo.Brick.Contracts\Nexo.Brick.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.Core.Domain\Nexo.Core.Domain.csproj" />

--- a/src/Nexo.Tests.Infrastructure/Certification/Reuse/PhaseWitnessPaths.cs
+++ b/src/Nexo.Tests.Infrastructure/Certification/Reuse/PhaseWitnessPaths.cs
@@ -1,0 +1,18 @@
+namespace Nexo.Tests.Infrastructure.Certification.Reuse;
+
+/// <summary>
+/// Shared paths for bundled phase-witness attested state log artifacts (Project C).
+/// </summary>
+public static class PhaseWitnessPaths
+{
+    public static string ArtifactRoot() =>
+        Path.Combine(
+            RepoPaths.FindRepoRoot(),
+            "samples", "certified-state-log-reuse", "Nexo.Certified.PhaseWitness");
+
+    public static string SchemaPath(string artifactRoot) => Path.Combine(artifactRoot, "state-schema.json");
+
+    public static string LogPath(string artifactRoot) => Path.Combine(artifactRoot, "attested-state-log.json");
+
+    public static string BehaviorRoot(string artifactRoot) => Path.Combine(artifactRoot, "behaviors");
+}

--- a/src/Nexo.Tests.Infrastructure/Certification/Reuse/ProjectCStateLogConsumer.cs
+++ b/src/Nexo.Tests.Infrastructure/Certification/Reuse/ProjectCStateLogConsumer.cs
@@ -1,0 +1,32 @@
+using Nexo.Certification.State;
+using Nexo.Infrastructure.Certification;
+using Nexo.Tests.Infrastructure.Certification.Reuse;
+
+namespace Nexo.Tests.Infrastructure.Certification.Reuse;
+
+/// <summary>
+/// Project C consumer surface: bundled artifact verification only (no gate, no Infrastructure in Project C exe).
+/// </summary>
+public static class ProjectCStateLogConsumer
+{
+    public static StateLogTrustResult VerifyBundledArtifacts(string artifactRoot, string? hmacKey = null)
+    {
+        var schema = AttestedStateLogWireFormat.DeserializeSchema(
+            File.ReadAllText(PhaseWitnessPaths.SchemaPath(artifactRoot)));
+        var log = AttestedStateLogWireFormat.DeserializeLog(
+            File.ReadAllText(PhaseWitnessPaths.LogPath(artifactRoot)));
+        var catalog = new FileCertifiedBehaviorCatalog(PhaseWitnessPaths.BehaviorRoot(artifactRoot));
+        var resolver = new CertifiedBehaviorCertificateResolver(catalog);
+
+        return StateLogVerifier.Verify(log, schema, resolver, hmacKey);
+    }
+
+    public static void AssertProjectCProjectHasNoGateOrInfrastructureReferences(string projectCcsprojPath)
+    {
+        var text = File.ReadAllText(projectCcsprojPath);
+        if (text.Contains("Nexo.Infrastructure", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Project C must not reference Nexo.Infrastructure.");
+        if (text.Contains("Adaptation.Generation", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Project C must not reference the generator.");
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/AttestedStateLogBindingTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/AttestedStateLogBindingTests.cs
@@ -172,6 +172,21 @@ public sealed class AttestedStateLogBindingTests
     }
 
     [Fact]
+    public void A2_FullyValidLogWithReplay_IsTrusted()
+    {
+        var log = Witness.BuildValidLog();
+        var result = StateLogVerifier.Verify(
+            log,
+            Witness.CreateSchema(),
+            Witness.CreateResolver(),
+            HmacKey,
+            Witness.CreateReplayer());
+
+        result.Trusted.Should().BeTrue($"expected TRUSTED, got {result.FailureCode}: {result.Reason}");
+        result.VerifiedTransitions.Should().Be(log.Count);
+    }
+
+    [Fact]
     public void G1_ZeroMutantGuard_VerifiedTransitionCountMatchesLogLength()
     {
         var log = Witness.BuildValidLog();

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/AttestedStateLogTrustGateTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/AttestedStateLogTrustGateTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.Certification.State;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Core.Application.Certification.Ports;
+using Nexo.Infrastructure.Certification;
+using Nexo.Infrastructure.Certification.Sdk.Extensions;
+using Nexo.Tests.Infrastructure.Certification.Reuse;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class AttestedStateLogTrustGateTests
+{
+    private const string HmacKey = "attested-state-log-test-hmac";
+
+    [Fact]
+    public void TrustGate_FromDi_TrustsBundledSampleLog()
+    {
+        var artifactRoot = PhaseWitnessPaths.ArtifactRoot();
+        var schema = AttestedStateLogWireFormat.DeserializeSchema(File.ReadAllText(PhaseWitnessPaths.SchemaPath(artifactRoot)));
+        var log = AttestedStateLogWireFormat.DeserializeLog(File.ReadAllText(PhaseWitnessPaths.LogPath(artifactRoot)));
+        var catalog = new FileCertifiedBehaviorCatalog(PhaseWitnessPaths.BehaviorRoot(artifactRoot));
+
+        var services = new ServiceCollection();
+        services.AddAttestedStateLogTrust(catalog);
+        var gate = services.BuildServiceProvider().GetRequiredService<IAttestedStateLogTrustGate>();
+
+        var result = gate.Verify(log, schema, HmacKey);
+
+        result.Trusted.Should().BeTrue($"expected TRUSTED, got {result.FailureCode}: {result.Reason}");
+        result.VerifiedTransitions.Should().Be(3);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/AttestedStateLogWireFormatTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/AttestedStateLogWireFormatTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Nexo.Certification.State;
+using Nexo.Infrastructure.Certification;
+using Nexo.Tests.Infrastructure.Certification.Reuse;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class AttestedStateLogWireFormatTests
+{
+    private const string HmacKey = "attested-state-log-test-hmac";
+
+    [Fact]
+    public void BundledSample_DeserializesAndTrustsTier1()
+    {
+        var artifactRoot = PhaseWitnessPaths.ArtifactRoot();
+        var schema = AttestedStateLogWireFormat.DeserializeSchema(File.ReadAllText(PhaseWitnessPaths.SchemaPath(artifactRoot)));
+        var log = AttestedStateLogWireFormat.DeserializeLog(File.ReadAllText(PhaseWitnessPaths.LogPath(artifactRoot)));
+        var catalog = new FileCertifiedBehaviorCatalog(PhaseWitnessPaths.BehaviorRoot(artifactRoot));
+        var resolver = new CertifiedBehaviorCertificateResolver(catalog);
+
+        var result = StateLogVerifier.Verify(log, schema, resolver, HmacKey);
+
+        result.Trusted.Should().BeTrue($"expected TRUSTED, got {result.FailureCode}: {result.Reason}");
+        result.VerifiedTransitions.Should().Be(3);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesTier1TrustVerdict()
+    {
+        var artifactRoot = PhaseWitnessPaths.ArtifactRoot();
+        var schema = AttestedStateLogWireFormat.DeserializeSchema(File.ReadAllText(PhaseWitnessPaths.SchemaPath(artifactRoot)));
+        var original = AttestedStateLogWireFormat.DeserializeLog(File.ReadAllText(PhaseWitnessPaths.LogPath(artifactRoot)));
+        var catalog = new FileCertifiedBehaviorCatalog(PhaseWitnessPaths.BehaviorRoot(artifactRoot));
+        var resolver = new CertifiedBehaviorCertificateResolver(catalog);
+
+        var json = AttestedStateLogWireFormat.SerializeLog(original);
+        var roundTripped = AttestedStateLogWireFormat.DeserializeLog(json);
+
+        var before = StateLogVerifier.Verify(original, schema, resolver, HmacKey);
+        var after = StateLogVerifier.Verify(roundTripped, schema, resolver, HmacKey);
+
+        after.Trusted.Should().Be(before.Trusted);
+        after.VerifiedTransitions.Should().Be(before.VerifiedTransitions);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CertifiedBehaviorCatalogTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CertifiedBehaviorCatalogTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Nexo.Certification.Contracts;
+using Nexo.Certification.State;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Infrastructure.Certification;
+using Nexo.Tests.Infrastructure.Certification.Reuse;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class CertifiedBehaviorCatalogTests
+{
+    private const string HmacKey = "attested-state-log-test-hmac";
+    private const string Source = "certified-behavior-alpha-v1";
+
+    [Fact]
+    public void InMemoryCatalog_Miss_ReturnsNotFound()
+    {
+        var catalog = new InMemoryCertifiedBehaviorCatalog(Array.Empty<CertifiedBehaviorEntry>());
+        var resolver = new CertifiedBehaviorCertificateResolver(catalog);
+
+        var result = resolver.Resolve(BrickContentHasher.ComputeSha256("missing"));
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FileCatalog_ResolvesTrustedBehavior_ForStateLogVerifier()
+    {
+        var entry = CreateEntry();
+        var tempDir = Path.Combine(Path.GetTempPath(), "nexo-behavior-catalog-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            FileCertifiedBehaviorCatalog.WriteEntry(tempDir, entry);
+            var catalog = new FileCertifiedBehaviorCatalog(tempDir);
+            var resolver = new CertifiedBehaviorCertificateResolver(catalog);
+
+            var resolve = resolver.Resolve(entry.ContentHash);
+            resolve.Found.Should().BeTrue();
+
+            var trust = CertificationTrustVerifier.Verify(resolve.Record!, resolve.BrickSource!, HmacKey);
+            trust.Trusted.Should().BeTrue($"expected TRUSTED, got {trust.FailureCode}: {trust.Reason}");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static CertifiedBehaviorEntry CreateEntry()
+    {
+        var record = new CertificationRecordData
+        {
+            Status = "PASS",
+            Stage = "witness",
+            Admitted = true,
+            Signed = true,
+            Timestamp = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+            BrickId = "behavior-alpha",
+            ContentHash = BrickContentHasher.ComputeSha256(Source),
+            EscapeRate = 0,
+            TotalMutants = 1,
+            SurvivingMutants = 0,
+            KilledMutants = new[] { "m1" },
+            SurvivingMutantIds = Array.Empty<string>()
+        };
+
+        record = record with { Signature = CertificationRecordSigning.Sign(record, HmacKey) };
+
+        return new CertifiedBehaviorEntry
+        {
+            ContentHash = record.ContentHash!,
+            Record = record,
+            Source = Source
+        };
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/CrossProjectStateLogReuseTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/CrossProjectStateLogReuseTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Nexo.Certification.State;
+using Nexo.Infrastructure.Certification;
+using Nexo.Tests.Infrastructure.Certification.Reuse;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class CrossProjectStateLogReuseTests
+{
+    private const string HmacKey = "attested-state-log-test-hmac";
+
+    [Fact]
+    public void HonestAttestedStateLog_ProjectC_TrustsTier1()
+    {
+        var projectCcsproj = Path.Combine(
+            RepoPaths.FindRepoRoot(),
+            "samples", "certified-state-log-reuse", "ProjectC", "ProjectC.csproj");
+        ProjectCStateLogConsumer.AssertProjectCProjectHasNoGateOrInfrastructureReferences(projectCcsproj);
+
+        var result = ProjectCStateLogConsumer.VerifyBundledArtifacts(PhaseWitnessPaths.ArtifactRoot(), HmacKey);
+
+        result.Trusted.Should().BeTrue($"expected TRUSTED, got {result.FailureCode}: {result.Reason}");
+        result.VerifiedTransitions.Should().Be(3);
+    }
+
+    [Fact]
+    public void TamperedAttestedStateLog_ProjectC_RefusesChainBreak()
+    {
+        var artifactRoot = PhaseWitnessPaths.ArtifactRoot();
+        var tempDir = Path.Combine(Path.GetTempPath(), "nexo-state-log-tamper-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            CopyDirectory(artifactRoot, tempDir);
+            var logPath = PhaseWitnessPaths.LogPath(tempDir);
+            var json = File.ReadAllText(logPath).Replace(
+                "\"prevEntryHash\": \"\"",
+                "\"prevEntryHash\": \"tampered-prev-entry\"",
+                StringComparison.Ordinal);
+
+            File.WriteAllText(logPath, json);
+
+            var result = ProjectCStateLogConsumer.VerifyBundledArtifacts(tempDir, HmacKey);
+
+            result.Trusted.Should().BeFalse();
+            result.FailureCode.Should().Be("chain-prev-entry-break");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ForgedBehaviorCert_ProjectC_Refuses()
+    {
+        var artifactRoot = PhaseWitnessPaths.ArtifactRoot();
+        var tempDir = Path.Combine(Path.GetTempPath(), "nexo-state-log-forged-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            CopyDirectory(artifactRoot, tempDir);
+            var behaviorRoot = PhaseWitnessPaths.BehaviorRoot(tempDir);
+            var recordPath = Path.Combine(Directory.GetDirectories(behaviorRoot).First(), "record.json");
+            var record = System.Text.Json.JsonSerializer.Deserialize<Nexo.Certification.Contracts.CertificationRecordData>(
+                File.ReadAllText(recordPath),
+                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+            record = record with { Signature = Convert.ToBase64String(new byte[32]) };
+            File.WriteAllText(
+                recordPath,
+                System.Text.Json.JsonSerializer.Serialize(record, new System.Text.Json.JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+                    WriteIndented = true
+                }));
+
+            var result = ProjectCStateLogConsumer.VerifyBundledArtifacts(tempDir, HmacKey);
+
+            result.Trusted.Should().BeFalse();
+            result.FailureCode.Should().Be("behavior-cert-untrusted");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        foreach (var directory in Directory.GetDirectories(source, "*", SearchOption.AllDirectories))
+            Directory.CreateDirectory(directory.Replace(source, destination, StringComparison.Ordinal));
+
+        foreach (var file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+        {
+            var target = file.Replace(source, destination, StringComparison.Ordinal);
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(file, target, overwrite: true);
+        }
+    }
+}

--- a/tools/GenStateLogFixtures/GenStateLogFixtures.csproj
+++ b/tools/GenStateLogFixtures/GenStateLogFixtures.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Nexo.Certification.State/Nexo.Certification.State.csproj" />
+    <ProjectReference Include="../../src/Nexo.Certification.Contracts/Nexo.Certification.Contracts.csproj" />
+    <ProjectReference Include="../../src/Nexo.Infrastructure/Nexo.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/Nexo.Core.Application/Nexo.Core.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/GenStateLogFixtures/Program.cs
+++ b/tools/GenStateLogFixtures/Program.cs
@@ -1,0 +1,58 @@
+using Nexo.Certification.Contracts;
+using Nexo.Certification.State;
+using Nexo.Core.Application.Certification.Models;
+using Nexo.Infrastructure.Certification;
+
+const string HmacKey = "attested-state-log-test-hmac";
+const string SchemaCanonical = """{"version":1,"stateBinding":{"version":"witness-v1","hashLength":44}}""";
+const string AlphaSource = "certified-behavior-alpha-v1";
+const string BetaSource = "certified-behavior-beta-v1";
+
+var outputRoot = args[0];
+var behaviorRoot = Path.Combine(outputRoot, "behaviors");
+
+var schema = new StateSchema(SchemaCanonical);
+var builder = new CertifiedTransitionBuilder();
+
+var alpha = CreateRecord("behavior-alpha", AlphaSource);
+var beta = CreateRecord("behavior-beta", BetaSource);
+
+var genesis = schema.ComputeBoundStateHash("genesis");
+var idle = schema.ComputeBoundStateHash("phase:idle");
+var armed = schema.ComputeBoundStateHash("phase:armed");
+var ready = schema.ComputeBoundStateHash("phase:ready");
+
+var t0 = builder.Create(genesis, "phase:advance", alpha.ContentHash!, idle, CertifiedTransition.GenesisPrevEntryHash);
+var t1 = builder.Create(idle, "phase:advance", alpha.ContentHash!, armed, t0.EntryHash);
+var t2 = builder.Create(armed, "phase:release", beta.ContentHash!, ready, t1.EntryHash);
+var log = new AttestedStateLog(new[] { t0, t1, t2 });
+
+Directory.CreateDirectory(behaviorRoot);
+File.WriteAllText(Path.Combine(outputRoot, "state-schema.json"), AttestedStateLogWireFormat.SerializeSchema(schema));
+File.WriteAllText(Path.Combine(outputRoot, "attested-state-log.json"), AttestedStateLogWireFormat.SerializeLog(log));
+
+FileCertifiedBehaviorCatalog.WriteEntry(behaviorRoot, new CertifiedBehaviorEntry { ContentHash = alpha.ContentHash!, Record = alpha, Source = AlphaSource });
+FileCertifiedBehaviorCatalog.WriteEntry(behaviorRoot, new CertifiedBehaviorEntry { ContentHash = beta.ContentHash!, Record = beta, Source = BetaSource });
+
+Console.WriteLine($"Wrote fixtures to {outputRoot}");
+
+static CertificationRecordData CreateRecord(string brickId, string source)
+{
+    var record = new CertificationRecordData
+    {
+        Status = "PASS",
+        Stage = "witness",
+        Admitted = true,
+        Signed = true,
+        Timestamp = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+        BrickId = brickId,
+        ContentHash = BrickContentHasher.ComputeSha256(source),
+        EscapeRate = 0,
+        TotalMutants = 1,
+        SurvivingMutants = 0,
+        KilledMutants = new[] { "m1" },
+        SurvivingMutantIds = Array.Empty<string>()
+    };
+
+    return record with { Signature = CertificationRecordSigning.Sign(record, HmacKey) };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 of attested state log binding: makes `Nexo.Certification.State` **callable and portable** outside hermetic test fixtures.

## WS1 — Certified behavior catalog + resolver

- `ICertifiedBehaviorCatalog` + `CertifiedBehaviorEntry` (content-hash keyed)
- `InMemoryCertifiedBehaviorCatalog`, `FileCertifiedBehaviorCatalog` (`{hash}/record.json` + `source.txt`)
- `CertifiedBehaviorCertificateResolver` adapts catalog → `ICertificateResolver`

## WS2 — Wire format + Tier-2 admission

- `AttestedStateLogWireFormat` JSON serialize/deserialize for schema + log
- **A2**: valid log + fake replayer → TRUSTED (Tier-2 admission)
- `AttestedStateLogWireFormatTests` (bundled sample + round-trip)

## WS3 — Project C cross-project reuse

- `samples/certified-state-log-reuse/Nexo.Certified.PhaseWitness/` bundled JSON artifacts
- `samples/certified-state-log-reuse/ProjectC/` — refs only `Nexo.Certification.State` + Contracts
- `scripts/pack-certified-state-log-reuse.sh`
- `CrossProjectStateLogReuseTests`: honest / tampered chain / forged cert

## WS4 — Trust port + DI + ledger

- `IAttestedStateLogTrustGate` + `AttestedStateLogTrustGate`
- `AddAttestedStateLogTrust()` DI extension
- Evidence section in `docs/certification-evidence.md`

## cert-gate

**60 tests** (was 51), all green locally.

## Out of scope (unchanged)

- Durable log storage, execution-engine replay, domain consumers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bfdb55e-e1da-43d1-aab1-227ede561b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bfdb55e-e1da-43d1-aab1-227ede561b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

