### PR TITLE
Phase 1: Physical-atom asset resolution + certified bundles

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -200,4 +200,9 @@
   <ItemGroup>
     <PackageVersion Include="NCrontab" Version="3.3.3" />
   </ItemGroup>
+  <!-- Physical-atom certification (Phase 0) -->
+  <ItemGroup>
+    <PackageVersion Include="NSec.Cryptography" Version="25.4.0" />
+    <PackageVersion Include="pocketken.H3" Version="4.0.0" />
+  </ItemGroup>
 </Project>

--- a/Nexo.sln
+++ b/Nexo.sln
@@ -119,6 +119,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Certification.Contract
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Certification.State", "src\Nexo.Certification.State\Nexo.Certification.State.csproj", "{B54D36C7-4226-4E82-A0BE-BC49B55B277E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Certification.Physical", "src\Nexo.Certification.Physical\Nexo.Certification.Physical.csproj", "{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -765,6 +767,18 @@ Global
 		{B54D36C7-4226-4E82-A0BE-BC49B55B277E}.Release|x64.Build.0 = Release|Any CPU
 		{B54D36C7-4226-4E82-A0BE-BC49B55B277E}.Release|x86.ActiveCfg = Release|Any CPU
 		{B54D36C7-4226-4E82-A0BE-BC49B55B277E}.Release|x86.Build.0 = Release|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Debug|x86.Build.0 = Debug|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Release|x64.Build.0 = Release|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Release|x86.ActiveCfg = Release|Any CPU
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -824,6 +838,7 @@ Global
 		{9E3C74B5-BCB4-4177-B52F-FFDA282B455E} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 		{265B00C0-D947-424D-A624-5233E0FDEC8C} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 		{B54D36C7-4226-4E82-A0BE-BC49B55B277E} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
+		{7023FD76-9ED9-4C7A-9E61-4CE020B836D0} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12345678-1234-1234-1234-123456789ABC}

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -73,7 +73,9 @@ Documentation index for the Nexo platform. Start here to find what you need.
 ## Security / Trust
 
 - `docs/physical-atom-phase0-spec.md` — **Phase 0 (Prototype):** physical-atom certificate schema, Ed25519 verifier, binding-scope policy (headless, cert-gate tested).
+- `docs/physical-atom-phase1-spec.md` — **Phase 1 (Prototype):** asset resolution store, certified bundle manifest, resolution verifier (headless).
 - `docs/physical-atom-phase0-test-report.md` — rejection-first test coverage report for Phase 0.
+- `docs/physical-atom-phase1-test-report.md` — Phase 1 resolution/bundle test report.
 - `samples/physical-atom-cert/` — signed sample certificate + issuer public key for headless verification replay.
 - `docs/FriendMeshPrefab.md` — prefab Docker Compose + env template for a small shared **Nexo.API** hub (friends / tailnet).
 - `docs/MeshPhase8OperatorHardening.md` — **Mesh Phase 8:** discovery admission, trust alias, `nexo mesh peers` / `mesh health` / `dotnet run --project commercial/src/Nexo.Commercial.MeshDirector -- director ...`, TLS example.

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -72,6 +72,9 @@ Documentation index for the Nexo platform. Start here to find what you need.
 
 ## Security / Trust
 
+- `docs/physical-atom-phase0-spec.md` — **Phase 0 (Prototype):** physical-atom certificate schema, Ed25519 verifier, binding-scope policy (headless, cert-gate tested).
+- `docs/physical-atom-phase0-test-report.md` — rejection-first test coverage report for Phase 0.
+- `samples/physical-atom-cert/` — signed sample certificate + issuer public key for headless verification replay.
 - `docs/FriendMeshPrefab.md` — prefab Docker Compose + env template for a small shared **Nexo.API** hub (friends / tailnet).
 - `docs/MeshPhase8OperatorHardening.md` — **Mesh Phase 8:** discovery admission, trust alias, `nexo mesh peers` / `mesh health` / `dotnet run --project commercial/src/Nexo.Commercial.MeshDirector -- director ...`, TLS example.
 - `docs/MeshVirtualLab.md` — **Virtual mesh lab:** two Nexo.API nodes in Docker + verify script (no extra hardware); **`scripts/bootstrap-cloud-mesh-lab.sh`** for Ubuntu/Debian cloud VMs.

--- a/docs/certification-evidence.md
+++ b/docs/certification-evidence.md
@@ -8,7 +8,7 @@ Version pin: `0.1.0` (from `VERSION`)
 
 | Property | Proof mechanism | Result | CI run |
 |----------|-----------------|--------|--------|
-| Atom portability (spike steps 1–5) | `spikes/portability/run-portability-spike.sh` — generate, certify, pack, external consume, cross-project execute | **PASS** (all steps) | Local spike; see [portability spike summary](../spikes/portability/spike-run-summary.md) when re-run |
+| Atom portability (spike steps 1–5) | `spikes/portability/run-portability-spike.sh` — generate, certify, pack, external consume, cross-project execute | **PASS** (all steps) | Local spike; re-run `run-portability-spike.sh` for fresh summary |
 | Atom gate teeth (strong witness) | `CertificationGateTeethTests.GoodBrick_StrongWitness_Admits_WithZeroEscapeRate` | **ADMIT**, `escape_rate=0` | [Cert gate 27918340788](https://github.com/IanFrelinger/Nexo/actions/runs/27918340788) |
 | Atom gate teeth (weak witness) | `CertificationGateTeethTests.WeakWitness_AllowsMutantEscapes_RejectsWithTeeth` | **REJECT**, `mutation`, `escape_rate > 0` | [Cert gate 27918340788](https://github.com/IanFrelinger/Nexo/actions/runs/27918340788) |
 | General generation 4b (buggy rejects) | `GenerationSafetyTests.BuggyGeneration_StrongWitness_Rejects` | **REJECT**, `correctness` \| `mutation` | [Cert gate 27918340788](https://github.com/IanFrelinger/Nexo/actions/runs/27918340788) |
@@ -197,6 +197,22 @@ CI: [run 28028224579](https://github.com/IanFrelinger/Nexo/actions/runs/28028224
 **What this proves:** Raw proposer acceptance is **measured** (admits/total via unchanged `ProposeAndCertifyCompositionService`), not gated. Full batch recorded at temperature > 0 including rejects; CI replays deterministically.
 
 **v0 boundary:** Single task (damage→health), one provider (cursor), record/replay batch.
+
+## Physical-atom certification (Phase 0 — Prototype)
+
+Headless cert + verifier core for binding physical objects to hosted digital-twin assets. Spec: `docs/physical-atom-phase0-spec.md`. Test report: `docs/physical-atom-phase0-test-report.md`.
+
+| Proof | Result |
+|-------|--------|
+| `PhysicalAtomCertificateVerifierTests` (R1–R7 refusal + A1–A4 admission) | **PASS** — forged sig, hash mismatch, binding-scope violations, geo H3 inconsistency, tampered extensions all refused |
+| `BundleCertificationBrickTests` | **PASS** — Design/Instance/Batch issuance; inconsistent inputs refused at issuance |
+| `PhysicalAtomSampleCertTests` | **PASS** — committed sample at `samples/physical-atom-cert/` verifies headless |
+
+**Design decision:** `Design` binding_scope with populated `manufacture_meta` is an explicit error (`binding-scope-manufacture-meta-forbidden`), not silently ignored.
+
+**Crypto:** Ed25519 issuer signatures via `Nexo.Certification.Physical` (NSec 25.4.0). Sample issuer key is documentation-only.
+
+cert-gate: **69 tests** @ [run 28486193636](https://github.com/IanFrelinger/Nexo/actions/runs/28486193636) (`conclusion: success`, PR #210).
 
 ## Contract-stability gaps
 

--- a/docs/certification-evidence.md
+++ b/docs/certification-evidence.md
@@ -214,6 +214,18 @@ Headless cert + verifier core for binding physical objects to hosted digital-twi
 
 cert-gate: **69 tests** @ [run 28486193636](https://github.com/IanFrelinger/Nexo/actions/runs/28486193636) (`conclusion: success`, PR #210).
 
+## Physical-atom asset resolution (Phase 1 — Prototype)
+
+Headless hosting/resolution loop: register assets + certs, resolve by atom/hash, verify bundles. Spec: `docs/physical-atom-phase1-spec.md`.
+
+| Proof | Result |
+|-------|--------|
+| `PhysicalAtomResolutionVerifierTests` (R1–R4 + A1–A2) | **PASS** — unresolved atom/asset, store byte mismatch, tampered bundle manifest refused |
+| `AssetBundleCertificationPipelineTests` | **PASS** — certify/register/resolve end-to-end |
+| `PhysicalAtomCertBundleManifestTests` | **PASS** — sample `design-scope.bundle.json` round-trips and verifies |
+
+Sample bundle: `samples/physical-atom-cert/design-scope.bundle.json`.
+
 ## Contract-stability gaps
 
 - Generated brick uses Nexo.Core.Domain.* namespaces (shipped via Nexo.Authoring/Nexo.Brick.Contracts but not the pinned package IDs)

--- a/docs/physical-atom-phase0-spec.md
+++ b/docs/physical-atom-phase0-spec.md
@@ -1,0 +1,84 @@
+# Physical-Atom Certificate — Phase 0 Formal Spec
+
+**Maturity:** `MaturityLevel.Prototype` for all artifacts in this phase.
+
+## Purpose
+
+Bind a physical atom (real-world object) to a hosted digital-twin asset via an Ed25519-signed certificate. Phase 0 delivers schema, standalone verification, and deterministic issuance — no rendering, device I/O, or network dependencies.
+
+## Schema (`PhysicalAtomCertificate`, version 1)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schemaVersion` | int | yes | Must be `1` |
+| `maturity` | enum | yes | `Prototype` \| `Preview` \| `Stable` |
+| `atomId` | UUID | yes | Non-empty GUID |
+| `bindingScope` | enum | yes | `Design` \| `Instance` \| `Batch` |
+| `assetHash` | string | yes | Lowercase hex SHA-256 (64 chars) of asset bytes |
+| `assetVersion` | string | yes | SemVer 2.0 |
+| `geoAnchor` | object | no | When present, load-bearing for geo consistency |
+| `manufactureMeta` | object | scope-dependent | See binding policy |
+| `extensions` | map<string, base64-bytes> | no | Signed but uninterpreted by core verifier |
+| `issuerSignature` | string | yes (issued certs) | Base64 Ed25519 signature (64 bytes) |
+
+### `geoAnchor`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `latitude` | double | [-90, 90] |
+| `longitude` | double | [-180, 180] |
+| `resolution` | int | H3 resolution [0, 15] |
+| `h3Index` | string | 15-char hex; must match lat/lon at resolution |
+
+### `manufactureMeta`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `batchId` | string? | Required for `Batch` scope |
+| `serialNumber` | string? | Required for `Instance` scope |
+| `manufacturedAt` | ISO-8601? | Optional timestamp |
+
+## Binding-scope validation policy
+
+| Scope | `manufactureMeta` | Rule |
+|-------|-------------------|------|
+| **Design** | Must be **absent/null** | Populated `manufactureMeta` is an **error** (not silently ignored) |
+| **Instance** | Required | Must include non-empty `serialNumber` |
+| **Batch** | Required | Must include non-empty `batchId` |
+
+When `geoAnchor` is present, `h3Index` must be consistent with `latitude`/`longitude` at `resolution` (computed via H3).
+
+## Signing
+
+Canonical JSON payload (camelCase, nulls omitted) over:
+
+```
+schemaVersion, maturity, atomId, bindingScope, assetHash, assetVersion,
+geoAnchor, manufactureMeta, extensions (keys sorted, values base64)
+```
+
+`issuerSignature` is **excluded** from the signed payload. Algorithm: **Ed25519** (NSec/libsodium).
+
+## Verification (`PhysicalAtomCertificateVerifier`)
+
+Order of checks:
+
+1. Structural / binding-scope policy (`PhysicalAtomCertificateValidationPolicy`)
+2. Ed25519 signature against issuer public key
+3. `assetHash` consistency vs. provided asset bytes
+
+Failure codes (kebab-case): `signature-invalid`, `asset-hash-mismatch`, `binding-scope-manufacture-meta-required`, `binding-scope-manufacture-meta-forbidden`, `geo-anchor-inconsistent`, etc.
+
+## Issuance (`BundleCertificationBrick`)
+
+Deterministic brick in `Nexo.Infrastructure.Certification.Physical`. Computes `assetHash` from asset bytes, validates binding-scope policy, signs with issuer private key. Refuses inconsistent inputs before signing.
+
+## Out of scope (Phase 0)
+
+Asset generation, QR/NFC encoding, XR clients, hosting/resolution backend, release channel logic.
+
+## Implementation
+
+- Library: `src/Nexo.Certification.Physical/`
+- Issuance: `src/Nexo.Infrastructure/Certification/Physical/BundleCertificationBrick.cs`
+- Tests: `src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomCertificateVerifierTests.cs`, `BundleCertificationBrickTests.cs`

--- a/docs/physical-atom-phase0-test-report.md
+++ b/docs/physical-atom-phase0-test-report.md
@@ -24,8 +24,13 @@
 |----|------|--------|
 | A1 | Well-formed `Design` scope | PASS |
 | A2 | Well-formed `Instance` scope | PASS |
-| A3 | Well-formed `Batch` scope | PASS |
 | A4 | `Design` + consistent `geo_anchor` | PASS |
+
+## Sample replay (`PhysicalAtomSampleCertTests`)
+
+| Case | Status |
+|------|--------|
+| Committed `samples/physical-atom-cert/instance-scope.example.json` verifies against documented asset bytes | PASS |
 
 ## Issuance coverage (`BundleCertificationBrickTests`)
 
@@ -47,11 +52,11 @@
 ```bash
 dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj \
   -f net8.0 \
-  --filter "FullyQualifiedName~PhysicalAtomCertificateVerifierTests|FullyQualifiedName~BundleCertificationBrickTests"
+  --filter "FullyQualifiedName~PhysicalAtomCertificateVerifierTests|FullyQualifiedName~BundleCertificationBrickTests|FullyQualifiedName~PhysicalAtomSampleCertTests"
 ```
 
 All tests are headless (xUnit, no GUI/simulator/device).
 
 ## Phase 0 gate
 
-Verifier rejects every malformed/tampered cert in the suite and accepts well-formed certs across all three `binding_scope` values. **17/17 tests passing** (11 verifier + 6 issuer).
+Verifier rejects every malformed/tampered cert in the suite and accepts well-formed certs across all three `binding_scope` values. **18/18 tests passing** (11 verifier + 6 issuer + 1 sample replay).

--- a/docs/physical-atom-phase0-test-report.md
+++ b/docs/physical-atom-phase0-test-report.md
@@ -1,0 +1,57 @@
+# Physical-Atom Phase 0 — Test Report
+
+**Sprint:** Phase 0 — Cert + Verifier Core  
+**Maturity:** Prototype  
+**Methodology:** Rejection-first; verifier witness fixtures independent of issuance code path.
+
+## Rejection coverage (verifier witness — `PhysicalAtomCertificateVerifierTests`)
+
+| ID | Case | Expected failure | Status |
+|----|------|------------------|--------|
+| R1 | Forged / invalid signature | `signature-invalid` | PASS |
+| R2 | `asset_hash` mismatch vs provided asset | `asset-hash-mismatch` | PASS |
+| R3 | `Instance` scope, null `manufacture_meta` | `binding-scope-manufacture-meta-required` | PASS |
+| R4 | `Design` scope with populated `manufacture_meta` | `binding-scope-manufacture-meta-forbidden` | PASS |
+| R5 | `geo_anchor` present, `h3_index` inconsistent with lat/lon | `geo-anchor-inconsistent` | PASS |
+| R6 | Tampered `extensions` map (signature no longer valid) | `signature-invalid` | PASS |
+| R7 | Wrong issuer public key | `signature-invalid` | PASS |
+
+**Design decision (R4):** `Design` + populated `manufacture_meta` is an explicit **error**, not silently ignored.
+
+## Happy-path coverage (verifier witness)
+
+| ID | Case | Status |
+|----|------|--------|
+| A1 | Well-formed `Design` scope | PASS |
+| A2 | Well-formed `Instance` scope | PASS |
+| A3 | Well-formed `Batch` scope | PASS |
+| A4 | `Design` + consistent `geo_anchor` | PASS |
+
+## Issuance coverage (`BundleCertificationBrickTests`)
+
+| Case | Status |
+|------|--------|
+| Issue `Design` / `Instance` / `Batch` → verifier accepts | PASS |
+| Refuse `Instance` without `manufacture_meta` | PASS |
+| Refuse `Design` with `manufacture_meta` | PASS |
+| Refuse inconsistent `geo_anchor` at issuance | PASS |
+
+## Witness independence
+
+- Verifier tests use `WitnessBuilder` — hand-authored certs signed with witness keys via `PhysicalAtomCertificateSigning` only.
+- Issuer tests use separate key material and `BundleCertificationBrick`; no shared fixtures with verifier suite.
+- Malformed/tampered certs in R1/R6 are constructed by direct field mutation, not via issuance path.
+
+## Execution
+
+```bash
+dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj \
+  -f net8.0 \
+  --filter "FullyQualifiedName~PhysicalAtomCertificateVerifierTests|FullyQualifiedName~BundleCertificationBrickTests"
+```
+
+All tests are headless (xUnit, no GUI/simulator/device).
+
+## Phase 0 gate
+
+Verifier rejects every malformed/tampered cert in the suite and accepts well-formed certs across all three `binding_scope` values. **17/17 tests passing** (11 verifier + 6 issuer).

--- a/docs/physical-atom-phase1-spec.md
+++ b/docs/physical-atom-phase1-spec.md
@@ -1,0 +1,75 @@
+# Physical-Atom Certificate — Phase 1 Formal Spec
+
+**Maturity:** `MaturityLevel.Prototype` for all artifacts in this phase.
+
+**Depends on:** Phase 0 (`PhysicalAtomCertificate`, `PhysicalAtomCertificateVerifier`, `BundleCertificationBrick`).
+
+## Purpose
+
+Close the hosting/resolution loop headlessly: register digital-twin assets, resolve them by `(asset_hash, asset_version)` or `atom_id`, and verify certificates against resolved bytes — without XR rendering, device I/O, or live network dependencies.
+
+## Scope (Phase 1)
+
+| In scope | Out of scope (later phases) |
+|----------|----------------------------|
+| In-memory resolution store | HTTP hosting backend |
+| `PhysicalAtomCertBundle` portable manifest | QR/NFC encoding |
+| Resolution-aware verifier | XR client / simulator |
+| `AssetBundleCertificationPipeline` | Release channel / release_class |
+| JSON manifest serialize/deserialize | Asset *generation* from 3D scans |
+
+## Resolution store (`IAssetResolutionStore`)
+
+| Operation | Behavior |
+|-----------|----------|
+| `TryResolveAsset(hash, version)` | Returns hosted asset bytes + content type |
+| `TryResolveCert(atomId)` | Returns registered certificate for atom |
+
+Prototype implementation: `InMemoryAssetResolutionStore`.
+
+## Certified bundle (`PhysicalAtomCertBundle`)
+
+Self-contained artifact for offline verification:
+
+| Field | Notes |
+|-------|-------|
+| `certificate` | Phase 0 `PhysicalAtomCertificate` |
+| `assetBytes` | Raw digital-twin asset bytes |
+| `contentType` | MIME type (default `application/octet-stream`) |
+| `issuerPublicKey` | 32-byte Ed25519 public key |
+
+JSON manifest: `PhysicalAtomCertBundleManifest` (`design-scope.bundle.json` sample).
+
+## Verification
+
+### `PhysicalAtomResolutionVerifier`
+
+1. Resolve registered cert for `atom_id` (must match provided cert)
+2. Resolve asset bytes for `(asset_hash, asset_version)`
+3. Delegate to Phase 0 `PhysicalAtomCertificateVerifier`
+
+Failure codes: `atom-unresolved`, `asset-unresolved`, `atom-cert-mismatch`, plus Phase 0 codes.
+
+### `PhysicalAtomCertBundleVerifier`
+
+1. Confirm bundle asset bytes hash to `certificate.asset_hash`
+2. Confirm bundle issuer key matches expected public key
+3. Delegate to Phase 0 verifier
+
+Failure codes: `bundle-asset-hash-mismatch`, `bundle-issuer-key-mismatch`, plus Phase 0 codes.
+
+## Issuance pipeline (`AssetBundleCertificationPipeline`)
+
+Deterministic flow:
+
+1. `BundleCertificationBrick.Issue` (Phase 0)
+2. Register asset + cert in resolution store
+3. Emit `PhysicalAtomCertBundle`
+
+Refuses inconsistent binding-scope inputs before registration (same policy as Phase 0).
+
+## Implementation
+
+- Resolution types: `src/Nexo.Certification.Physical/Resolution/`
+- Pipeline: `src/Nexo.Infrastructure/Certification/Physical/AssetBundleCertificationPipeline.cs`
+- Tests: `PhysicalAtomResolutionVerifierTests`, `AssetBundleCertificationPipelineTests`, `PhysicalAtomCertBundleManifestTests`

--- a/docs/physical-atom-phase1-test-report.md
+++ b/docs/physical-atom-phase1-test-report.md
@@ -1,0 +1,43 @@
+# Physical-Atom Phase 1 — Test Report
+
+**Sprint:** Phase 1 — Asset Resolution + Certified Bundles  
+**Maturity:** Prototype  
+**Methodology:** Rejection-first; resolution witness independent of pipeline tests.
+
+## Rejection coverage (`PhysicalAtomResolutionVerifierTests`)
+
+| ID | Case | Expected failure | Status |
+|----|------|------------------|--------|
+| R1 | Unregistered `atom_id` | `atom-unresolved` | PASS |
+| R2 | Store returns bytes that don't match cert hash | `asset-hash-mismatch` | PASS |
+| R3 | Registered cert but missing asset | `asset-unresolved` | PASS |
+| R4 | Tampered bundle cert hash vs embedded asset | `bundle-asset-hash-mismatch` | PASS |
+
+## Happy-path coverage
+
+| ID | Case | Status |
+|----|------|--------|
+| A1 | Resolution store + cert verifies | PASS |
+| A2 | Self-contained bundle verifies | PASS |
+| A3 | Pipeline certify-and-register + resolution verify | PASS |
+| A4 | Sample bundle manifest round-trip | PASS |
+
+## Pipeline coverage (`AssetBundleCertificationPipelineTests`)
+
+| Case | Status |
+|------|--------|
+| Certify, register, resolve, verify end-to-end | PASS |
+| Refuse invalid binding-scope at pipeline | PASS |
+
+## Execution
+
+```bash
+dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 \
+  --filter "FullyQualifiedName~PhysicalAtomResolution|FullyQualifiedName~AssetBundleCertification|FullyQualifiedName~PhysicalAtomCertBundleManifest"
+```
+
+All tests headless (xUnit, in-memory store, no network).
+
+## Phase 1 gate
+
+Resolution verifier rejects unresolved/tampered hosting paths; accepts well-formed bundles and pipeline output. **9/9 Phase 1 tests passing** (included in cert-gate total).

--- a/samples/physical-atom-cert/README.md
+++ b/samples/physical-atom-cert/README.md
@@ -7,6 +7,7 @@
 | File | Purpose |
 |------|---------|
 | `instance-scope.example.json` | Signed `Instance` scope certificate |
+| `design-scope.bundle.json` | Self-contained Design-scope certified bundle manifest (Phase 1) |
 | `issuer-public-key.sample.b64` | Base64 Ed25519 public key (32 bytes) for verification |
 
 ## Bound asset
@@ -33,7 +34,7 @@ var result = PhysicalAtomCertificateVerifier.Verify(cert, assetBytes, issuerPubl
 // result.Trusted == true
 ```
 
-Hermetic replay: `PhysicalAtomSampleCertTests` in the cert-gate suite.
+Hermetic replay: `PhysicalAtomSampleCertTests` and `PhysicalAtomCertBundleManifestTests` in the cert-gate suite.
 
 ## Spec
 

--- a/samples/physical-atom-cert/README.md
+++ b/samples/physical-atom-cert/README.md
@@ -1,0 +1,40 @@
+# Physical-atom certificate sample (Phase 0)
+
+**Maturity:** Prototype — sample issuer key is for documentation and CI only, not production PKI.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `instance-scope.example.json` | Signed `Instance` scope certificate |
+| `issuer-public-key.sample.b64` | Base64 Ed25519 public key (32 bytes) for verification |
+
+## Bound asset
+
+The certificate binds to UTF-8 bytes of the string:
+
+```
+sample-digital-twin-asset-v1
+```
+
+SHA-256 hex (`assetHash` in the JSON): `18301e3630ca2816dcb1e23264aaec41d9ed4108337c9b5a936e39565d01c742`
+
+## Verify (headless)
+
+```csharp
+using Nexo.Certification.Physical;
+
+var cert = /* deserialize instance-scope.example.json */;
+var assetBytes = System.Text.Encoding.UTF8.GetBytes("sample-digital-twin-asset-v1");
+var issuerPublicKey = Convert.FromBase64String(
+    File.ReadAllText("samples/physical-atom-cert/issuer-public-key.sample.b64").Trim());
+
+var result = PhysicalAtomCertificateVerifier.Verify(cert, assetBytes, issuerPublicKey);
+// result.Trusted == true
+```
+
+Hermetic replay: `PhysicalAtomSampleCertTests` in the cert-gate suite.
+
+## Spec
+
+See `docs/physical-atom-phase0-spec.md`.

--- a/samples/physical-atom-cert/design-scope.bundle.json
+++ b/samples/physical-atom-cert/design-scope.bundle.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "maturity": "Prototype",
+  "certificate": {
+    "schemaVersion": 1,
+    "maturity": "Prototype",
+    "atomId": "550e8400-e29b-41d4-a716-446655440001",
+    "bindingScope": "Design",
+    "assetHash": "18301e3630ca2816dcb1e23264aaec41d9ed4108337c9b5a936e39565d01c742",
+    "assetVersion": "1.0.0",
+    "extensions": {},
+    "issuerSignature": "KcK7tV0yU/2V13GWvlmCmXceyGqSIJisDieJeu1/XJN+zr5lRiZjLH64afp9ftkZUCoWllghNNFMsOVH7GYJBg=="
+  },
+  "contentType": "application/octet-stream",
+  "assetBytesBase64": "c2FtcGxlLWRpZ2l0YWwtdHdpbi1hc3NldC12MQ==",
+  "issuerPublicKeyBase64": "SOAn5IcnCADrZ0YtsWCmD6cZacp/xtKi8/iNwPDvjU0="
+}

--- a/samples/physical-atom-cert/instance-scope.example.json
+++ b/samples/physical-atom-cert/instance-scope.example.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "maturity": "Prototype",
+  "atomId": "550e8400-e29b-41d4-a716-446655440000",
+  "bindingScope": "Instance",
+  "assetHash": "18301e3630ca2816dcb1e23264aaec41d9ed4108337c9b5a936e39565d01c742",
+  "assetVersion": "1.0.0",
+  "geoAnchor": {
+    "latitude": 37.7749,
+    "longitude": -122.4194,
+    "resolution": 9,
+    "h3Index": "897016d01d3ffff"
+  },
+  "manufactureMeta": {
+    "batchId": "BATCH-SAMPLE-001",
+    "serialNumber": "SN-SAMPLE-42",
+    "manufacturedAt": "2026-06-01T00:00:00Z"
+  },
+  "extensions": {},
+  "issuerSignature": "ezD/dUuely6gPUZwa6kcNlQs4mP5Gcx0Cxh2sIKXz/bXstqX87ROKaMgbRvHW2EQchex8XXXt3ljZ+9trfbICA=="
+}

--- a/samples/physical-atom-cert/issuer-public-key.sample.b64
+++ b/samples/physical-atom-cert/issuer-public-key.sample.b64
@@ -1,0 +1,1 @@
+SOAn5IcnCADrZ0YtsWCmD6cZacp/xtKi8/iNwPDvjU0=

--- a/scripts/cert-gate-config.sh
+++ b/scripts/cert-gate-config.sh
@@ -21,6 +21,7 @@ readonly CERT_GATE_FILTER='FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Ce
 #   AttestedStateLogBindingTests: 10
 #   PhysicalAtomCertificateVerifierTests: 11
 #   BundleCertificationBrickTests: 6
+#   PhysicalAtomSampleCertTests: 1
 # Excluded from cert-gate filter: LocalFixtures.CompositionAcceptanceRateBatchFixtureGeneratorTests (local fixture regen only)
 
 cert_gate_list_tests() {

--- a/scripts/cert-gate-config.sh
+++ b/scripts/cert-gate-config.sh
@@ -19,6 +19,8 @@ readonly CERT_GATE_FILTER='FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Ce
 #   CompositionAcceptanceRateMeasurementTests: 3
 #   CompositionAcceptanceRateProtocolTests: 1
 #   AttestedStateLogBindingTests: 10
+#   PhysicalAtomCertificateVerifierTests: 11
+#   BundleCertificationBrickTests: 6
 # Excluded from cert-gate filter: LocalFixtures.CompositionAcceptanceRateBatchFixtureGeneratorTests (local fixture regen only)
 
 cert_gate_list_tests() {

--- a/scripts/cert-gate-config.sh
+++ b/scripts/cert-gate-config.sh
@@ -22,6 +22,9 @@ readonly CERT_GATE_FILTER='FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Ce
 #   PhysicalAtomCertificateVerifierTests: 11
 #   BundleCertificationBrickTests: 6
 #   PhysicalAtomSampleCertTests: 1
+#   PhysicalAtomResolutionVerifierTests: 6
+#   AssetBundleCertificationPipelineTests: 2
+#   PhysicalAtomCertBundleManifestTests: 1
 # Excluded from cert-gate filter: LocalFixtures.CompositionAcceptanceRateBatchFixtureGeneratorTests (local fixture regen only)
 
 cert_gate_list_tests() {

--- a/src/Nexo.Certification.Physical/AssetContentHasher.cs
+++ b/src/Nexo.Certification.Physical/AssetContentHasher.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Canonical SHA-256 content hash for asset bytes bound into physical-atom certificates.
+/// </summary>
+public static class AssetContentHasher
+{
+    public static string ComputeSha256Hex(ReadOnlySpan<byte> assetBytes)
+    {
+        if (assetBytes.IsEmpty)
+            throw new ArgumentException("Asset bytes are required.", nameof(assetBytes));
+
+        var hash = SHA256.HashData(assetBytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    public static string ComputeSha256Hex(string canonicalSource)
+    {
+        if (string.IsNullOrEmpty(canonicalSource))
+            throw new ArgumentException("Canonical source is required.", nameof(canonicalSource));
+
+        return ComputeSha256Hex(Encoding.UTF8.GetBytes(canonicalSource));
+    }
+}

--- a/src/Nexo.Certification.Physical/BindingScope.cs
+++ b/src/Nexo.Certification.Physical/BindingScope.cs
@@ -1,0 +1,11 @@
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Determines which optional certificate fields are load-bearing for verification.
+/// </summary>
+public enum BindingScope
+{
+    Design = 0,
+    Instance = 1,
+    Batch = 2
+}

--- a/src/Nexo.Certification.Physical/EncodingCompat.cs
+++ b/src/Nexo.Certification.Physical/EncodingCompat.cs
@@ -1,0 +1,8 @@
+using System.Text;
+
+namespace Nexo.Certification.Physical;
+
+internal static class EncodingCompat
+{
+    internal static readonly UTF8Encoding Utf8 = new(encoderShouldEmitUTF8Identifier: false);
+}

--- a/src/Nexo.Certification.Physical/GeoAnchor.cs
+++ b/src/Nexo.Certification.Physical/GeoAnchor.cs
@@ -1,0 +1,10 @@
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Optional geographic anchor binding a physical atom to a location on Earth.
+/// </summary>
+public sealed record GeoAnchor(
+    double Latitude,
+    double Longitude,
+    int Resolution,
+    string H3Index);

--- a/src/Nexo.Certification.Physical/GeoAnchorValidator.cs
+++ b/src/Nexo.Certification.Physical/GeoAnchorValidator.cs
@@ -1,0 +1,61 @@
+using System.Text.RegularExpressions;
+using H3;
+using H3.Model;
+
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Validates optional geo anchors: coordinate bounds and H3 index consistency with lat/lon.
+/// </summary>
+public static class GeoAnchorValidator
+{
+    private const int MinResolution = 0;
+    private const int MaxResolution = 15;
+
+    public static bool IsConsistent(GeoAnchor anchor, out string? reason)
+    {
+        if (anchor.Latitude is < -90 or > 90)
+        {
+            reason = "Geo anchor latitude must be within [-90, 90].";
+            return false;
+        }
+
+        if (anchor.Longitude is < -180 or > 180)
+        {
+            reason = "Geo anchor longitude must be within [-180, 180].";
+            return false;
+        }
+
+        if (anchor.Resolution is < MinResolution or > MaxResolution)
+        {
+            reason = $"Geo anchor resolution must be within [{MinResolution}, {MaxResolution}].";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(anchor.H3Index))
+        {
+            reason = "Geo anchor h3_index is required when geo_anchor is present.";
+            return false;
+        }
+
+        if (!Regex.IsMatch(anchor.H3Index, "^[0-9a-fA-F]{15}$"))
+        {
+            reason = "Geo anchor h3_index must be a 15-character hexadecimal H3 cell index.";
+            return false;
+        }
+
+        var expected = H3Index.FromLatLng(new LatLng(anchor.Latitude, anchor.Longitude), anchor.Resolution)
+            .ToString()
+            .ToLowerInvariant();
+        var actual = anchor.H3Index.ToLowerInvariant();
+
+        if (!string.Equals(expected, actual, StringComparison.Ordinal))
+        {
+            reason = $"Geo anchor h3_index '{actual}' is inconsistent with lat/lon at resolution {anchor.Resolution} (expected '{expected}').";
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+}

--- a/src/Nexo.Certification.Physical/ManufactureMeta.cs
+++ b/src/Nexo.Certification.Physical/ManufactureMeta.cs
@@ -1,0 +1,10 @@
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Optional manufacturing metadata. Load-bearing for <see cref="BindingScope.Instance"/> and
+/// <see cref="BindingScope.Batch"/> scopes per validation policy.
+/// </summary>
+public sealed record ManufactureMeta(
+    string? BatchId,
+    string? SerialNumber,
+    DateTimeOffset? ManufacturedAt);

--- a/src/Nexo.Certification.Physical/MaturityLevel.cs
+++ b/src/Nexo.Certification.Physical/MaturityLevel.cs
@@ -1,0 +1,11 @@
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Maturity of certification artifacts. Phase 0 outputs are <see cref="Prototype"/> unless promoted.
+/// </summary>
+public enum MaturityLevel
+{
+    Prototype = 0,
+    Preview = 1,
+    Stable = 2
+}

--- a/src/Nexo.Certification.Physical/Nexo.Certification.Physical.csproj
+++ b/src/Nexo.Certification.Physical/Nexo.Certification.Physical.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>Nexo.Certification.Physical</PackageId>
+    <Title>Nexo Certification Physical</Title>
+    <Description>Physical-atom certificate schema, Ed25519 signing, and standalone verification for digital-twin asset binding.</Description>
+    <PackageTags>nexo;certification;physical-atom;trust;ed25519</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSec.Cryptography" />
+    <PackageReference Include="pocketken.H3" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nexo.Certification.Physical/PhysicalAtomCertificate.cs
+++ b/src/Nexo.Certification.Physical/PhysicalAtomCertificate.cs
@@ -1,0 +1,34 @@
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Binds a physical atom to a hosted digital-twin asset via Ed25519 issuer attestation.
+/// </summary>
+public sealed record PhysicalAtomCertificate
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+
+    public MaturityLevel Maturity { get; init; } = MaturityLevel.Prototype;
+
+    public Guid AtomId { get; init; }
+
+    public BindingScope BindingScope { get; init; }
+
+    /// <summary>Lowercase hex SHA-256 digest (64 characters) of the bound asset bytes.</summary>
+    public string AssetHash { get; init; } = string.Empty;
+
+    /// <summary>SemVer of the bound asset.</summary>
+    public string AssetVersion { get; init; } = string.Empty;
+
+    public GeoAnchor? GeoAnchor { get; init; }
+
+    public ManufactureMeta? ManufactureMeta { get; init; }
+
+    /// <summary>Signed but uninterpreted by the core verifier.</summary>
+    public IReadOnlyDictionary<string, byte[]> Extensions { get; init; } =
+        new Dictionary<string, byte[]>(StringComparer.Ordinal);
+
+    /// <summary>Base64-encoded Ed25519 signature over the canonical signing payload.</summary>
+    public string? IssuerSignature { get; init; }
+}

--- a/src/Nexo.Certification.Physical/PhysicalAtomCertificateSigning.cs
+++ b/src/Nexo.Certification.Physical/PhysicalAtomCertificateSigning.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NSec.Cryptography;
+
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Canonical Ed25519 signing for physical-atom certificates.
+/// </summary>
+public static class PhysicalAtomCertificateSigning
+{
+    private static readonly SignatureAlgorithm Algorithm = SignatureAlgorithm.Ed25519;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    public static string Sign(PhysicalAtomCertificate certificate, ReadOnlySpan<byte> issuerPrivateKey)
+    {
+        var payload = BuildSigningPayload(certificate);
+        using var key = Key.Import(Algorithm, issuerPrivateKey, KeyBlobFormat.RawPrivateKey);
+        var signature = Algorithm.Sign(key, payload);
+        return Convert.ToBase64String(signature);
+    }
+
+    public static bool VerifySignature(PhysicalAtomCertificate certificate, ReadOnlySpan<byte> issuerPublicKey)
+    {
+        if (string.IsNullOrWhiteSpace(certificate.IssuerSignature))
+            return false;
+
+        byte[] signatureBytes;
+        try
+        {
+            signatureBytes = Convert.FromBase64String(certificate.IssuerSignature);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        var payload = BuildSigningPayload(certificate);
+        var publicKey = PublicKey.Import(Algorithm, issuerPublicKey, KeyBlobFormat.RawPublicKey);
+        return Algorithm.Verify(publicKey, payload, signatureBytes);
+    }
+
+    public static byte[] BuildSigningPayload(PhysicalAtomCertificate certificate) =>
+        EncodingCompat.Utf8.GetBytes(BuildSigningPayloadJson(certificate));
+
+    internal static string BuildSigningPayloadJson(PhysicalAtomCertificate certificate)
+    {
+        var extensions = certificate.Extensions
+            .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+            .ToDictionary(
+                entry => entry.Key,
+                entry => Convert.ToBase64String(entry.Value),
+                StringComparer.Ordinal);
+
+        var payload = new SigningPayload(
+            certificate.SchemaVersion,
+            certificate.Maturity.ToString(),
+            certificate.AtomId,
+            certificate.BindingScope.ToString(),
+            certificate.AssetHash,
+            certificate.AssetVersion,
+            certificate.GeoAnchor,
+            certificate.ManufactureMeta,
+            extensions);
+
+        return JsonSerializer.Serialize(payload, SerializerOptions);
+    }
+
+    private sealed record SigningPayload(
+        int SchemaVersion,
+        string Maturity,
+        Guid AtomId,
+        string BindingScope,
+        string AssetHash,
+        string AssetVersion,
+        GeoAnchor? GeoAnchor,
+        ManufactureMeta? ManufactureMeta,
+        IReadOnlyDictionary<string, string> Extensions);
+}

--- a/src/Nexo.Certification.Physical/PhysicalAtomCertificateValidationPolicy.cs
+++ b/src/Nexo.Certification.Physical/PhysicalAtomCertificateValidationPolicy.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Binding-scope validation policy for physical-atom certificates.
+/// </summary>
+public static class PhysicalAtomCertificateValidationPolicy
+{
+    private static readonly Regex SemVerPattern = new(
+        @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex AssetHashPattern = new(
+        "^[0-9a-f]{64}$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    public static bool ValidateBindingScopeConsistency(
+        PhysicalAtomCertificate certificate,
+        out string? failureCode,
+        out string? reason)
+    {
+        if (certificate.AtomId == Guid.Empty)
+        {
+            failureCode = "atom-id-invalid";
+            reason = "atom_id must be a non-empty UUID.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(certificate.AssetHash) || !AssetHashPattern.IsMatch(certificate.AssetHash))
+        {
+            failureCode = "asset-hash-invalid";
+            reason = "asset_hash must be a 64-character lowercase SHA-256 hex digest.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(certificate.AssetVersion) || !SemVerPattern.IsMatch(certificate.AssetVersion))
+        {
+            failureCode = "asset-version-invalid";
+            reason = "asset_version must be a valid SemVer string.";
+            return false;
+        }
+
+        if (certificate.SchemaVersion != PhysicalAtomCertificate.CurrentSchemaVersion)
+        {
+            failureCode = "schema-version-unsupported";
+            reason = $"schema_version {certificate.SchemaVersion} is not supported (expected {PhysicalAtomCertificate.CurrentSchemaVersion}).";
+            return false;
+        }
+
+        switch (certificate.BindingScope)
+        {
+            case BindingScope.Design:
+                if (certificate.ManufactureMeta is not null)
+                {
+                    failureCode = "binding-scope-manufacture-meta-forbidden";
+                    reason = "Design binding_scope forbids manufacture_meta; populated manufacture_meta must be rejected.";
+                    return false;
+                }
+
+                break;
+
+            case BindingScope.Instance:
+                if (certificate.ManufactureMeta is null)
+                {
+                    failureCode = "binding-scope-manufacture-meta-required";
+                    reason = "Instance binding_scope requires non-null manufacture_meta.";
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(certificate.ManufactureMeta.SerialNumber))
+                {
+                    failureCode = "binding-scope-serial-required";
+                    reason = "Instance binding_scope requires manufacture_meta.serial_number.";
+                    return false;
+                }
+
+                break;
+
+            case BindingScope.Batch:
+                if (certificate.ManufactureMeta is null)
+                {
+                    failureCode = "binding-scope-manufacture-meta-required";
+                    reason = "Batch binding_scope requires non-null manufacture_meta.";
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(certificate.ManufactureMeta.BatchId))
+                {
+                    failureCode = "binding-scope-batch-required";
+                    reason = "Batch binding_scope requires manufacture_meta.batch_id.";
+                    return false;
+                }
+
+                break;
+
+            default:
+                failureCode = "binding-scope-unknown";
+                reason = $"Unknown binding_scope '{certificate.BindingScope}'.";
+                return false;
+        }
+
+        if (certificate.GeoAnchor is not null && !GeoAnchorValidator.IsConsistent(certificate.GeoAnchor, out var geoReason))
+        {
+            failureCode = "geo-anchor-inconsistent";
+            reason = geoReason;
+            return false;
+        }
+
+        failureCode = null;
+        reason = null;
+        return true;
+    }
+}

--- a/src/Nexo.Certification.Physical/PhysicalAtomCertificateVerifier.cs
+++ b/src/Nexo.Certification.Physical/PhysicalAtomCertificateVerifier.cs
@@ -1,0 +1,51 @@
+namespace Nexo.Certification.Physical;
+
+/// <summary>
+/// Standalone physical-atom certificate verifier (StateLogVerifier lineage: structural trust checks).
+/// </summary>
+public static class PhysicalAtomCertificateVerifier
+{
+    public static PhysicalAtomTrustResult Verify(
+        PhysicalAtomCertificate certificate,
+        ReadOnlySpan<byte> assetBytes,
+        ReadOnlySpan<byte> issuerPublicKey)
+    {
+        if (certificate is null)
+            return Refused("certificate-missing", "Physical atom certificate is required.");
+
+        if (assetBytes.IsEmpty)
+            return Refused("asset-bytes-missing", "Asset bytes are required for hash consistency verification.");
+
+        if (issuerPublicKey.IsEmpty)
+            return Refused("issuer-public-key-missing", "Issuer public key is required.");
+
+        if (string.IsNullOrWhiteSpace(certificate.IssuerSignature))
+            return Refused("signature-missing", "issuer_signature is required.");
+
+        if (!PhysicalAtomCertificateValidationPolicy.ValidateBindingScopeConsistency(
+                certificate,
+                out var policyCode,
+                out var policyReason))
+        {
+            return Refused(policyCode!, policyReason!);
+        }
+
+        if (!PhysicalAtomCertificateSigning.VerifySignature(certificate, issuerPublicKey))
+            return Refused("signature-invalid", "issuer_signature is invalid or forged.");
+
+        var actualHash = AssetContentHasher.ComputeSha256Hex(assetBytes);
+        if (!string.Equals(actualHash, certificate.AssetHash, StringComparison.Ordinal))
+        {
+            return Refused(
+                "asset-hash-mismatch",
+                $"Provided asset hash does not match certificate asset_hash (expected {certificate.AssetHash}, got {actualHash}).");
+        }
+
+        return new PhysicalAtomTrustResult(true, null, null);
+    }
+
+    private static PhysicalAtomTrustResult Refused(string code, string reason) =>
+        new(false, code, reason);
+}
+
+public sealed record PhysicalAtomTrustResult(bool Trusted, string? FailureCode, string? Reason);

--- a/src/Nexo.Certification.Physical/Resolution/DigitalTwinAssetRecord.cs
+++ b/src/Nexo.Certification.Physical/Resolution/DigitalTwinAssetRecord.cs
@@ -1,0 +1,10 @@
+namespace Nexo.Certification.Physical.Resolution;
+
+/// <summary>
+/// Hosted digital-twin asset bytes keyed by content hash and semver version.
+/// </summary>
+public sealed record DigitalTwinAssetRecord(
+    string AssetHash,
+    string AssetVersion,
+    string ContentType,
+    byte[] AssetBytes);

--- a/src/Nexo.Certification.Physical/Resolution/IAssetResolutionStore.cs
+++ b/src/Nexo.Certification.Physical/Resolution/IAssetResolutionStore.cs
@@ -1,0 +1,11 @@
+namespace Nexo.Certification.Physical.Resolution;
+
+/// <summary>
+/// Resolves hosted digital-twin assets and registered certificates for physical atoms.
+/// </summary>
+public interface IAssetResolutionStore
+{
+    bool TryResolveAsset(string assetHash, string assetVersion, out DigitalTwinAssetRecord? asset);
+
+    bool TryResolveCert(Guid atomId, out PhysicalAtomCertificate? certificate);
+}

--- a/src/Nexo.Certification.Physical/Resolution/InMemoryAssetResolutionStore.cs
+++ b/src/Nexo.Certification.Physical/Resolution/InMemoryAssetResolutionStore.cs
@@ -1,0 +1,46 @@
+namespace Nexo.Certification.Physical.Resolution;
+
+/// <summary>
+/// In-memory resolution store for headless tests and local prototypes.
+/// </summary>
+public sealed class InMemoryAssetResolutionStore : IAssetResolutionStore
+{
+    private readonly Dictionary<(string Hash, string Version), DigitalTwinAssetRecord> _assets = new();
+    private readonly Dictionary<Guid, PhysicalAtomCertificate> _certs = new();
+
+    public void RegisterAsset(DigitalTwinAssetRecord asset)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+        _assets[(asset.AssetHash, asset.AssetVersion)] = asset;
+    }
+
+    public void RegisterCert(PhysicalAtomCertificate certificate)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+        _certs[certificate.AtomId] = certificate;
+    }
+
+    public bool TryResolveAsset(string assetHash, string assetVersion, out DigitalTwinAssetRecord? asset)
+    {
+        if (_assets.TryGetValue((assetHash, assetVersion), out var record))
+        {
+            asset = record;
+            return true;
+        }
+
+        asset = null;
+        return false;
+    }
+
+    public bool TryResolveCert(Guid atomId, out PhysicalAtomCertificate? certificate)
+    {
+        if (_certs.TryGetValue(atomId, out var cert))
+        {
+            certificate = cert;
+            return true;
+        }
+
+        certificate = null;
+        return false;
+    }
+}

--- a/src/Nexo.Certification.Physical/Resolution/PhysicalAtomCertBundle.cs
+++ b/src/Nexo.Certification.Physical/Resolution/PhysicalAtomCertBundle.cs
@@ -1,0 +1,10 @@
+namespace Nexo.Certification.Physical.Resolution;
+
+/// <summary>
+/// Self-contained certified bundle: certificate, asset bytes, and issuer public key for offline verification.
+/// </summary>
+public sealed record PhysicalAtomCertBundle(
+    PhysicalAtomCertificate Certificate,
+    byte[] AssetBytes,
+    string ContentType,
+    byte[] IssuerPublicKey);

--- a/src/Nexo.Certification.Physical/Resolution/PhysicalAtomCertBundleManifest.cs
+++ b/src/Nexo.Certification.Physical/Resolution/PhysicalAtomCertBundleManifest.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nexo.Certification.Physical.Resolution;
+
+/// <summary>
+/// JSON manifest serialization for portable certified bundles (Phase 1, Prototype maturity).
+/// </summary>
+public static class PhysicalAtomCertBundleManifest
+{
+    private static readonly JsonSerializerOptions SerializerOptions = CreateOptions();
+
+    public static string Serialize(PhysicalAtomCertBundle bundle)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+
+        var manifest = new ManifestDto(
+            PhysicalAtomCertificate.CurrentSchemaVersion,
+            MaturityLevel.Prototype.ToString(),
+            bundle.Certificate,
+            bundle.ContentType,
+            Convert.ToBase64String(bundle.AssetBytes),
+            Convert.ToBase64String(bundle.IssuerPublicKey));
+
+        return JsonSerializer.Serialize(manifest, SerializerOptions);
+    }
+
+    public static PhysicalAtomCertBundle Deserialize(string manifestJson)
+    {
+        if (string.IsNullOrWhiteSpace(manifestJson))
+            throw new ArgumentException("Manifest JSON is required.", nameof(manifestJson));
+
+        var dto = JsonSerializer.Deserialize<ManifestDto>(manifestJson, SerializerOptions)
+            ?? throw new InvalidOperationException("Manifest JSON could not be parsed.");
+
+        if (dto.SchemaVersion != PhysicalAtomCertificate.CurrentSchemaVersion)
+            throw new InvalidOperationException($"Unsupported manifest schema version {dto.SchemaVersion}.");
+
+        return new PhysicalAtomCertBundle(
+            dto.Certificate ?? throw new InvalidOperationException("Manifest certificate is required."),
+            Convert.FromBase64String(dto.AssetBytesBase64 ?? throw new InvalidOperationException("Manifest assetBytesBase64 is required.")),
+            dto.ContentType ?? "application/octet-stream",
+            Convert.FromBase64String(dto.IssuerPublicKeyBase64 ?? throw new InvalidOperationException("Manifest issuerPublicKeyBase64 is required.")));
+    }
+
+    private sealed record ManifestDto(
+        int SchemaVersion,
+        string Maturity,
+        PhysicalAtomCertificate? Certificate,
+        string? ContentType,
+        string? AssetBytesBase64,
+        string? IssuerPublicKeyBase64);
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = true
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
+    }
+}

--- a/src/Nexo.Certification.Physical/Resolution/PhysicalAtomCertBundleVerifier.cs
+++ b/src/Nexo.Certification.Physical/Resolution/PhysicalAtomCertBundleVerifier.cs
@@ -1,0 +1,46 @@
+namespace Nexo.Certification.Physical.Resolution;
+
+/// <summary>
+/// Verifies a self-contained certified bundle (certificate + asset bytes + issuer public key).
+/// </summary>
+public static class PhysicalAtomCertBundleVerifier
+{
+    public static PhysicalAtomTrustResult Verify(
+        PhysicalAtomCertBundle bundle,
+        ReadOnlySpan<byte> issuerPublicKey)
+    {
+        if (bundle is null)
+            return Refused("bundle-missing", "Physical atom cert bundle is required.");
+
+        if (bundle.AssetBytes is null || bundle.AssetBytes.Length == 0)
+            return Refused("bundle-asset-missing", "Bundle asset bytes are required.");
+
+        if (issuerPublicKey.IsEmpty)
+            return Refused("issuer-public-key-missing", "Issuer public key is required.");
+
+        if (!string.Equals(
+                AssetContentHasher.ComputeSha256Hex(bundle.AssetBytes),
+                bundle.Certificate.AssetHash,
+                StringComparison.Ordinal))
+        {
+            return Refused(
+                "bundle-asset-hash-mismatch",
+                "Bundle asset bytes do not match certificate asset_hash.");
+        }
+
+        if (!bundle.IssuerPublicKey.AsSpan().SequenceEqual(issuerPublicKey))
+        {
+            return Refused(
+                "bundle-issuer-key-mismatch",
+                "Bundle issuer public key does not match the expected issuer key.");
+        }
+
+        return PhysicalAtomCertificateVerifier.Verify(
+            bundle.Certificate,
+            bundle.AssetBytes,
+            issuerPublicKey);
+    }
+
+    private static PhysicalAtomTrustResult Refused(string code, string reason) =>
+        new(false, code, reason);
+}

--- a/src/Nexo.Certification.Physical/Resolution/PhysicalAtomResolutionVerifier.cs
+++ b/src/Nexo.Certification.Physical/Resolution/PhysicalAtomResolutionVerifier.cs
@@ -1,0 +1,58 @@
+namespace Nexo.Certification.Physical.Resolution;
+
+/// <summary>
+/// Verifies a certificate by resolving hosted asset bytes from a store, then delegating to the Phase 0 verifier.
+/// </summary>
+public static class PhysicalAtomResolutionVerifier
+{
+    public static PhysicalAtomTrustResult Verify(
+        PhysicalAtomCertificate certificate,
+        IAssetResolutionStore store,
+        ReadOnlySpan<byte> issuerPublicKey)
+    {
+        if (certificate is null)
+            return Refused("certificate-missing", "Physical atom certificate is required.");
+
+        if (store is null)
+            return Refused("store-missing", "Asset resolution store is required.");
+
+        if (issuerPublicKey.IsEmpty)
+            return Refused("issuer-public-key-missing", "Issuer public key is required.");
+
+        if (!store.TryResolveCert(certificate.AtomId, out var registered) || registered is null)
+            return Refused("atom-unresolved", $"No registered certificate for atom_id '{certificate.AtomId}'.");
+
+        if (!ReferenceEquals(registered, certificate)
+            && !CertificatesEquivalent(registered, certificate))
+        {
+            return Refused(
+                "atom-cert-mismatch",
+                "Provided certificate does not match the registered certificate for this atom_id.");
+        }
+
+        if (!store.TryResolveAsset(certificate.AssetHash, certificate.AssetVersion, out var asset)
+            || asset is null)
+        {
+            return Refused(
+                "asset-unresolved",
+                $"No hosted asset for hash '{certificate.AssetHash}' version '{certificate.AssetVersion}'.");
+        }
+
+        return PhysicalAtomCertificateVerifier.Verify(
+            certificate,
+            asset.AssetBytes,
+            issuerPublicKey);
+    }
+
+    private static bool CertificatesEquivalent(PhysicalAtomCertificate left, PhysicalAtomCertificate right) =>
+        left.SchemaVersion == right.SchemaVersion
+        && left.Maturity == right.Maturity
+        && left.AtomId == right.AtomId
+        && left.BindingScope == right.BindingScope
+        && string.Equals(left.AssetHash, right.AssetHash, StringComparison.Ordinal)
+        && string.Equals(left.AssetVersion, right.AssetVersion, StringComparison.Ordinal)
+        && string.Equals(left.IssuerSignature, right.IssuerSignature, StringComparison.Ordinal);
+
+    private static PhysicalAtomTrustResult Refused(string code, string reason) =>
+        new(false, code, reason);
+}

--- a/src/Nexo.Infrastructure/Certification/Physical/AssetBundleCertificationPipeline.cs
+++ b/src/Nexo.Infrastructure/Certification/Physical/AssetBundleCertificationPipeline.cs
@@ -1,0 +1,96 @@
+using Nexo.Certification.Physical;
+using Nexo.Certification.Physical.Resolution;
+
+namespace Nexo.Infrastructure.Certification.Physical;
+
+/// <summary>
+/// Input to deterministic asset bundle certification and registration.
+/// </summary>
+public sealed class AssetBundleCertificationRequest
+{
+    public Guid AtomId { get; init; }
+
+    public BindingScope BindingScope { get; init; }
+
+    public required byte[] AssetBytes { get; init; }
+
+    public required string AssetVersion { get; init; }
+
+    public string ContentType { get; init; } = "application/octet-stream";
+
+    public GeoAnchor? GeoAnchor { get; init; }
+
+    public ManufactureMeta? ManufactureMeta { get; init; }
+
+    public IReadOnlyDictionary<string, byte[]> Extensions { get; init; } =
+        new Dictionary<string, byte[]>(StringComparer.Ordinal);
+}
+
+public sealed record AssetBundleCertificationResult(
+    bool Succeeded,
+    PhysicalAtomCertBundle? Bundle,
+    string? FailureCode,
+    string? Reason)
+{
+    public static AssetBundleCertificationResult Ok(PhysicalAtomCertBundle bundle) =>
+        new(true, bundle, null, null);
+
+    public static AssetBundleCertificationResult Refused(string code, string reason) =>
+        new(false, null, code, reason);
+}
+
+/// <summary>
+/// Phase 1 pipeline: issue certificate, register asset + cert in resolution store, emit portable bundle.
+/// </summary>
+public sealed class AssetBundleCertificationPipeline
+{
+    private readonly BundleCertificationBrick _issuer;
+
+    public AssetBundleCertificationPipeline(BundleCertificationBrick issuer)
+    {
+        _issuer = issuer ?? throw new ArgumentNullException(nameof(issuer));
+    }
+
+    public AssetBundleCertificationResult CertifyAndRegister(
+        InMemoryAssetResolutionStore store,
+        AssetBundleCertificationRequest request,
+        ReadOnlySpan<byte> issuerPublicKey)
+    {
+        if (store is null)
+            return AssetBundleCertificationResult.Refused("store-missing", "Asset resolution store is required.");
+
+        if (issuerPublicKey.IsEmpty)
+            return AssetBundleCertificationResult.Refused("issuer-public-key-missing", "Issuer public key is required.");
+
+        var issue = _issuer.Issue(new BundleCertificationRequest
+        {
+            AtomId = request.AtomId,
+            BindingScope = request.BindingScope,
+            AssetBytes = request.AssetBytes,
+            AssetVersion = request.AssetVersion,
+            GeoAnchor = request.GeoAnchor,
+            ManufactureMeta = request.ManufactureMeta,
+            Extensions = request.Extensions
+        });
+
+        if (!issue.Succeeded || issue.Certificate is null)
+            return AssetBundleCertificationResult.Refused(issue.FailureCode!, issue.Reason!);
+
+        var assetHash = AssetContentHasher.ComputeSha256Hex(request.AssetBytes);
+        store.RegisterAsset(new DigitalTwinAssetRecord(
+            assetHash,
+            request.AssetVersion,
+            request.ContentType,
+            request.AssetBytes.ToArray()));
+
+        store.RegisterCert(issue.Certificate);
+
+        var bundle = new PhysicalAtomCertBundle(
+            issue.Certificate,
+            request.AssetBytes.ToArray(),
+            request.ContentType,
+            issuerPublicKey.ToArray());
+
+        return AssetBundleCertificationResult.Ok(bundle);
+    }
+}

--- a/src/Nexo.Infrastructure/Certification/Physical/BundleCertificationBrick.cs
+++ b/src/Nexo.Infrastructure/Certification/Physical/BundleCertificationBrick.cs
@@ -1,0 +1,90 @@
+using Nexo.Certification.Physical;
+
+namespace Nexo.Infrastructure.Certification.Physical;
+
+/// <summary>
+/// Input to deterministic physical-atom certificate issuance.
+/// </summary>
+public sealed class BundleCertificationRequest
+{
+    public Guid AtomId { get; init; }
+
+    public BindingScope BindingScope { get; init; }
+
+    public required byte[] AssetBytes { get; init; }
+
+    public required string AssetVersion { get; init; }
+
+    public GeoAnchor? GeoAnchor { get; init; }
+
+    public ManufactureMeta? ManufactureMeta { get; init; }
+
+    public IReadOnlyDictionary<string, byte[]> Extensions { get; init; } =
+        new Dictionary<string, byte[]>(StringComparer.Ordinal);
+}
+
+public sealed record BundleCertificationResult(
+    bool Succeeded,
+    PhysicalAtomCertificate? Certificate,
+    string? FailureCode,
+    string? Reason)
+{
+    public static BundleCertificationResult Ok(PhysicalAtomCertificate certificate) =>
+        new(true, certificate, null, null);
+
+    public static BundleCertificationResult Refused(string code, string reason) =>
+        new(false, null, code, reason);
+}
+
+/// <summary>
+/// Deterministic certification brick: issues signed <see cref="PhysicalAtomCertificate"/> values
+/// using the cert-gate Ed25519 signing pattern. Refuses inconsistent binding_scope inputs.
+/// </summary>
+public sealed class BundleCertificationBrick
+{
+    private readonly byte[] _issuerPrivateKey;
+
+    public BundleCertificationBrick(ReadOnlySpan<byte> issuerPrivateKey)
+    {
+        if (issuerPrivateKey.IsEmpty)
+            throw new ArgumentException("Issuer private key is required.", nameof(issuerPrivateKey));
+
+        _issuerPrivateKey = issuerPrivateKey.ToArray();
+    }
+
+    public BundleCertificationResult Issue(BundleCertificationRequest request)
+    {
+        if (request is null)
+            return BundleCertificationResult.Refused("request-missing", "Certification request is required.");
+
+        if (request.AssetBytes is null || request.AssetBytes.Length == 0)
+            return BundleCertificationResult.Refused("asset-bytes-missing", "Asset bytes are required.");
+
+        var assetHash = AssetContentHasher.ComputeSha256Hex(request.AssetBytes);
+        var unsigned = new PhysicalAtomCertificate
+        {
+            AtomId = request.AtomId,
+            BindingScope = request.BindingScope,
+            AssetHash = assetHash,
+            AssetVersion = request.AssetVersion,
+            GeoAnchor = request.GeoAnchor,
+            ManufactureMeta = request.ManufactureMeta,
+            Extensions = request.Extensions
+        };
+
+        if (!PhysicalAtomCertificateValidationPolicy.ValidateBindingScopeConsistency(
+                unsigned,
+                out var failureCode,
+                out var reason))
+        {
+            return BundleCertificationResult.Refused(failureCode!, reason!);
+        }
+
+        var signed = unsigned with
+        {
+            IssuerSignature = PhysicalAtomCertificateSigning.Sign(unsigned, _issuerPrivateKey)
+        };
+
+        return BundleCertificationResult.Ok(signed);
+    }
+}

--- a/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
+++ b/src/Nexo.Infrastructure/Nexo.Infrastructure.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj" />
+    <ProjectReference Include="..\Nexo.Certification.Physical\Nexo.Certification.Physical.csproj" />
     <ProjectReference Include="..\Nexo.Brick.Contracts\Nexo.Brick.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.Core.Domain\Nexo.Core.Domain.csproj" />

--- a/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
+++ b/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Nexo.Certification.Physical\Nexo.Certification.Physical.csproj" />
     <ProjectReference Include="..\Nexo.Certification.Contracts\Nexo.Certification.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Certification.State\Nexo.Certification.State.csproj" />
     <ProjectReference Include="..\Nexo.Abstractions\Nexo.Abstractions.csproj" />

--- a/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
+++ b/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
@@ -13,6 +13,7 @@
   <!-- xUnit: limit parallelism to reduce memory usage (Cursor, CI) -->
   <ItemGroup>
     <Content Include="Certification/Dogfood/RecordedCompositionProposals/**/*.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="../../samples/physical-atom-cert/**/*" CopyToOutputDirectory="PreserveNewest" Link="physical-atom-cert/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <!-- Workaround for Castle.Core net6.0 assembly loading issue on .NET 8.0 -->
   <ItemGroup>

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/AssetBundleCertificationPipelineTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/AssetBundleCertificationPipelineTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Nexo.Certification.Physical;
+using Nexo.Certification.Physical.Resolution;
+using Nexo.Infrastructure.Certification.Physical;
+using NSec.Cryptography;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+/// <summary>
+/// Phase 1 asset bundle certification pipeline tests (separate witness keys from resolution tests).
+/// </summary>
+[Trait("Category", "Certification")]
+public sealed class AssetBundleCertificationPipelineTests
+{
+    private static readonly (byte[] PrivateKey, byte[] PublicKey) PipelineKeys = CreatePipelineKeyPair();
+
+    private readonly AssetBundleCertificationPipeline _pipeline =
+        new(new BundleCertificationBrick(PipelineKeys.PrivateKey));
+
+    [Fact]
+    public void CertifyAndRegister_ProducesResolvableBundle()
+    {
+        var assetBytes = "pipeline-twin-asset-v1"u8.ToArray();
+        var store = new InMemoryAssetResolutionStore();
+
+        var result = _pipeline.CertifyAndRegister(
+            store,
+            new AssetBundleCertificationRequest
+            {
+                AtomId = Guid.NewGuid(),
+                BindingScope = BindingScope.Design,
+                AssetBytes = assetBytes,
+                AssetVersion = "3.0.0",
+                ContentType = "model/gltf-binary"
+            },
+            PipelineKeys.PublicKey);
+
+        result.Succeeded.Should().BeTrue();
+        result.Bundle.Should().NotBeNull();
+
+        var resolved = PhysicalAtomResolutionVerifier.Verify(
+            result.Bundle!.Certificate,
+            store,
+            PipelineKeys.PublicKey);
+
+        resolved.Trusted.Should().BeTrue();
+
+        var bundleCheck = PhysicalAtomCertBundleVerifier.Verify(result.Bundle, PipelineKeys.PublicKey);
+        bundleCheck.Trusted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CertifyAndRegister_RefusesInvalidBindingScope()
+    {
+        var store = new InMemoryAssetResolutionStore();
+
+        var result = _pipeline.CertifyAndRegister(
+            store,
+            new AssetBundleCertificationRequest
+            {
+                AtomId = Guid.NewGuid(),
+                BindingScope = BindingScope.Instance,
+                AssetBytes = "x"u8.ToArray(),
+                AssetVersion = "1.0.0",
+                ManufactureMeta = null
+            },
+            PipelineKeys.PublicKey);
+
+        result.Succeeded.Should().BeFalse();
+        result.FailureCode.Should().Be("binding-scope-manufacture-meta-required");
+    }
+
+    private static (byte[] PrivateKey, byte[] PublicKey) CreatePipelineKeyPair()
+    {
+        using var key = Key.Create(
+            SignatureAlgorithm.Ed25519,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+
+        return (
+            key.Export(KeyBlobFormat.RawPrivateKey),
+            key.PublicKey.Export(KeyBlobFormat.RawPublicKey));
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/BundleCertificationBrickTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/BundleCertificationBrickTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Nexo.Certification.Physical;
+using Nexo.Infrastructure.Certification.Physical;
+using NSec.Cryptography;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+/// <summary>
+/// BundleCertificationBrick issuance tests (separate from verifier witness fixtures).
+/// </summary>
+[Trait("Category", "Certification")]
+public sealed class BundleCertificationBrickTests
+{
+    private static readonly byte[] IssuerAssetBytes = "issuer-twin-asset-v2"u8.ToArray();
+
+    private static readonly (byte[] PrivateKey, byte[] PublicKey) IssuerKeys = CreateIssuerKeyPair();
+
+    private readonly BundleCertificationBrick _brick = new(IssuerKeys.PrivateKey);
+
+    [Fact]
+    public void Issue_DesignScope_ProducesVerifiableCertificate()
+    {
+        var result = _brick.Issue(new BundleCertificationRequest
+        {
+            AtomId = Guid.NewGuid(),
+            BindingScope = BindingScope.Design,
+            AssetBytes = IssuerAssetBytes,
+            AssetVersion = "2.1.0"
+        });
+
+        result.Succeeded.Should().BeTrue();
+        result.Certificate.Should().NotBeNull();
+
+        var verify = PhysicalAtomCertificateVerifier.Verify(
+            result.Certificate!,
+            IssuerAssetBytes,
+            IssuerKeys.PublicKey);
+
+        verify.Trusted.Should().BeTrue();
+        result.Certificate!.BindingScope.Should().Be(BindingScope.Design);
+        result.Certificate.ManufactureMeta.Should().BeNull();
+    }
+
+    [Fact]
+    public void Issue_InstanceScope_ProducesVerifiableCertificate()
+    {
+        var result = _brick.Issue(new BundleCertificationRequest
+        {
+            AtomId = Guid.NewGuid(),
+            BindingScope = BindingScope.Instance,
+            AssetBytes = IssuerAssetBytes,
+            AssetVersion = "2.1.0",
+            ManufactureMeta = new ManufactureMeta(null, "SN-ISSUER-007", DateTimeOffset.UtcNow)
+        });
+
+        result.Succeeded.Should().BeTrue();
+
+        var verify = PhysicalAtomCertificateVerifier.Verify(
+            result.Certificate!,
+            IssuerAssetBytes,
+            IssuerKeys.PublicKey);
+
+        verify.Trusted.Should().BeTrue();
+        result.Certificate!.ManufactureMeta!.SerialNumber.Should().Be("SN-ISSUER-007");
+    }
+
+    [Fact]
+    public void Issue_BatchScope_ProducesVerifiableCertificate()
+    {
+        var result = _brick.Issue(new BundleCertificationRequest
+        {
+            AtomId = Guid.NewGuid(),
+            BindingScope = BindingScope.Batch,
+            AssetBytes = IssuerAssetBytes,
+            AssetVersion = "2.1.0",
+            ManufactureMeta = new ManufactureMeta("BATCH-ISSUER-99", null, DateTimeOffset.UtcNow)
+        });
+
+        result.Succeeded.Should().BeTrue();
+
+        var verify = PhysicalAtomCertificateVerifier.Verify(
+            result.Certificate!,
+            IssuerAssetBytes,
+            IssuerKeys.PublicKey);
+
+        verify.Trusted.Should().BeTrue();
+        result.Certificate!.ManufactureMeta!.BatchId.Should().Be("BATCH-ISSUER-99");
+    }
+
+    [Fact]
+    public void Issue_InstanceWithoutManufactureMeta_Refuses()
+    {
+        var result = _brick.Issue(new BundleCertificationRequest
+        {
+            AtomId = Guid.NewGuid(),
+            BindingScope = BindingScope.Instance,
+            AssetBytes = IssuerAssetBytes,
+            AssetVersion = "1.0.0",
+            ManufactureMeta = null
+        });
+
+        result.Succeeded.Should().BeFalse();
+        result.FailureCode.Should().Be("binding-scope-manufacture-meta-required");
+    }
+
+    [Fact]
+    public void Issue_DesignWithManufactureMeta_Refuses()
+    {
+        var result = _brick.Issue(new BundleCertificationRequest
+        {
+            AtomId = Guid.NewGuid(),
+            BindingScope = BindingScope.Design,
+            AssetBytes = IssuerAssetBytes,
+            AssetVersion = "1.0.0",
+            ManufactureMeta = new ManufactureMeta("BATCH-X", "SN-X", DateTimeOffset.UtcNow)
+        });
+
+        result.Succeeded.Should().BeFalse();
+        result.FailureCode.Should().Be("binding-scope-manufacture-meta-forbidden");
+    }
+
+    [Fact]
+    public void Issue_InconsistentGeoAnchor_Refuses()
+    {
+        var result = _brick.Issue(new BundleCertificationRequest
+        {
+            AtomId = Guid.NewGuid(),
+            BindingScope = BindingScope.Design,
+            AssetBytes = IssuerAssetBytes,
+            AssetVersion = "1.0.0",
+            GeoAnchor = new GeoAnchor(37.7749, -122.4194, 9, "000000000000000")
+        });
+
+        result.Succeeded.Should().BeFalse();
+        result.FailureCode.Should().Be("geo-anchor-inconsistent");
+    }
+
+    private static (byte[] PrivateKey, byte[] PublicKey) CreateIssuerKeyPair()
+    {
+        using var key = Key.Create(
+            SignatureAlgorithm.Ed25519,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+
+        return (
+            key.Export(KeyBlobFormat.RawPrivateKey),
+            key.PublicKey.Export(KeyBlobFormat.RawPublicKey));
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomCertBundleManifestTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomCertBundleManifestTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using Nexo.Certification.Physical.Resolution;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+[Trait("Category", "Certification")]
+public sealed class PhysicalAtomCertBundleManifestTests
+{
+    private static readonly string SampleManifestPath =
+        Path.Combine(AppContext.BaseDirectory, "physical-atom-cert", "design-scope.bundle.json");
+
+    [Fact]
+    public void SampleBundleManifest_RoundTripsAndVerifies()
+    {
+        var json = File.ReadAllText(SampleManifestPath);
+        var bundle = PhysicalAtomCertBundleManifest.Deserialize(json);
+
+        var reserialized = PhysicalAtomCertBundleManifest.Serialize(bundle);
+        var roundTrip = PhysicalAtomCertBundleManifest.Deserialize(reserialized);
+
+        var result = PhysicalAtomCertBundleVerifier.Verify(roundTrip, bundle.IssuerPublicKey);
+
+        result.Trusted.Should().BeTrue();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomCertificateVerifierTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomCertificateVerifierTests.cs
@@ -1,0 +1,284 @@
+using FluentAssertions;
+using Nexo.Certification.Physical;
+using NSec.Cryptography;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+/// <summary>
+/// Physical-atom certificate verifier refusal/admission tests.
+/// Witness fixtures are hand-authored independently of the issuance code path.
+/// </summary>
+[Trait("Category", "Certification")]
+public sealed class PhysicalAtomCertificateVerifierTests
+{
+    private static readonly SignatureAlgorithm Algorithm = SignatureAlgorithm.Ed25519;
+
+    private static readonly byte[] WitnessAssetBytes =
+        "witness-digital-twin-asset-v1"u8.ToArray();
+
+    private static readonly string WitnessAssetHash =
+        AssetContentHasher.ComputeSha256Hex(WitnessAssetBytes);
+
+    private static readonly (byte[] PrivateKey, byte[] PublicKey) WitnessIssuerKeys = CreateWitnessKeyPair();
+
+    private static readonly (byte[] PrivateKey, byte[] PublicKey) ForgedIssuerKeys = CreateWitnessKeyPair();
+
+    [Fact]
+    public void R1_ForgedSignature_Refuses()
+    {
+        var cert = WitnessBuilder.CreateSigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            WitnessIssuerKeys.PrivateKey);
+
+        var forged = cert with { IssuerSignature = Convert.ToBase64String(new byte[64]) };
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            forged,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("signature-invalid");
+    }
+
+    [Fact]
+    public void R2_AssetHashMismatch_Refuses()
+    {
+        var cert = WitnessBuilder.CreateSigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            "different-asset-bytes"u8.ToArray(),
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("asset-hash-mismatch");
+    }
+
+    [Fact]
+    public void R3_InstanceScopeMissingManufactureMeta_Refuses()
+    {
+        var unsigned = WitnessBuilder.CreateUnsigned(
+            BindingScope.Instance,
+            WitnessAssetHash,
+            manufactureMeta: null);
+
+        var cert = WitnessBuilder.Sign(unsigned, WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("binding-scope-manufacture-meta-required");
+    }
+
+    [Fact]
+    public void R4_DesignScopeWithManufactureMeta_Refuses()
+    {
+        var unsigned = WitnessBuilder.CreateUnsigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            manufactureMeta: new ManufactureMeta("BATCH-001", "SN-001", DateTimeOffset.Parse("2026-01-01T00:00:00Z")));
+
+        var cert = WitnessBuilder.Sign(unsigned, WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("binding-scope-manufacture-meta-forbidden");
+    }
+
+    [Fact]
+    public void R5_GeoAnchorH3IndexInconsistent_Refuses()
+    {
+        var geo = new GeoAnchor(37.7749, -122.4194, 9, "000000000000000");
+        var unsigned = WitnessBuilder.CreateUnsigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            geoAnchor: geo);
+
+        var cert = WitnessBuilder.Sign(unsigned, WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("geo-anchor-inconsistent");
+    }
+
+    [Fact]
+    public void R6_TamperedExtensions_Refuses()
+    {
+        var extensions = new Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            ["vendor.note"] = "original"u8.ToArray()
+        };
+
+        var unsigned = WitnessBuilder.CreateUnsigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            extensions: extensions);
+
+        var cert = WitnessBuilder.Sign(unsigned, WitnessIssuerKeys.PrivateKey);
+        var tamperedExtensions = new Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            ["vendor.note"] = "tampered"u8.ToArray()
+        };
+        var tampered = cert with { Extensions = tamperedExtensions };
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            tampered,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("signature-invalid");
+    }
+
+    [Fact]
+    public void R7_WrongIssuerPublicKey_Refuses()
+    {
+        var cert = WitnessBuilder.CreateSigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            ForgedIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("signature-invalid");
+    }
+
+    [Fact]
+    public void A1_DesignScopeWellFormed_Accepts()
+    {
+        var cert = WitnessBuilder.CreateSigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeTrue();
+        result.FailureCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void A2_InstanceScopeWellFormed_Accepts()
+    {
+        var unsigned = WitnessBuilder.CreateUnsigned(
+            BindingScope.Instance,
+            WitnessAssetHash,
+            manufactureMeta: new ManufactureMeta(null, "SN-WITNESS-001", DateTimeOffset.Parse("2026-03-15T12:00:00Z")));
+
+        var cert = WitnessBuilder.Sign(unsigned, WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A3_BatchScopeWellFormed_Accepts()
+    {
+        var unsigned = WitnessBuilder.CreateUnsigned(
+            BindingScope.Batch,
+            WitnessAssetHash,
+            manufactureMeta: new ManufactureMeta("BATCH-WITNESS-42", null, DateTimeOffset.Parse("2026-02-01T08:30:00Z")));
+
+        var cert = WitnessBuilder.Sign(unsigned, WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A4_DesignScopeWithConsistentGeoAnchor_Accepts()
+    {
+        var geo = new GeoAnchor(37.7749, -122.4194, 9, "897016d01d3ffff");
+        var unsigned = WitnessBuilder.CreateUnsigned(
+            BindingScope.Design,
+            WitnessAssetHash,
+            geoAnchor: geo);
+
+        var cert = WitnessBuilder.Sign(unsigned, WitnessIssuerKeys.PrivateKey);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(
+            cert,
+            WitnessAssetBytes,
+            WitnessIssuerKeys.PublicKey);
+
+        result.Trusted.Should().BeTrue();
+    }
+
+    private static (byte[] PrivateKey, byte[] PublicKey) CreateWitnessKeyPair()
+    {
+        using var key = Key.Create(
+            Algorithm,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+
+        return (
+            key.Export(KeyBlobFormat.RawPrivateKey),
+            key.PublicKey.Export(KeyBlobFormat.RawPublicKey));
+    }
+
+    /// <summary>
+    /// Independent witness oracle — constructs and signs certs without the issuance brick.
+    /// </summary>
+    private static class WitnessBuilder
+    {
+        public static PhysicalAtomCertificate CreateUnsigned(
+            BindingScope scope,
+            string assetHash,
+            GeoAnchor? geoAnchor = null,
+            ManufactureMeta? manufactureMeta = null,
+            IReadOnlyDictionary<string, byte[]>? extensions = null) =>
+            new()
+            {
+                AtomId = Guid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                BindingScope = scope,
+                AssetHash = assetHash,
+                AssetVersion = "1.0.0",
+                GeoAnchor = geoAnchor,
+                ManufactureMeta = manufactureMeta,
+                Extensions = extensions ?? new Dictionary<string, byte[]>(StringComparer.Ordinal)
+            };
+
+        public static PhysicalAtomCertificate Sign(PhysicalAtomCertificate unsigned, byte[] privateKey) =>
+            unsigned with
+            {
+                IssuerSignature = PhysicalAtomCertificateSigning.Sign(unsigned, privateKey)
+            };
+
+        public static PhysicalAtomCertificate CreateSigned(
+            BindingScope scope,
+            string assetHash,
+            byte[] privateKey) =>
+            Sign(CreateUnsigned(scope, assetHash), privateKey);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomResolutionVerifierTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomResolutionVerifierTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using Nexo.Certification.Physical;
+using Nexo.Certification.Physical.Resolution;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+/// <summary>
+/// Phase 1 resolution verifier refusal/admission tests.
+/// Witness fixtures are independent of the certification pipeline.
+/// </summary>
+[Trait("Category", "Certification")]
+public sealed class PhysicalAtomResolutionVerifierTests
+{
+    private static readonly byte[] WitnessAssetBytes = "resolution-witness-asset-v1"u8.ToArray();
+
+    private static readonly string WitnessAssetHash =
+        AssetContentHasher.ComputeSha256Hex(WitnessAssetBytes);
+
+    private static readonly byte[] WitnessIssuerPublicKey =
+        Convert.FromBase64String("SOAn5IcnCADrZ0YtsWCmD6cZacp/xtKi8/iNwPDvjU0=");
+
+    private static readonly Guid WitnessAtomId =
+        Guid.Parse("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+
+    [Fact]
+    public void R1_UnresolvedAtomId_Refuses()
+    {
+        var store = ResolutionWitness.CreateStore(withAsset: true, withCert: false);
+        var cert = ResolutionWitness.CreateSignedCert(WitnessAtomId, WitnessAssetHash);
+
+        var result = PhysicalAtomResolutionVerifier.Verify(
+            cert,
+            store,
+            WitnessIssuerPublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("atom-unresolved");
+    }
+
+    [Fact]
+    public void R2_StoreAssetBytesMismatch_Refuses()
+    {
+        var store = ResolutionWitness.CreateStore(withAsset: false, withCert: true);
+        store.RegisterAsset(new DigitalTwinAssetRecord(
+            WitnessAssetHash,
+            "1.0.0",
+            "application/octet-stream",
+            "wrong-bytes-for-hash"u8.ToArray()));
+
+        var cert = ResolutionWitness.CreateSignedCert(WitnessAtomId, WitnessAssetHash);
+
+        var result = PhysicalAtomResolutionVerifier.Verify(
+            cert,
+            store,
+            WitnessIssuerPublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("asset-hash-mismatch");
+    }
+
+    [Fact]
+    public void R3_MissingAssetBytes_Refuses()
+    {
+        var store = ResolutionWitness.CreateStore(withAsset: false, withCert: true);
+        var cert = ResolutionWitness.CreateSignedCert(WitnessAtomId, WitnessAssetHash);
+
+        var result = PhysicalAtomResolutionVerifier.Verify(
+            cert,
+            store,
+            WitnessIssuerPublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("asset-unresolved");
+    }
+
+    [Fact]
+    public void R4_TamperedBundleManifestAssetHash_Refuses()
+    {
+        var bundle = ResolutionWitness.CreateValidBundle();
+        var tampered = bundle with
+        {
+            Certificate = bundle.Certificate with { AssetHash = "0000000000000000000000000000000000000000000000000000000000000000" }
+        };
+
+        var result = PhysicalAtomCertBundleVerifier.Verify(tampered, WitnessIssuerPublicKey);
+
+        result.Trusted.Should().BeFalse();
+        result.FailureCode.Should().Be("bundle-asset-hash-mismatch");
+    }
+
+    [Fact]
+    public void A1_ResolvedAssetAndCert_Accepts()
+    {
+        var store = ResolutionWitness.CreateStore(withAsset: true, withCert: true);
+        var cert = ResolutionWitness.CreateSignedCert(WitnessAtomId, WitnessAssetHash);
+
+        var result = PhysicalAtomResolutionVerifier.Verify(
+            cert,
+            store,
+            WitnessIssuerPublicKey);
+
+        result.Trusted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A2_ValidBundle_Accepts()
+    {
+        var bundle = ResolutionWitness.CreateValidBundle();
+
+        var result = PhysicalAtomCertBundleVerifier.Verify(bundle, WitnessIssuerPublicKey);
+
+        result.Trusted.Should().BeTrue();
+    }
+
+    private static class ResolutionWitness
+    {
+        private static readonly byte[] PrivateKey =
+            Convert.FromHexString("91A5020FE6CFB499DED63C0EC5B61C37B9353F2005CD1676831D53C6225B7992");
+
+        public static InMemoryAssetResolutionStore CreateStore(bool withAsset, bool withCert)
+        {
+            var store = new InMemoryAssetResolutionStore();
+            if (withAsset)
+            {
+                store.RegisterAsset(new DigitalTwinAssetRecord(
+                    WitnessAssetHash,
+                    "1.0.0",
+                    "application/octet-stream",
+                    WitnessAssetBytes));
+            }
+
+            if (withCert)
+            {
+                store.RegisterCert(CreateSignedCert(WitnessAtomId, WitnessAssetHash));
+            }
+
+            return store;
+        }
+
+        public static PhysicalAtomCertificate CreateSignedCert(Guid atomId, string assetHash)
+        {
+            var unsigned = new PhysicalAtomCertificate
+            {
+                AtomId = atomId,
+                BindingScope = BindingScope.Design,
+                AssetHash = assetHash,
+                AssetVersion = "1.0.0"
+            };
+
+            return unsigned with
+            {
+                IssuerSignature = PhysicalAtomCertificateSigning.Sign(unsigned, PrivateKey)
+            };
+        }
+
+        public static PhysicalAtomCertBundle CreateValidBundle() =>
+            new(
+                CreateSignedCert(WitnessAtomId, WitnessAssetHash),
+                WitnessAssetBytes,
+                "application/octet-stream",
+                WitnessIssuerPublicKey);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomSampleCertTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Certification/PhysicalAtomSampleCertTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nexo.Certification.Physical;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Certification;
+
+/// <summary>
+/// Replays the committed sample certificate against its documented asset bytes and issuer public key.
+/// </summary>
+[Trait("Category", "Certification")]
+public sealed class PhysicalAtomSampleCertTests
+{
+    private static readonly string SampleRoot =
+        Path.Combine(AppContext.BaseDirectory, "physical-atom-cert");
+
+    [Fact]
+    public void SampleInstanceScopeCert_VerifierAccepts()
+    {
+        var certJson = File.ReadAllText(Path.Combine(SampleRoot, "instance-scope.example.json"));
+        var pubB64 = File.ReadAllText(Path.Combine(SampleRoot, "issuer-public-key.sample.b64")).Trim();
+
+        using var doc = JsonDocument.Parse(certJson);
+        var root = doc.RootElement;
+
+        var cert = new PhysicalAtomCertificate
+        {
+            SchemaVersion = root.GetProperty("schemaVersion").GetInt32(),
+            Maturity = Enum.Parse<MaturityLevel>(root.GetProperty("maturity").GetString()!),
+            AtomId = root.GetProperty("atomId").GetGuid(),
+            BindingScope = Enum.Parse<BindingScope>(root.GetProperty("bindingScope").GetString()!),
+            AssetHash = root.GetProperty("assetHash").GetString()!,
+            AssetVersion = root.GetProperty("assetVersion").GetString()!,
+            GeoAnchor = ParseGeoAnchor(root.GetProperty("geoAnchor")),
+            ManufactureMeta = ParseManufactureMeta(root.GetProperty("manufactureMeta")),
+            Extensions = new Dictionary<string, byte[]>(StringComparer.Ordinal),
+            IssuerSignature = root.GetProperty("issuerSignature").GetString()
+        };
+
+        var assetBytes = "sample-digital-twin-asset-v1"u8.ToArray();
+        var issuerPublicKey = Convert.FromBase64String(pubB64);
+
+        var result = PhysicalAtomCertificateVerifier.Verify(cert, assetBytes, issuerPublicKey);
+
+        result.Trusted.Should().BeTrue();
+    }
+
+    private static GeoAnchor ParseGeoAnchor(JsonElement element) =>
+        new(
+            element.GetProperty("latitude").GetDouble(),
+            element.GetProperty("longitude").GetDouble(),
+            element.GetProperty("resolution").GetInt32(),
+            element.GetProperty("h3Index").GetString()!);
+
+    private static ManufactureMeta ParseManufactureMeta(JsonElement element) =>
+        new(
+            element.TryGetProperty("batchId", out var batch) ? batch.GetString() : null,
+            element.TryGetProperty("serialNumber", out var serial) ? serial.GetString() : null,
+            element.TryGetProperty("manufacturedAt", out var at)
+                ? DateTimeOffset.Parse(at.GetString()!)
+                : null);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 1** of the physical-atom certification tower: headless asset resolution, certified bundle format, and resolution-aware verification.

**Note:** This branch stacks on Phase 0 (#210). Merge #210 first, or merge this PR for both phases together.

## Phase 1 scope

| Delivered | Deferred (Phase 2+) |
|-----------|---------------------|
| In-memory resolution store | HTTP hosting backend |
| `PhysicalAtomCertBundle` + JSON manifest | QR/NFC encoding |
| `PhysicalAtomResolutionVerifier` | XR client / simulator |
| `AssetBundleCertificationPipeline` | Release channel logic |
| Sample `design-scope.bundle.json` | 3D asset generation pipeline |

## Changes (Phase 1)

- **`Nexo.Certification.Physical.Resolution`**
  - `IAssetResolutionStore` / `InMemoryAssetResolutionStore`
  - `DigitalTwinAssetRecord`, `PhysicalAtomCertBundle`
  - `PhysicalAtomResolutionVerifier` — resolve cert + asset → Phase 0 verifier
  - `PhysicalAtomCertBundleVerifier` — offline bundle verification
  - `PhysicalAtomCertBundleManifest` — JSON serialize/deserialize
- **`AssetBundleCertificationPipeline`** — issue cert, register asset+cert, emit bundle
- **Tests (rejection-first):** 9 new tests
- **Docs:** `docs/physical-atom-phase1-spec.md`, `docs/physical-atom-phase1-test-report.md`
- **cert-gate:** 78 tests total (+9 from Phase 1)

## Testing

```bash
bash scripts/run-cert-gate.sh
# cert-gate reported 78 tests (expected>=78) — all passed locally
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e10a11b6-4fec-45b4-b2f1-302a84bc2ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e10a11b6-4fec-45b4-b2f1-302a84bc2ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

