### PR TITLE
feat(spatial): P2 ARKit platform shell + P1 land docs

### DIFF
--- a/Nexo.Kernel.sln
+++ b/Nexo.Kernel.sln
@@ -55,6 +55,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Spatial.Multiplayer", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Spatial.Runtime", "src\Nexo.Spatial.Runtime\Nexo.Spatial.Runtime.csproj", "{F26866BB-754B-44A0-B33F-80CE9E486B03}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Spatial.Platform.ARKit", "src\Nexo.Spatial.Platform.ARKit\Nexo.Spatial.Platform.ARKit.csproj", "{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -365,6 +367,18 @@ Global
 		{F26866BB-754B-44A0-B33F-80CE9E486B03}.Release|x64.Build.0 = Release|Any CPU
 		{F26866BB-754B-44A0-B33F-80CE9E486B03}.Release|x86.ActiveCfg = Release|Any CPU
 		{F26866BB-754B-44A0-B33F-80CE9E486B03}.Release|x86.Build.0 = Release|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Debug|x64.Build.0 = Debug|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Debug|x86.Build.0 = Debug|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Release|x64.ActiveCfg = Release|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Release|x64.Build.0 = Release|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Release|x86.ActiveCfg = Release|Any CPU
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -395,5 +409,6 @@ Global
 		{E2DE65D6-67A4-408D-A709-BEABCE074133} = {31297073-3FD6-401C-A313-89BE7C850D6B}
 		{4F9E2BCD-9241-40B5-911F-B53541BB3CC1} = {31297073-3FD6-401C-A313-89BE7C850D6B}
 		{F26866BB-754B-44A0-B33F-80CE9E486B03} = {31297073-3FD6-401C-A313-89BE7C850D6B}
+		{075FBDC0-DF1B-46B2-A74E-70C1A6CCF6B1} = {31297073-3FD6-401C-A313-89BE7C850D6B}
 	EndGlobalSection
 EndGlobal

--- a/Nexo.sln
+++ b/Nexo.sln
@@ -127,6 +127,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Spatial.Multiplayer", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Spatial.Runtime", "src\Nexo.Spatial.Runtime\Nexo.Spatial.Runtime.csproj", "{1994BD0A-3A3D-446B-8C42-19BC595552AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Spatial.Platform.ARKit", "src\Nexo.Spatial.Platform.ARKit\Nexo.Spatial.Platform.ARKit.csproj", "{45158B1C-694F-4CB1-ABDA-3523289E17AC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -821,6 +823,18 @@ Global
 		{1994BD0A-3A3D-446B-8C42-19BC595552AA}.Release|x64.Build.0 = Release|Any CPU
 		{1994BD0A-3A3D-446B-8C42-19BC595552AA}.Release|x86.ActiveCfg = Release|Any CPU
 		{1994BD0A-3A3D-446B-8C42-19BC595552AA}.Release|x86.Build.0 = Release|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Debug|x64.Build.0 = Debug|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Debug|x86.Build.0 = Debug|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Release|x64.Build.0 = Release|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Release|x86.ActiveCfg = Release|Any CPU
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -884,6 +898,7 @@ Global
 		{BBC9470A-8631-4B98-A1EC-14FBD9FDB0E0} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 		{9DDA2BD5-1BC7-4592-94C3-4455690D2B67} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 		{1994BD0A-3A3D-446B-8C42-19BC595552AA} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
+		{45158B1C-694F-4CB1-ABDA-3523289E17AC} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12345678-1234-1234-1234-123456789ABC}

--- a/docs/DocsIndex.md
+++ b/docs/DocsIndex.md
@@ -79,6 +79,7 @@ Documentation index for the Nexo platform. Start here to find what you need.
 - `docs/physical-atom-phase0-test-report.md` — rejection-first test coverage report for Phase 0.
 - `docs/physical-atom-phase1-test-report.md` — Phase 1 resolution/bundle test report.
 - `docs/physical-atom-phase2-test-report.md` — Phase 2 QR/NFC tag encoding test report.
+- `docs/spatial-multiplayer.md` — **Spatial P1:** single host authority per match scope (v1 decision).
 - `samples/physical-atom-cert/` — signed sample certificate + issuer public key for headless verification replay.
 - `docs/FriendMeshPrefab.md` — prefab Docker Compose + env template for a small shared **Nexo.API** hub (friends / tailnet).
 - `docs/MeshPhase8OperatorHardening.md` — **Mesh Phase 8:** discovery admission, trust alias, `nexo mesh peers` / `mesh health` / `dotnet run --project commercial/src/Nexo.Commercial.MeshDirector -- director ...`, TLS example.

--- a/docs/certification-evidence.md
+++ b/docs/certification-evidence.md
@@ -248,6 +248,21 @@ HTTP resolution routing + tag→verify orchestration. Spec: `docs/physical-atom-
 | `HttpAssetResolutionRouterTests` | **PASS** — headless GET routes for cert + asset |
 | `PhysicalAtomEndToEndFlowTests` | **PASS** — pipeline → HTTP → tag verify |
 
+## Spatial pose arc (P1 — Prototype, #220)
+
+Identity/pose seam landed on `master` via squash merge `4f550b03`. Duplicate `Nexo.Certification.PhysicalAtom` dropped; spatial runtime binds through `TagVerifyResolverAdapter` → `PhysicalAtomTagVerifyOrchestrator`.
+
+| Proof | Result |
+|-------|--------|
+| `SpatialBindingServiceRejectionTests` + `TagVerifyResolverAdapterSeamTests` | **PASS** — uncertified atom, issuer mismatch, mid-stream asset-hash change refused |
+| `ScopedPoseRelayRejectionTests` | **PASS** — host-only publish, non-member subscribe refused, no pose replay for late joiners |
+| `PoseStreamConsumerRejectionTests` | **PASS** — confidence/gap/velocity policies downstream of provider |
+| `dependency-boundary-gate` | **PASS** — only `Nexo.Spatial.Runtime` references `Nexo.Certification.Physical` |
+
+Projects: `Nexo.Spatial.Contracts`, `Nexo.Spatial.Runtime`, `Nexo.Spatial.Multiplayer`. Doc: `docs/spatial-multiplayer.md`.
+
+**Deferred:** 0c8b hash-chained bundle transitions (use `PhysicalAtomCertBundleVerifier` instead). Real ARKit/ARCore SDK wiring is P2 (`Nexo.Spatial.Platform.ARKit` stub landed separately).
+
 ## Contract-stability gaps
 
 - Generated brick uses Nexo.Core.Domain.* namespaces (shipped via Nexo.Authoring/Nexo.Brick.Contracts but not the pinned package IDs)

--- a/src/Nexo.Spatial.Platform.ARKit/ArKitSpatialAnchorProvider.cs
+++ b/src/Nexo.Spatial.Platform.ARKit/ArKitSpatialAnchorProvider.cs
@@ -1,0 +1,54 @@
+using System.Reactive.Linq;
+using Nexo.Spatial.Contracts;
+
+namespace Nexo.Spatial.Platform.ARKit;
+
+/// <summary>
+/// ARKit platform <see cref="ISpatialAnchorProvider"/> (P2).
+/// Until native ARKit session wiring exists, non-iOS and uninitialized sessions fail closed.
+/// </summary>
+public sealed class ArKitSpatialAnchorProvider : ISpatialAnchorProvider
+{
+    private readonly bool _sessionReady;
+
+    /// <summary>
+    /// Creates a provider. On non-iOS hosts, poses are never emitted.
+    /// </summary>
+    /// <param name="sessionReady">When true on iOS, indicates native session is active (future P2 wiring).</param>
+    public ArKitSpatialAnchorProvider(bool sessionReady = false)
+    {
+        _sessionReady = sessionReady;
+    }
+
+    public Task<PoseSample?> GetCurrentPose(string atomId)
+    {
+        if (string.IsNullOrWhiteSpace(atomId))
+            return Task.FromResult<PoseSample?>(null);
+
+        if (!IsTrackingAvailable())
+            return Task.FromResult<PoseSample?>(null);
+
+        // Native ARKit pose lookup is P2 follow-up; unavailable until wired.
+        return Task.FromResult<PoseSample?>(null);
+    }
+
+    public IObservable<PoseSample> ObservePose(string atomId)
+    {
+        if (string.IsNullOrWhiteSpace(atomId) || !IsTrackingAvailable())
+            return Observable.Return(CreateLostSample());
+
+        // Session ready on iOS but native bridge not wired yet — still fail closed.
+        return Observable.Return(CreateLostSample());
+    }
+
+    private bool IsTrackingAvailable() =>
+        ArKitSpatialAvailability.IsSupported() && _sessionReady;
+
+    private static PoseSample CreateLostSample() =>
+        new(
+            new SpatialVector3(0, 0, 0),
+            new SpatialQuaternion(0, 0, 0, 1),
+            0,
+            DateTimeOffset.UtcNow,
+            TrackingState.Lost);
+}

--- a/src/Nexo.Spatial.Platform.ARKit/ArKitSpatialAvailability.cs
+++ b/src/Nexo.Spatial.Platform.ARKit/ArKitSpatialAvailability.cs
@@ -1,0 +1,20 @@
+namespace Nexo.Spatial.Platform.ARKit;
+
+/// <summary>
+/// Runtime probe for ARKit platform availability (no ARKit SDK reference in open core).
+/// </summary>
+public static class ArKitSpatialAvailability
+{
+    /// <summary>
+    /// True when running on iOS 11+ where ARKit can be bound by a future native adapter.
+    /// Always false on headless CI hosts (Linux, macOS desktop, Windows).
+    /// </summary>
+    public static bool IsSupported()
+    {
+#if NET5_0_OR_GREATER
+        return OperatingSystem.IsIOSVersionAtLeast(11);
+#else
+        return false;
+#endif
+    }
+}

--- a/src/Nexo.Spatial.Platform.ARKit/Nexo.Spatial.Platform.ARKit.csproj
+++ b/src/Nexo.Spatial.Platform.ARKit/Nexo.Spatial.Platform.ARKit.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>Nexo.Spatial.Platform.ARKit</PackageId>
+    <Title>Nexo Spatial ARKit Platform</Title>
+    <Description>ARKit-backed ISpatialAnchorProvider (P2). Headless hosts fail closed until native ARKit session wiring lands.</Description>
+    <PackageTags>nexo;spatial;arkit;platform</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nexo.Spatial.Contracts\Nexo.Spatial.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
+++ b/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
@@ -71,6 +71,7 @@
     <ProjectReference Include="..\Nexo.Spatial.Contracts\Nexo.Spatial.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Spatial.Runtime\Nexo.Spatial.Runtime.csproj" />
     <ProjectReference Include="..\Nexo.Spatial.Multiplayer\Nexo.Spatial.Multiplayer.csproj" />
+    <ProjectReference Include="..\Nexo.Spatial.Platform.ARKit\Nexo.Spatial.Platform.ARKit.csproj" />
     <ProjectReference Include="..\Nexo.Abstractions\Nexo.Abstractions.csproj" />
     <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
     <ProjectReference Include="..\Nexo.Tests.Contracts\Nexo.Tests.Contracts.csproj" />

--- a/src/Nexo.Tests.Infrastructure/Tests/Spatial/ArKitSpatialAnchorProviderRejectionTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Spatial/ArKitSpatialAnchorProviderRejectionTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Nexo.Spatial.Contracts;
+using Nexo.Spatial.Platform.ARKit;
+using System.Reactive.Linq;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Spatial;
+
+/// <summary>
+/// P2 ARKit provider rejection tests (headless CI — no device SDK).
+/// </summary>
+[Trait("Category", "Spatial")]
+public sealed class ArKitSpatialAnchorProviderRejectionTests
+{
+    [Fact]
+    public async Task R1_NonIosHost_GetCurrentPose_ReturnsNullNotFabricatedPose()
+    {
+        ArKitSpatialAvailability.IsSupported().Should().BeFalse("headless CI is never iOS");
+
+        var provider = new ArKitSpatialAnchorProvider(sessionReady: true);
+        var pose = await provider.GetCurrentPose("atom-a");
+
+        pose.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task R2_NonIosHost_ObservePose_EmitsLostNotTracking()
+    {
+        var provider = new ArKitSpatialAnchorProvider(sessionReady: true);
+
+        var sample = await provider.ObservePose("atom-a").FirstAsync();
+
+        sample.TrackingState.Should().Be(TrackingState.Lost);
+        sample.Confidence.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task R3_BlankAtomId_ObservePose_EmitsLost()
+    {
+        var provider = new ArKitSpatialAnchorProvider();
+
+        var sample = await provider.ObservePose("  ").FirstAsync();
+
+        sample.TrackingState.Should().Be(TrackingState.Lost);
+    }
+
+    [Fact]
+    public async Task R4_UninitializedSession_OnNonIos_StillFailsClosed()
+    {
+        var provider = new ArKitSpatialAnchorProvider(sessionReady: false);
+        var pose = await provider.GetCurrentPose("atom-a");
+
+        pose.Should().BeNull();
+        var sample = await provider.ObservePose("atom-a").FirstAsync();
+        sample.TrackingState.Should().Be(TrackingState.Lost);
+    }
+}


### PR DESCRIPTION
## Summary

Post-#220 execution: P2-S1 ARKit platform provider shell (headless, no SDK) plus P1 spatial arc documentation in the evidence ledger.

- **`Nexo.Spatial.Platform.ARKit`** — `ArKitSpatialAnchorProvider` + `ArKitSpatialAvailability`
- Zero ARKit SDK references; `OperatingSystem.IsIOSVersionAtLeast(11)` gate only
- Fail-closed on CI/desktop: `GetCurrentPose` → null, `ObservePose` → `TrackingState.Lost`
- 4 new rejection tests (`ArKitSpatialAnchorProviderRejectionTests`)
- **26 total** spatial tests green

## Docs

- `docs/certification-evidence.md` — P1 spatial arc land section (#220)
- `docs/DocsIndex.md` — `spatial-multiplayer.md` entry

## Deferred

Native ARKit session bridge (actual frame poses) — next P2 slice on device/iOS TFM.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~Tests.Spatial`
- [x] `make dependency-boundary-gate`


Made with [Cursor](https://cursor.com)