### PR TITLE
feat(skills): policy-gated skills foundation with Agent Framework adapter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,20 +4,20 @@
   </PropertyGroup>
   <!-- Microsoft Extensions -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
     <PackageVersion Include="OsmSharp" Version="6.2.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
@@ -27,10 +27,10 @@
   </ItemGroup>
   <!-- System Packages -->
   <ItemGroup>
-    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.9" />
     <!-- Override transitive 4.3.0 (NU1903 / GHSA-cmhx-cq75-c4mj). -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
@@ -205,6 +205,10 @@
   <!-- Background Agents Packages -->
   <ItemGroup>
     <PackageVersion Include="NCrontab" Version="3.3.3" />
+  </ItemGroup>
+  <!-- Agent Skills -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.13.0" />
   </ItemGroup>
   <!-- Physical-atom certification (Phase 0) -->
   <ItemGroup>

--- a/Nexo.sln
+++ b/Nexo.sln
@@ -139,6 +139,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Provenance.Graph.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Provenance.Demo", "tools\Nexo.Provenance.Demo\Nexo.Provenance.Demo.csproj", "{1D8336EA-841C-41D3-8004-B961477D2160}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nexo.Skills.AgentFramework", "src\Nexo.Skills.AgentFramework\Nexo.Skills.AgentFramework.csproj", "{AE3D7D75-B115-439B-ABA1-4D174BA158BE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -905,6 +907,18 @@ Global
 		{1D8336EA-841C-41D3-8004-B961477D2160}.Release|x64.Build.0 = Release|Any CPU
 		{1D8336EA-841C-41D3-8004-B961477D2160}.Release|x86.ActiveCfg = Release|Any CPU
 		{1D8336EA-841C-41D3-8004-B961477D2160}.Release|x86.Build.0 = Release|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Release|x64.Build.0 = Release|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -974,6 +988,7 @@ Global
 		{B42C5AE2-1208-49CB-A3E8-DF58B1088052} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 		{935D3EE2-2EE3-4651-BF2D-A75151FE1B81} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 		{1D8336EA-841C-41D3-8004-B961477D2160} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
+		{AE3D7D75-B115-439B-ABA1-4D174BA158BE} = {9D4F8B1A-0B6E-4A3E-8A6A-0DE12C7C6E2F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12345678-1234-1234-1234-123456789ABC}

--- a/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
+++ b/application/src/Nexo.API/Endpoints/NexoEndpoints.cs
@@ -17,6 +17,9 @@ using Nexo.Core.Application.Bricks;
 using Nexo.Core.Application.NodeCapabilityRuntime.Models;
 using Nexo.Core.Application.NodeCapabilityRuntime.Ports;
 using Nexo.Core.Application.Trust.Ports;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Mesh.Models;
 using Nexo.Core.Application.Validation.UseCases.RunValidation;
 using Nexo.Abstractions;
 using Nexo.BackgroundAgents.Configuration;
@@ -232,6 +235,24 @@ public static class NexoEndpoints
             .WithSummary("Update trust allow/deny rules for category/source")
             .Produces<TrustBoundaryMutationResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/skills", ListSkillsAsync)
+            .WithName("ListSkills")
+            .WithSummary("Advertise visible skills for a trust tier")
+            .Produces<SkillListResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/skills/approvals", ListSkillApprovalsAsync)
+            .WithName("ListSkillApprovals")
+            .WithSummary("List pending skill script approvals")
+            .Produces<SkillApprovalsResponse>(StatusCodes.Status200OK);
+
+        group.MapPost("/skills/approvals/{requestId}/resolve", ResolveSkillApprovalAsync)
+            .WithName("ResolveSkillApproval")
+            .WithSummary("Approve or deny a pending skill script")
+            .Produces<SkillApprovalItem>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapGet("/knowledge/query", QueryKnowledgeAsync)
             .WithName("QueryKnowledge")
@@ -1038,6 +1059,78 @@ public static class NexoEndpoints
             IsPaused: paused,
             RecentAudit: audit,
             AuditByType: byType));
+    }
+
+    private static async Task<IResult> ListSkillsAsync(
+        [FromServices] INexoSkillCatalog? catalog,
+        [FromServices] INexoSkillExecutionContextFactory? contextFactory,
+        [FromQuery] string tier = "Trusted",
+        CancellationToken cancellationToken = default)
+    {
+        if (catalog is null || contextFactory is null)
+            return Results.BadRequest(new ProblemDetails { Title = "Skills subsystem is not registered." });
+
+        if (!Enum.TryParse<PeerTrustTier>(tier, ignoreCase: true, out var trustTier))
+            return Results.BadRequest(new ProblemDetails { Title = $"Unknown trust tier '{tier}'." });
+
+        var context = contextFactory.Create(trustTier, "api-operator");
+        var skills = await catalog.AdvertiseAsync(context, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(new SkillListResponse(
+            trustTier.ToString(),
+            skills.Select(static s => new SkillDescriptorItem(s.Name, s.Description)).ToList()));
+    }
+
+    private static Task<IResult> ListSkillApprovalsAsync(
+        [FromServices] INexoSkillApprovalStore? approvalStore,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var pending = approvalStore?.GetPending() ?? [];
+        return Task.FromResult(Results.Ok(new SkillApprovalsResponse(
+            pending.Select(static r => new SkillApprovalItem(
+                r.RequestId,
+                r.Key.SkillName,
+                r.Key.ScriptPath,
+                r.Key.TrustTier.ToString(),
+                r.Key.BarrierLevel,
+                r.Key.PolicyPackId,
+                r.Description,
+                r.Status.ToString(),
+                r.RequestedAt)).ToList())));
+    }
+
+    private static Task<IResult> ResolveSkillApprovalAsync(
+        string requestId,
+        [FromBody] ResolveSkillApprovalRequest request,
+        [FromServices] INexoSkillApprovalStore? approvalStore,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (approvalStore is null)
+            return Task.FromResult(Results.BadRequest(new ProblemDetails { Title = "Skill approval store is not registered." }));
+
+        if (!Enum.TryParse<NexoSkillApprovalStatus>(request.Decision, ignoreCase: true, out var status)
+            || status is not (NexoSkillApprovalStatus.Approved or NexoSkillApprovalStatus.Denied))
+        {
+            return Task.FromResult(Results.BadRequest(new ProblemDetails
+            {
+                Title = "Decision must be Approved or Denied.",
+            }));
+        }
+
+        if (!approvalStore.TryResolve(requestId, status, out var resolved) || resolved is null)
+            return Task.FromResult(Results.NotFound(new ProblemDetails { Title = $"Approval '{requestId}' not found." }));
+
+        return Task.FromResult(Results.Ok(new SkillApprovalItem(
+            resolved.RequestId,
+            resolved.Key.SkillName,
+            resolved.Key.ScriptPath,
+            resolved.Key.TrustTier.ToString(),
+            resolved.Key.BarrierLevel,
+            resolved.Key.PolicyPackId,
+            resolved.Description,
+            resolved.Status.ToString(),
+            resolved.RequestedAt)));
     }
 
     private static async Task<IResult> SetTrustPauseAsync(

--- a/application/src/Nexo.API/Endpoints/SkillApprovalDtos.cs
+++ b/application/src/Nexo.API/Endpoints/SkillApprovalDtos.cs
@@ -1,0 +1,27 @@
+namespace Nexo.API.Endpoints;
+
+/// <summary>Response for GET /api/skills.</summary>
+public sealed record SkillListResponse(
+    string TrustTier,
+    IReadOnlyList<SkillDescriptorItem> Skills);
+
+/// <summary>Skill advertisement item.</summary>
+public sealed record SkillDescriptorItem(string Name, string Description);
+
+/// <summary>Response for GET /api/skills/approvals.</summary>
+public sealed record SkillApprovalsResponse(IReadOnlyList<SkillApprovalItem> Pending);
+
+/// <summary>Pending or resolved skill script approval.</summary>
+public sealed record SkillApprovalItem(
+    string RequestId,
+    string SkillName,
+    string ScriptPath,
+    string TrustTier,
+    string BarrierLevel,
+    string? PolicyPackId,
+    string Description,
+    string Status,
+    DateTimeOffset RequestedAt);
+
+/// <summary>Request body for POST /api/skills/approvals/{id}/resolve.</summary>
+public sealed record ResolveSkillApprovalRequest(string Decision);

--- a/application/src/Nexo.CLI/Commands/SkillsCommand.cs
+++ b/application/src/Nexo.CLI/Commands/SkillsCommand.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.CLI.Commands;
+
+/// <summary>
+/// CLI for skill advertisement, disclosure, and human-in-the-loop script approvals.
+/// </summary>
+public sealed class SkillsCommand
+{
+    private readonly INexoSkillCatalog? _catalog;
+    private readonly INexoSkillExecutionContextFactory? _contextFactory;
+    private readonly INexoSkillApprovalStore? _approvalStore;
+    private readonly ILogger<SkillsCommand> _logger;
+
+    /// <summary>Initializes a new skills command.</summary>
+    public SkillsCommand(
+        ILogger<SkillsCommand> logger,
+        INexoSkillCatalog? catalog = null,
+        INexoSkillExecutionContextFactory? contextFactory = null,
+        INexoSkillApprovalStore? approvalStore = null)
+    {
+        _logger = logger;
+        _catalog = catalog;
+        _contextFactory = contextFactory;
+        _approvalStore = approvalStore;
+    }
+
+    /// <summary>Lists skill advertisements for a trust tier.</summary>
+    public async Task<int> ListAsync(string tier, bool json)
+    {
+        if (_catalog is null || _contextFactory is null)
+        {
+            Console.Error.WriteLine("Skills subsystem is not registered.");
+            return 1;
+        }
+
+        var context = CreateContext(tier);
+        var skills = await _catalog.AdvertiseAsync(context).ConfigureAwait(false);
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(skills, new JsonSerializerOptions { WriteIndented = true }));
+            return 0;
+        }
+
+        Console.WriteLine($"Visible skills ({tier}):");
+        foreach (var skill in skills)
+            Console.WriteLine($"- {skill.Name}: {skill.Description}");
+        return 0;
+    }
+
+    /// <summary>Loads full SKILL.md content for a skill.</summary>
+    public async Task<int> LoadAsync(string skillName, string tier)
+    {
+        if (_catalog is null || _contextFactory is null)
+        {
+            Console.Error.WriteLine("Skills subsystem is not registered.");
+            return 1;
+        }
+
+        try
+        {
+            var content = await _catalog.LoadAsync(skillName, CreateContext(tier)).ConfigureAwait(false);
+            Console.WriteLine(content);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load skill {Skill}", skillName);
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    /// <summary>Lists pending skill script approvals.</summary>
+    public Task<int> ListApprovalsAsync(bool json)
+    {
+        if (_approvalStore is null)
+        {
+            Console.Error.WriteLine("Skill approval store is not registered.");
+            return Task.FromResult(1);
+        }
+
+        var pending = _approvalStore.GetPending();
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(pending, new JsonSerializerOptions { WriteIndented = true }));
+            return Task.FromResult(0);
+        }
+
+        if (pending.Count == 0)
+        {
+            Console.WriteLine("No pending skill script approvals.");
+            return Task.FromResult(0);
+        }
+
+        foreach (var request in pending)
+        {
+            Console.WriteLine(
+                $"{request.RequestId}  {request.Key.SkillName}:{request.Key.ScriptPath}  " +
+                $"tier={request.Key.TrustTier} barrier={request.Key.BarrierLevel}  {request.Description}");
+        }
+
+        return Task.FromResult(0);
+    }
+
+    /// <summary>Approves a pending skill script request.</summary>
+    public Task<int> ApproveAsync(string requestId, bool json)
+        => ResolveAsync(requestId, NexoSkillApprovalStatus.Approved, json);
+
+    /// <summary>Denies a pending skill script request.</summary>
+    public Task<int> DenyAsync(string requestId, bool json)
+        => ResolveAsync(requestId, NexoSkillApprovalStatus.Denied, json);
+
+    private Task<int> ResolveAsync(string requestId, NexoSkillApprovalStatus status, bool json)
+    {
+        if (_approvalStore is null)
+        {
+            Console.Error.WriteLine("Skill approval store is not registered.");
+            return Task.FromResult(1);
+        }
+
+        if (!_approvalStore.TryResolve(requestId, status, out var request) || request is null)
+        {
+            Console.Error.WriteLine($"Approval request '{requestId}' was not found or already resolved.");
+            return Task.FromResult(1);
+        }
+
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(request, new JsonSerializerOptions { WriteIndented = true }));
+            return Task.FromResult(0);
+        }
+
+        Console.WriteLine($"Resolved {request.RequestId} -> {request.Status}");
+        return Task.FromResult(0);
+    }
+
+    private NexoSkillExecutionContext CreateContext(string tier)
+    {
+        var trustTier = Enum.TryParse<PeerTrustTier>(tier, ignoreCase: true, out var parsed)
+            ? parsed
+            : PeerTrustTier.Trusted;
+
+        return _contextFactory!.Create(trustTier, "cli-operator");
+    }
+}

--- a/application/src/Nexo.CLI/Program.CommandRegistration.cs
+++ b/application/src/Nexo.CLI/Program.CommandRegistration.cs
@@ -218,6 +218,7 @@ static partial class Program
 
 
         var trustCmd = BuildTrustCommand(jsonOpt);
+        var skillsCmd = BuildSkillsCommand(jsonOpt);
 
 
         // nexo test - Multi-platform test execution
@@ -608,6 +609,8 @@ static partial class Program
         root.AddCommand(new ComposeCommand());
         var meshCmd = new MeshCommand();
         root.AddCommand(meshCmd);
+        root.AddCommand(trustCmd);
+        root.AddCommand(skillsCmd);
         root.AddCommand(backgroundAgentCmd);
         root.AddCommand(testCmd);
         root.AddCommand(escalateCmd);

--- a/application/src/Nexo.CLI/Program.SkillsCommands.cs
+++ b/application/src/Nexo.CLI/Program.SkillsCommands.cs
@@ -1,0 +1,91 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using Nexo.CLI.Commands;
+
+namespace Nexo.CLI;
+
+/// <summary>Program.</summary>
+static partial class Program
+{
+    private static Command BuildSkillsCommand(Option<bool> jsonOpt)
+    {
+        var skillsCmd = new Command("skills", "Inspect and govern Nexo agent skills");
+
+        var listCmd = new Command("list", "Advertise visible skills for a trust tier")
+        {
+            new Option<string>("--tier", () => "Trusted", "Trust tier (Trusted, Untrusted, Unknown)"),
+            jsonOpt,
+        };
+        listCmd.SetHandler(
+            async (string tier, bool json) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<SkillsCommand>();
+                Environment.Exit(await cmd.ListAsync(tier, json));
+            },
+            listCmd.Options[0] as Option<string> ?? throw new InvalidOperationException(),
+            jsonOpt);
+        skillsCmd.AddCommand(listCmd);
+
+        var loadCmd = new Command("load", "Load full skill instructions (SKILL.md)")
+        {
+            new Argument<string>("name", "Skill name"),
+            new Option<string>("--tier", () => "Trusted", "Trust tier"),
+        };
+        loadCmd.SetHandler(
+            async (string name, string tier) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<SkillsCommand>();
+                Environment.Exit(await cmd.LoadAsync(name, tier));
+            },
+            loadCmd.Arguments[0] as Argument<string> ?? throw new InvalidOperationException(),
+            loadCmd.Options[0] as Option<string> ?? throw new InvalidOperationException());
+        skillsCmd.AddCommand(loadCmd);
+
+        var approvalsCmd = new Command("approvals", "Human-in-the-loop skill script approvals");
+        var approvalsListCmd = new Command("list", "List pending skill script approvals")
+        {
+            jsonOpt,
+        };
+        approvalsListCmd.SetHandler(
+            async (bool json) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<SkillsCommand>();
+                Environment.Exit(await cmd.ListApprovalsAsync(json));
+            },
+            jsonOpt);
+        approvalsCmd.AddCommand(approvalsListCmd);
+
+        var approveCmd = new Command("approve", "Approve a pending skill script")
+        {
+            new Argument<string>("request-id", "Pending approval request id"),
+            jsonOpt,
+        };
+        approveCmd.SetHandler(
+            async (string requestId, bool json) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<SkillsCommand>();
+                Environment.Exit(await cmd.ApproveAsync(requestId, json));
+            },
+            approveCmd.Arguments[0] as Argument<string> ?? throw new InvalidOperationException(),
+            jsonOpt);
+        approvalsCmd.AddCommand(approveCmd);
+
+        var denyCmd = new Command("deny", "Deny a pending skill script")
+        {
+            new Argument<string>("request-id", "Pending approval request id"),
+            jsonOpt,
+        };
+        denyCmd.SetHandler(
+            async (string requestId, bool json) =>
+            {
+                var cmd = ServiceProvider.GetRequiredService<SkillsCommand>();
+                Environment.Exit(await cmd.DenyAsync(requestId, json));
+            },
+            denyCmd.Arguments[0] as Argument<string> ?? throw new InvalidOperationException(),
+            jsonOpt);
+        approvalsCmd.AddCommand(denyCmd);
+
+        skillsCmd.AddCommand(approvalsCmd);
+        return skillsCmd;
+    }
+}

--- a/application/src/Nexo.CLI/Program.cs
+++ b/application/src/Nexo.CLI/Program.cs
@@ -111,6 +111,7 @@ static partial class Program
         services.AddScoped<Nexo.CLI.Commands.BackgroundAgent.OperatorDashboardBackgroundAgentCommand>();
         services.AddScoped<Nexo.CLI.Commands.BackgroundAgent.SensitivityCommand>();
         services.AddScoped<TrustCommand>();
+        services.AddScoped<SkillsCommand>();
         services.AddScoped<Nexo.CLI.Commands.BackgroundAgent.RAGCommand>();
         services.AddScoped<Nexo.CLI.Commands.BackgroundAgent.WebSearchCommand>();
 

--- a/config/trust-packs/internal-only.json
+++ b/config/trust-packs/internal-only.json
@@ -16,5 +16,35 @@
     "git": true,
     "vscode": true
   },
-  "projectRules": []
+  "projectRules": [],
+  "skillRules": {
+    "visibility": {
+      "Trusted": {
+        "allow": ["nexo-trust-inspector", "nexo-active-policy-pack"],
+        "deny": []
+      },
+      "Untrusted": {
+        "allow": ["nexo-trust-inspector"],
+        "deny": ["nexo-active-policy-pack"]
+      },
+      "Unknown": {
+        "allow": [],
+        "deny": ["*"]
+      }
+    },
+    "allowedScripts": {
+      "nexo-trust-inspector": ["scripts/list-packs.sh"]
+    },
+    "autoApproveScripts": [
+      {
+        "skill": "nexo-trust-inspector",
+        "script": "scripts/list-packs.sh",
+        "tiers": ["Trusted"]
+      }
+    ],
+    "scriptLimits": {
+      "timeoutSeconds": 30,
+      "maxOutputBytes": 65536
+    }
+  }
 }

--- a/config/trust-packs/strict-enterprise.json
+++ b/config/trust-packs/strict-enterprise.json
@@ -17,5 +17,29 @@
     "git": true,
     "vscode": true
   },
-  "projectRules": []
+  "projectRules": [],
+  "skillRules": {
+    "visibility": {
+      "Trusted": {
+        "allow": ["nexo-trust-inspector"],
+        "deny": ["nexo-active-policy-pack"]
+      },
+      "Untrusted": {
+        "allow": [],
+        "deny": ["*"]
+      },
+      "Unknown": {
+        "allow": [],
+        "deny": ["*"]
+      }
+    },
+    "allowedScripts": {
+      "nexo-trust-inspector": ["scripts/list-packs.sh"]
+    },
+    "autoApproveScripts": [],
+    "scriptLimits": {
+      "timeoutSeconds": 15,
+      "maxOutputBytes": 32768
+    }
+  }
 }

--- a/skills/nexo-trust-inspector/SKILL.md
+++ b/skills/nexo-trust-inspector/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: nexo-trust-inspector
+description: Inspect Nexo trust policy packs — list available packs and describe the active pack.
+license: Apache-2.0
+compatibility: Nexo 0.x
+allowed-tools: run_skill_script read_skill_resource
+---
+
+# Nexo Trust Inspector
+
+Use this skill to inspect trust policy packs configured for the local Nexo runtime.
+
+## Workflow
+
+1. Load this skill for full instructions.
+2. Read `references/pack-schema.md` when you need the JSON schema.
+3. Run `scripts/list-packs.sh` with an optional trust-packs directory path argument.
+
+## Safety
+
+This skill only reads JSON policy pack files. It does not modify policy state.

--- a/skills/nexo-trust-inspector/references/pack-schema.md
+++ b/skills/nexo-trust-inspector/references/pack-schema.md
@@ -1,0 +1,11 @@
+# Trust policy pack schema (excerpt)
+
+Trust policy packs are versioned JSON documents under `config/trust-packs/`.
+
+Core fields:
+
+- `id`, `version`, `displayName`, `description`
+- `categoryRules`, `sourceRules`, `projectRules`
+- `skillRules` (optional) — skill visibility, script allow-list, auto-approve tuples, script limits
+
+See `src/Nexo.Core.Application/Trust/Models/TrustPolicyPack.cs` for the canonical model.

--- a/skills/nexo-trust-inspector/scripts/list-packs.sh
+++ b/skills/nexo-trust-inspector/scripts/list-packs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-}"
+if [[ -z "$ROOT" ]]; then
+  if [[ -n "${NEXO_TRUST_POLICY_PACKS_PATH:-}" ]]; then
+    ROOT="$NEXO_TRUST_POLICY_PACKS_PATH"
+  else
+    ROOT="config/trust-packs"
+  fi
+fi
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "Trust pack directory not found: $ROOT" >&2
+  exit 1
+fi
+
+echo "Trust policy packs in $ROOT:"
+for file in "$ROOT"/*.json; do
+  [[ -f "$file" ]] || continue
+  base="$(basename "$file")"
+  if [[ "$base" == "active-pack.json" ]]; then
+    continue
+  fi
+  id="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('id','?'))" "$file")"
+  version="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('version','?'))" "$file")"
+  echo "- ${id}@${version} (${base})"
+done
+
+if [[ -f "$ROOT/active-pack.json" ]]; then
+  echo
+  echo "Active pack:"
+  cat "$ROOT/active-pack.json"
+fi

--- a/src/Nexo.BackgroundAgents.HostRunners/SelfExtendRunnerAdapter.cs
+++ b/src/Nexo.BackgroundAgents.HostRunners/SelfExtendRunnerAdapter.cs
@@ -10,6 +10,9 @@ using Nexo.BackgroundAgents.Observations;
 using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Security;
 using Nexo.Core.Application.Certification.Ports;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
 using Nexo.Runtime;
 
 namespace Nexo.BackgroundAgents.HostRunners;
@@ -39,6 +42,8 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
     private readonly ICertificationRecordStore _certificationStore;
     private readonly IBackgroundAgentRegistry? _agentRegistry;
     private readonly IDataSensitivityRegistry? _sensitivityRegistry;
+    private readonly INexoSkillAgentBridge? _skillAgentBridge;
+    private readonly INexoSkillCacheController? _skillCacheController;
 
     public SelfExtendRunnerAdapter(
         IModel model,
@@ -50,7 +55,9 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         IAggressivenessModeStore? modeStore = null,
         ICertificationRecordStore? certificationStore = null,
         IBackgroundAgentRegistry? agentRegistry = null,
-        IDataSensitivityRegistry? sensitivityRegistry = null)
+        IDataSensitivityRegistry? sensitivityRegistry = null,
+        INexoSkillAgentBridge? skillAgentBridge = null,
+        INexoSkillCacheController? skillCacheController = null)
     {
         _model = model ?? throw new ArgumentNullException(nameof(model));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -62,6 +69,8 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
         _certificationStore = certificationStore ?? FailClosedCertificationRecordStore.Instance;
         _agentRegistry = agentRegistry;
         _sensitivityRegistry = sensitivityRegistry;
+        _skillAgentBridge = skillAgentBridge;
+        _skillCacheController = skillCacheController;
     }
 
     /// <inheritdoc />
@@ -170,14 +179,16 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
                 modelName);
             var scratchpadPath = ResolveScratchpadPath(repoRoot!, resolvedAgentName);
             var recent = LoadRecentObservations();
-            var snapshot = BuildSnapshot(
-                repoRoot!,
-                resolvedAgentName,
-                resolvedAgentId,
-                effectiveObjective,
-                scratchpadPath,
-                recent,
-                claimed);
+            var snapshot = await WithSkillInstructionsAsync(
+                BuildSnapshot(
+                    repoRoot!,
+                    resolvedAgentName,
+                    resolvedAgentId,
+                    effectiveObjective,
+                    scratchpadPath,
+                    recent,
+                    claimed),
+                cancellationToken).ConfigureAwait(false);
 
             // Multi-turn ReAct: agent loops up to MaxIterations, executing tool calls inline
             // through the policy engine and feeding observations back into the conversation.
@@ -191,6 +202,7 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
             var writePaths = cycle.MergedDelta is null
                 ? Array.Empty<string>()
                 : ExtractWritePaths(cycle.MergedDelta.Log);
+            InvalidateSkillCacheIfNeeded(repoRoot!, writePaths);
             PlannerScratchpad.Append(scratchpadPath, new ScratchpadEntry(
                 DateTimeOffset.UtcNow,
                 resolvedAgentName,
@@ -452,5 +464,58 @@ public sealed class SelfExtendRunnerAdapter : ISelfExtendRunner
                 result.Add(path);
         }
         return result;
+    }
+
+    private async Task<WorldSnapshot> WithSkillInstructionsAsync(WorldSnapshot snapshot, CancellationToken cancellationToken)
+    {
+        if (_skillAgentBridge is null)
+            return snapshot;
+
+        try
+        {
+            var context = new NexoSkillExecutionContext(
+                ActingIdentity: snapshot.Data.TryGetValue("AgentName", out var name) ? name?.ToString() ?? "self-extend" : "self-extend",
+                BarrierLevel: "internal",
+                TrustTier: PeerTrustTier.Trusted,
+                PolicyPackId: null,
+                CorrelationId: Guid.NewGuid().ToString("N"));
+
+            var instructions = await _skillAgentBridge.BuildSkillInstructionsAsync(context, cancellationToken)
+                .ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(instructions))
+                return snapshot;
+
+            var data = new Dictionary<string, object?>(snapshot.Data)
+            {
+                ["AvailableSkills"] = instructions
+            };
+            return snapshot with { Data = data };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Skill instruction injection skipped");
+            return snapshot;
+        }
+    }
+
+    private void InvalidateSkillCacheIfNeeded(string repoRoot, IReadOnlyList<string> writePaths)
+    {
+        if (_skillCacheController is null || writePaths.Count == 0)
+            return;
+
+        var skillsRoot = Path.GetFullPath(Path.Combine(repoRoot, "skills"));
+        var touchedSkills = writePaths.Any(path =>
+        {
+            var full = Path.IsPathRooted(path)
+                ? Path.GetFullPath(path)
+                : Path.GetFullPath(Path.Combine(repoRoot, path));
+            return full.StartsWith(skillsRoot, StringComparison.OrdinalIgnoreCase);
+        });
+
+        if (!touchedSkills)
+            return;
+
+        _skillCacheController.InvalidateIfContentChanged(skillsRoot);
+        _logger.LogInformation("Invalidated skill cache after skill rewrite under {SkillsRoot}", skillsRoot);
     }
 }

--- a/src/Nexo.BackgroundAgents/Skills/ApprovalGateSkillApprovalBridge.cs
+++ b/src/Nexo.BackgroundAgents/Skills/ApprovalGateSkillApprovalBridge.cs
@@ -1,0 +1,34 @@
+using Nexo.BackgroundAgents.Configuration;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.BackgroundAgents.Skills;
+
+/// <summary>
+/// Bridges background-agent approval gates to Nexo skill script approval.
+/// </summary>
+public sealed class ApprovalGateSkillApprovalBridge : INexoSkillApprovalGate
+{
+    private readonly IApprovalGate _approvalGate;
+
+    /// <summary>Initializes a new approval gate bridge.</summary>
+    public ApprovalGateSkillApprovalBridge(IApprovalGate approvalGate)
+        => _approvalGate = approvalGate;
+
+    /// <inheritdoc />
+    public async Task<NexoSkillApprovalStatus> RequestApprovalAsync(
+        string actionDescription,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _approvalGate.RequestApprovalAsync(actionDescription, timeout, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result switch
+        {
+            ApprovalResult.Approved => NexoSkillApprovalStatus.Approved,
+            ApprovalResult.TimedOut => NexoSkillApprovalStatus.TimedOut,
+            _ => NexoSkillApprovalStatus.Denied,
+        };
+    }
+}

--- a/src/Nexo.BackgroundAgents/Trust/DataDecisionAuditLog.cs
+++ b/src/Nexo.BackgroundAgents/Trust/DataDecisionAuditLog.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using Nexo.Core.Application.Skills.Models;
 using Nexo.Core.Application.Trust.Models;
 using Nexo.Core.Application.Trust.Ports;
 using Nexo.Core.Domain;
@@ -124,6 +125,28 @@ public sealed class DataDecisionAuditLog : IDataDecisionAuditLog, ISanitizationA
             TenantId = tenantId,
             SourceId = taskId,
             Disposition = success ? "Success" : "Failure",
+        });
+    }
+
+    /// <inheritdoc />
+    public void LogSkillDisclosure(NexoSkillAuditEvent auditEvent)
+    {
+        Append(new DataDecisionAuditEntry
+        {
+            EventType = auditEvent.EventType,
+            Timestamp = auditEvent.OccurredAt,
+            SkillName = auditEvent.SkillName,
+            ActingIdentity = auditEvent.ActingIdentity,
+            BarrierLevel = auditEvent.BarrierLevel,
+            TrustTier = auditEvent.TrustTier,
+            PolicyPackId = auditEvent.PolicyPackId,
+            CorrelationId = auditEvent.CorrelationId,
+            ResourcePath = auditEvent.ResourcePath,
+            ScriptPath = auditEvent.ScriptPath,
+            ScriptContentHash = auditEvent.ScriptContentHash,
+            Outcome = auditEvent.Outcome,
+            DurationMs = auditEvent.DurationMs,
+            Reason = auditEvent.Detail,
         });
     }
 

--- a/src/Nexo.BackgroundAgents/Trust/LiteDbDataDecisionAuditLog.cs
+++ b/src/Nexo.BackgroundAgents/Trust/LiteDbDataDecisionAuditLog.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using LiteDB;
+using Nexo.Core.Application.Skills.Models;
 using Nexo.Core.Application.Trust.Models;
 using Nexo.Core.Application.Trust.Ports;
 
@@ -116,6 +117,28 @@ public sealed class LiteDbDataDecisionAuditLog : IDataDecisionAuditLog, ISanitiz
             TenantId = tenantId,
             SourceId = taskId,
             Disposition = success ? "Success" : "Failure",
+        });
+    }
+
+    /// <inheritdoc />
+    public void LogSkillDisclosure(NexoSkillAuditEvent auditEvent)
+    {
+        Append(new DataDecisionAuditEntry
+        {
+            EventType = auditEvent.EventType,
+            Timestamp = auditEvent.OccurredAt,
+            SkillName = auditEvent.SkillName,
+            ActingIdentity = auditEvent.ActingIdentity,
+            BarrierLevel = auditEvent.BarrierLevel,
+            TrustTier = auditEvent.TrustTier,
+            PolicyPackId = auditEvent.PolicyPackId,
+            CorrelationId = auditEvent.CorrelationId,
+            ResourcePath = auditEvent.ResourcePath,
+            ScriptPath = auditEvent.ScriptPath,
+            ScriptContentHash = auditEvent.ScriptContentHash,
+            Outcome = auditEvent.Outcome,
+            DurationMs = auditEvent.DurationMs,
+            Reason = auditEvent.Detail,
         });
     }
 

--- a/src/Nexo.Core.Application/Skills/Models/NexoScriptRunOptions.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoScriptRunOptions.cs
@@ -1,0 +1,7 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Enforcement limits for local skill script execution.</summary>
+public sealed record NexoScriptRunOptions(
+    TimeSpan Timeout,
+    int MaxOutputBytes,
+    string WorkingDirectoryRoot);

--- a/src/Nexo.Core.Application/Skills/Models/NexoScriptRunResult.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoScriptRunResult.cs
@@ -1,0 +1,10 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Outcome of a sandboxed skill script run.</summary>
+public sealed record NexoScriptRunResult(
+    string Output,
+    int ExitCode,
+    TimeSpan Duration,
+    bool OutputTruncated,
+    string ScriptContentHash,
+    string Outcome);

--- a/src/Nexo.Core.Application/Skills/Models/NexoSkillApprovalRequest.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoSkillApprovalRequest.cs
@@ -1,0 +1,9 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Pending human-in-the-loop approval for a skill script.</summary>
+public sealed record NexoSkillApprovalRequest(
+    string RequestId,
+    SkillScriptApprovalKey Key,
+    string Description,
+    DateTimeOffset RequestedAt,
+    NexoSkillApprovalStatus Status);

--- a/src/Nexo.Core.Application/Skills/Models/NexoSkillApprovalStatus.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoSkillApprovalStatus.cs
@@ -1,0 +1,11 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Result of a skill script approval request.</summary>
+public enum NexoSkillApprovalStatus
+{
+    AutoApproved,
+    Approved,
+    Denied,
+    TimedOut,
+    Pending,
+}

--- a/src/Nexo.Core.Application/Skills/Models/NexoSkillAuditEvent.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoSkillAuditEvent.cs
@@ -1,0 +1,20 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>
+/// Stable audit contract for skill disclosure and script execution.
+/// </summary>
+public sealed record NexoSkillAuditEvent(
+    string EventType,
+    string SkillName,
+    string ActingIdentity,
+    string BarrierLevel,
+    string TrustTier,
+    string? PolicyPackId,
+    string CorrelationId,
+    DateTimeOffset OccurredAt,
+    string? ResourcePath = null,
+    string? ScriptPath = null,
+    string? ScriptContentHash = null,
+    string? Outcome = null,
+    long? DurationMs = null,
+    string? Detail = null);

--- a/src/Nexo.Core.Application/Skills/Models/NexoSkillAuditEventType.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoSkillAuditEventType.cs
@@ -1,0 +1,14 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>
+/// Stable wire identifiers for skill disclosure audit events.
+/// </summary>
+public static class NexoSkillAuditEventType
+{
+    public static readonly string SkillAdvertised = "SKILL_ADVERTISED";
+    public static readonly string SkillLoaded = "SKILL_LOADED";
+    public static readonly string SkillResourceRead = "SKILL_RESOURCE_READ";
+    public static readonly string SkillScriptApprovalRequested = "SKILL_SCRIPT_APPROVAL_REQUESTED";
+    public static readonly string SkillScriptApprovalResolved = "SKILL_SCRIPT_APPROVAL_RESOLVED";
+    public static readonly string SkillScriptExecuted = "SKILL_SCRIPT_EXECUTED";
+}

--- a/src/Nexo.Core.Application/Skills/Models/NexoSkillDescriptor.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoSkillDescriptor.cs
@@ -1,0 +1,9 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Nexo-facing skill advertisement (stage 1).</summary>
+public sealed record NexoSkillDescriptor(
+    string Name,
+    string Description,
+    string? License = null,
+    string? Compatibility = null,
+    IReadOnlyList<string>? AllowedTools = null);

--- a/src/Nexo.Core.Application/Skills/Models/NexoSkillDisclosureStage.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoSkillDisclosureStage.cs
@@ -1,0 +1,12 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Progressive disclosure stage for agent skills.</summary>
+public enum NexoSkillDisclosureStage
+{
+    Advertised = 1,
+    Loaded = 2,
+    ResourceRead = 3,
+    ScriptApprovalRequested = 4,
+    ScriptApprovalResolved = 5,
+    ScriptExecuted = 6,
+}

--- a/src/Nexo.Core.Application/Skills/Models/NexoSkillExecutionContext.cs
+++ b/src/Nexo.Core.Application/Skills/Models/NexoSkillExecutionContext.cs
@@ -1,0 +1,13 @@
+using Nexo.Core.Application.Mesh.Models;
+
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>
+/// Trust and identity context applied when resolving skill visibility and execution.
+/// </summary>
+public sealed record NexoSkillExecutionContext(
+    string ActingIdentity,
+    string BarrierLevel,
+    PeerTrustTier TrustTier,
+    string? PolicyPackId,
+    string CorrelationId);

--- a/src/Nexo.Core.Application/Skills/Models/SkillPolicyRules.cs
+++ b/src/Nexo.Core.Application/Skills/Models/SkillPolicyRules.cs
@@ -1,0 +1,24 @@
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Skill governance rules embedded in a trust policy pack.</summary>
+public sealed record SkillPolicyRules(
+    IReadOnlyDictionary<string, SkillTierVisibilityRules> Visibility,
+    IReadOnlyDictionary<string, IReadOnlyList<string>> AllowedScripts,
+    IReadOnlyList<SkillScriptAutoApprovalRule> AutoApproveScripts,
+    SkillScriptLimits ScriptLimits);
+
+/// <summary>Per-tier skill visibility allow/deny lists.</summary>
+public sealed record SkillTierVisibilityRules(
+    IReadOnlyList<string> Allow,
+    IReadOnlyList<string> Deny);
+
+/// <summary>Auto-approval tuple for (skill, script, tier).</summary>
+public sealed record SkillScriptAutoApprovalRule(
+    string Skill,
+    string Script,
+    IReadOnlyList<string> Tiers);
+
+/// <summary>Default script execution limits from policy.</summary>
+public sealed record SkillScriptLimits(
+    int TimeoutSeconds,
+    int MaxOutputBytes);

--- a/src/Nexo.Core.Application/Skills/Models/SkillScriptApprovalKey.cs
+++ b/src/Nexo.Core.Application/Skills/Models/SkillScriptApprovalKey.cs
@@ -1,0 +1,11 @@
+using Nexo.Core.Application.Mesh.Models;
+
+namespace Nexo.Core.Application.Skills.Models;
+
+/// <summary>Identity tuple for skill script approval decisions.</summary>
+public sealed record SkillScriptApprovalKey(
+    string SkillName,
+    string ScriptPath,
+    PeerTrustTier TrustTier,
+    string BarrierLevel,
+    string? PolicyPackId);

--- a/src/Nexo.Core.Application/Skills/Ports/INexoScriptRunner.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoScriptRunner.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Executes skill scripts under Nexo sandbox and routing policy.
+/// </summary>
+public interface INexoScriptRunner
+{
+    Task<NexoScriptRunResult> RunAsync(
+        string skillName,
+        string scriptPath,
+        string scriptAbsolutePath,
+        string scriptContentHash,
+        JsonElement? args,
+        NexoScriptRunOptions options,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoScriptSandbox.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoScriptSandbox.cs
@@ -1,0 +1,22 @@
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Swappable sandbox for local skill script execution.
+/// </summary>
+public interface INexoScriptSandbox
+{
+    Task<SandboxScriptResult> RunAsync(
+        string scriptAbsolutePath,
+        string workingDirectory,
+        TimeSpan timeout,
+        int maxOutputBytes,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Raw sandbox execution result.</summary>
+public sealed record SandboxScriptResult(
+    string StandardOutput,
+    string StandardError,
+    int ExitCode,
+    bool OutputTruncated,
+    TimeSpan Duration);

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillAgentBridge.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillAgentBridge.cs
@@ -1,0 +1,16 @@
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Builds skill advertisement text for agent system prompts (stage 1 disclosure).
+/// </summary>
+public interface INexoSkillAgentBridge
+{
+    /// <summary>
+    /// Returns markdown instructions listing visible skills for the acting context.
+    /// </summary>
+    Task<string> BuildSkillInstructionsAsync(
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalGate.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalGate.cs
@@ -1,0 +1,14 @@
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Human-in-the-loop approval gate for skill script execution.
+/// </summary>
+public interface INexoSkillApprovalGate
+{
+    Task<NexoSkillApprovalStatus> RequestApprovalAsync(
+        string actionDescription,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalResolver.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalResolver.cs
@@ -1,0 +1,14 @@
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Resolves script execution approval via policy auto-approve or human-in-the-loop gate.
+/// </summary>
+public interface INexoSkillApprovalResolver
+{
+    Task<NexoSkillApprovalStatus> ResolveScriptApprovalAsync(
+        SkillScriptApprovalKey key,
+        string description,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalStore.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalStore.cs
@@ -3,7 +3,7 @@ using Nexo.Core.Application.Skills.Models;
 namespace Nexo.Core.Application.Skills.Ports;
 
 /// <summary>
-/// Stores pending skill script approvals for operator visibility.
+/// Stores pending skill script approvals for operator visibility and human-in-the-loop waits.
 /// </summary>
 public interface INexoSkillApprovalStore
 {
@@ -11,5 +11,15 @@ public interface INexoSkillApprovalStore
 
     bool TryResolve(string requestId, NexoSkillApprovalStatus status, out NexoSkillApprovalRequest? request);
 
+    bool TryGet(string requestId, out NexoSkillApprovalRequest? request);
+
     IReadOnlyList<NexoSkillApprovalRequest> GetPending();
+
+    /// <summary>
+    /// Blocks until an operator resolves the request or the timeout elapses.
+    /// </summary>
+    Task<NexoSkillApprovalStatus> WaitForResolutionAsync(
+        string requestId,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalStore.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillApprovalStore.cs
@@ -1,0 +1,15 @@
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Stores pending skill script approvals for operator visibility.
+/// </summary>
+public interface INexoSkillApprovalStore
+{
+    NexoSkillApprovalRequest RegisterPending(SkillScriptApprovalKey key, string description);
+
+    bool TryResolve(string requestId, NexoSkillApprovalStatus status, out NexoSkillApprovalRequest? request);
+
+    IReadOnlyList<NexoSkillApprovalRequest> GetPending();
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillAuditLog.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillAuditLog.cs
@@ -1,0 +1,11 @@
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Emits structured skill disclosure audit events to configured sinks.
+/// </summary>
+public interface INexoSkillAuditLog
+{
+    void Log(NexoSkillAuditEvent auditEvent);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillCacheController.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillCacheController.cs
@@ -1,0 +1,13 @@
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Runtime-controlled skill cache invalidation (content-hash based).
+/// </summary>
+public interface INexoSkillCacheController
+{
+    void InvalidateAll();
+
+    void InvalidateIfContentChanged(string skillsRootPath);
+
+    string ComputeContentHash(string skillsRootPath);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillCatalog.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillCatalog.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Nexo-owned skill catalog exposing the four-stage progressive disclosure flow.
+/// </summary>
+public interface INexoSkillCatalog
+{
+    Task<IReadOnlyList<NexoSkillDescriptor>> AdvertiseAsync(
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default);
+
+    Task<string> LoadAsync(
+        string skillName,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default);
+
+    Task<string> ReadResourceAsync(
+        string skillName,
+        string resourcePath,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default);
+
+    Task<NexoScriptRunResult> RunScriptAsync(
+        string skillName,
+        string scriptPath,
+        JsonElement? args,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillExecutionContextFactory.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillExecutionContextFactory.cs
@@ -1,0 +1,15 @@
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Builds <see cref="NexoSkillExecutionContext"/> from ambient runtime state.
+/// </summary>
+public interface INexoSkillExecutionContextFactory
+{
+    NexoSkillExecutionContext Create(
+        PeerTrustTier trustTier,
+        string? actingIdentity = null,
+        string? correlationId = null);
+}

--- a/src/Nexo.Core.Application/Skills/Ports/INexoSkillPolicyEvaluator.cs
+++ b/src/Nexo.Core.Application/Skills/Ports/INexoSkillPolicyEvaluator.cs
@@ -1,0 +1,19 @@
+using Nexo.Core.Application.Skills.Models;
+
+namespace Nexo.Core.Application.Skills.Ports;
+
+/// <summary>
+/// Evaluates skill visibility and script governance from the active trust policy pack.
+/// </summary>
+public interface INexoSkillPolicyEvaluator
+{
+    bool IsSkillVisible(NexoSkillDescriptor skill, NexoSkillExecutionContext context);
+
+    bool IsScriptAllowed(string skillName, string scriptPath, NexoSkillExecutionContext context);
+
+    bool IsScriptAutoApproved(string skillName, string scriptPath, NexoSkillExecutionContext context);
+
+    NexoScriptRunOptions GetScriptLimits(NexoSkillExecutionContext context);
+
+    SkillPolicyRules? GetActiveSkillRules();
+}

--- a/src/Nexo.Core.Application/Skills/SkillContentHasher.cs
+++ b/src/Nexo.Core.Application/Skills/SkillContentHasher.cs
@@ -1,0 +1,14 @@
+using System.Security.Cryptography;
+
+namespace Nexo.Core.Application.Skills;
+
+/// <summary>Content hashing helpers for skill cache invalidation and audit.</summary>
+public static class SkillContentHasher
+{
+    /// <summary>Computes SHA-256 hex digest of a file's contents.</summary>
+    public static string ComputeFileHash(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream));
+    }
+}

--- a/src/Nexo.Core.Application/Trust/Models/DataDecisionAuditEntry.cs
+++ b/src/Nexo.Core.Application/Trust/Models/DataDecisionAuditEntry.cs
@@ -49,4 +49,37 @@ public sealed class DataDecisionAuditEntry
 
     /// <summary>Assigned sensitivity or trust level name.</summary>
     public string? LevelName { get; init; }
+
+    /// <summary>Skill name for skill disclosure audit events.</summary>
+    public string? SkillName { get; init; }
+
+    /// <summary>Acting identity for skill disclosure audit events.</summary>
+    public string? ActingIdentity { get; init; }
+
+    /// <summary>Barrier level for skill disclosure audit events.</summary>
+    public string? BarrierLevel { get; init; }
+
+    /// <summary>Trust tier for skill disclosure audit events.</summary>
+    public string? TrustTier { get; init; }
+
+    /// <summary>Active policy pack id for skill disclosure audit events.</summary>
+    public string? PolicyPackId { get; init; }
+
+    /// <summary>Correlation id for skill disclosure audit events.</summary>
+    public string? CorrelationId { get; init; }
+
+    /// <summary>Resource path for skill resource-read events.</summary>
+    public string? ResourcePath { get; init; }
+
+    /// <summary>Script path for skill script events.</summary>
+    public string? ScriptPath { get; init; }
+
+    /// <summary>SHA-256 hash of script content for skill script events.</summary>
+    public string? ScriptContentHash { get; init; }
+
+    /// <summary>Execution outcome for skill script events.</summary>
+    public string? Outcome { get; init; }
+
+    /// <summary>Execution duration in milliseconds for skill script events.</summary>
+    public long? DurationMs { get; init; }
 }

--- a/src/Nexo.Core.Application/Trust/Models/TrustPolicyPack.cs
+++ b/src/Nexo.Core.Application/Trust/Models/TrustPolicyPack.cs
@@ -1,3 +1,5 @@
+using Nexo.Core.Application.Skills.Models;
+
 namespace Nexo.Core.Application.Trust.Models;
 
 /// <summary>
@@ -12,6 +14,7 @@ namespace Nexo.Core.Application.Trust.Models;
 /// <param name="SourceRules">Global source allow/deny rules (true = allowed).</param>
 /// <param name="ProjectRules">Per-project source override rules.</param>
 /// <param name="RecommendedFor">Optional audience hint (e.g. enterprise, developer).</param>
+/// <param name="SkillRules">Optional agent skill visibility, script allow-list, and approval rules.</param>
 public sealed record TrustPolicyPack(
     string Id,
     string Version,
@@ -21,4 +24,5 @@ public sealed record TrustPolicyPack(
     IReadOnlyDictionary<string, bool> CategoryRules,
     IReadOnlyDictionary<string, bool> SourceRules,
     IReadOnlyList<TrustPolicyPackProjectRule> ProjectRules,
-    string? RecommendedFor = null);
+    string? RecommendedFor = null,
+    SkillPolicyRules? SkillRules = null);

--- a/src/Nexo.Core.Application/Trust/Ports/IDataDecisionAuditLog.cs
+++ b/src/Nexo.Core.Application/Trust/Ports/IDataDecisionAuditLog.cs
@@ -1,3 +1,4 @@
+using Nexo.Core.Application.Skills.Models;
 using Nexo.Core.Application.Trust.Models;
 
 namespace Nexo.Core.Application.Trust.Ports;
@@ -32,6 +33,9 @@ public interface IDataDecisionAuditLog
 
     /// <summary>Log a copilot task completion for tenant-scoped audit trails (Product Fleet Phase 0.5).</summary>
     void LogCopilotTask(string tenantId, string taskId, bool success);
+
+    /// <summary>Log a skill disclosure or script execution audit event.</summary>
+    void LogSkillDisclosure(NexoSkillAuditEvent auditEvent);
 
     /// <summary>Get recent audit entries (all types).</summary>
     IReadOnlyList<DataDecisionAuditEntry> GetRecent(int maxCount, DateTimeOffset? since = null, DateTimeOffset? until = null, string? eventType = null);

--- a/src/Nexo.Hosting/ModuleSelection.cs
+++ b/src/Nexo.Hosting/ModuleSelection.cs
@@ -17,5 +17,6 @@ internal sealed record ModuleSelection(
     bool IncludeBackgroundAgentRag,
     bool IncludeObservationPipeline,
     bool IncludeTrustServices,
+    bool IncludeSkills,
     bool IncludeWorkflowIntegrations,
     bool IncludeTestingAdapters);

--- a/src/Nexo.Hosting/Nexo.Hosting.csproj
+++ b/src/Nexo.Hosting/Nexo.Hosting.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\Nexo.Contracts\Nexo.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Transport.Grpc\Nexo.Transport.Grpc.csproj" />
     <ProjectReference Include="..\Nexo.Runtime\Nexo.Runtime.csproj" />
+    <ProjectReference Include="..\Nexo.Skills.AgentFramework\Nexo.Skills.AgentFramework.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nexo.Hosting/NexoKernelRegistrar.Phases.cs
+++ b/src/Nexo.Hosting/NexoKernelRegistrar.Phases.cs
@@ -24,12 +24,14 @@ using Nexo.Infrastructure.Execution.Ephemeral;
 using Nexo.Infrastructure.Execution.LoadPolicy;
 using Nexo.Infrastructure.Knowledge;
 using Nexo.Infrastructure.MeshLab;
+using Nexo.Infrastructure.Skills.Sdk.Extensions;
 using Nexo.Infrastructure.Persistence.Ephemeral;
 using Nexo.Orchestration;
 using Nexo.Orchestration.Models;
 using Nexo.Orchestration.Transport;
 using Nexo.Runtime;
 using Nexo.Runtime.Routing;
+using Nexo.Skills.AgentFramework;
 using Nexo.Transport.Grpc;
 
 namespace Nexo.Hosting;
@@ -413,6 +415,25 @@ internal static partial class NexoKernelRegistrar
         if (modules.IncludeTrustServices)
         {
             services.AddTrustServices(useSanitizingProviderFactory: trustEnabled, ephemeralLifecycle: ephemeralModels, skipProviderRegistration: useAdaptive);
+        }
+
+        if (modules.IncludeSkills)
+        {
+            services.AddNexoSkills();
+            services.AddNexoAgentFrameworkSkills(options =>
+            {
+                var repoRoot = RepoPathResolver.FindRepoRoot();
+                options.SkillRootPaths.Add(Path.Combine(repoRoot, "skills"));
+            });
+
+            services.TryAddSingleton<Nexo.Core.Application.Skills.Ports.INexoSkillApprovalGate>(sp =>
+            {
+                var backgroundGate = sp.GetService<Nexo.BackgroundAgents.Configuration.IApprovalGate>();
+                if (backgroundGate != null)
+                    return new Nexo.BackgroundAgents.Skills.ApprovalGateSkillApprovalBridge(backgroundGate);
+
+                return new Nexo.Infrastructure.Skills.DenySkillApprovalGate();
+            });
         }
 
         // Path A: adaptive load-balancing wraps everything

--- a/src/Nexo.Hosting/NexoKernelRegistrar.Phases.cs
+++ b/src/Nexo.Hosting/NexoKernelRegistrar.Phases.cs
@@ -425,15 +425,6 @@ internal static partial class NexoKernelRegistrar
                 var repoRoot = RepoPathResolver.FindRepoRoot();
                 options.SkillRootPaths.Add(Path.Combine(repoRoot, "skills"));
             });
-
-            services.TryAddSingleton<Nexo.Core.Application.Skills.Ports.INexoSkillApprovalGate>(sp =>
-            {
-                var backgroundGate = sp.GetService<Nexo.BackgroundAgents.Configuration.IApprovalGate>();
-                if (backgroundGate != null)
-                    return new Nexo.BackgroundAgents.Skills.ApprovalGateSkillApprovalBridge(backgroundGate);
-
-                return new Nexo.Infrastructure.Skills.DenySkillApprovalGate();
-            });
         }
 
         // Path A: adaptive load-balancing wraps everything

--- a/src/Nexo.Hosting/NexoServiceCollectionExtensions.Deployment.cs
+++ b/src/Nexo.Hosting/NexoServiceCollectionExtensions.Deployment.cs
@@ -82,6 +82,7 @@ public static partial class NexoServiceCollectionExtensions
                 IncludeBackgroundAgentRag: true,
                 IncludeObservationPipeline: true,
                 IncludeTrustServices: true,
+                IncludeSkills: true,
                 IncludeWorkflowIntegrations: true,
                 IncludeTestingAdapters: true),
             NexoDeploymentProfile.Server => new ModuleSelection(
@@ -94,6 +95,7 @@ public static partial class NexoServiceCollectionExtensions
                 IncludeBackgroundAgentRag: true,
                 IncludeObservationPipeline: true,
                 IncludeTrustServices: true,
+                IncludeSkills: true,
                 IncludeWorkflowIntegrations: true,
                 IncludeTestingAdapters: true),
             NexoDeploymentProfile.Edge => new ModuleSelection(
@@ -106,6 +108,7 @@ public static partial class NexoServiceCollectionExtensions
                 IncludeBackgroundAgentRag: false,
                 IncludeObservationPipeline: false,
                 IncludeTrustServices: false,
+                IncludeSkills: false,
                 IncludeWorkflowIntegrations: false,
                 IncludeTestingAdapters: false),
             NexoDeploymentProfile.AirGapped => new ModuleSelection(
@@ -118,6 +121,7 @@ public static partial class NexoServiceCollectionExtensions
                 IncludeBackgroundAgentRag: false,
                 IncludeObservationPipeline: false,
                 IncludeTrustServices: false,
+                IncludeSkills: false,
                 IncludeWorkflowIntegrations: false,
                 IncludeTestingAdapters: false),
             NexoDeploymentProfile.System => new ModuleSelection(
@@ -130,6 +134,7 @@ public static partial class NexoServiceCollectionExtensions
                 IncludeBackgroundAgentRag: false,
                 IncludeObservationPipeline: false,
                 IncludeTrustServices: false,
+                IncludeSkills: false,
                 IncludeWorkflowIntegrations: false,
                 IncludeTestingAdapters: false),
             _ => throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unknown Nexo deployment profile.")

--- a/src/Nexo.Infrastructure/Skills/DenySkillApprovalGate.cs
+++ b/src/Nexo.Infrastructure/Skills/DenySkillApprovalGate.cs
@@ -1,0 +1,17 @@
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Default gate that denies all skill script approvals.
+/// </summary>
+public sealed class DenySkillApprovalGate : INexoSkillApprovalGate
+{
+    /// <inheritdoc />
+    public Task<NexoSkillApprovalStatus> RequestApprovalAsync(
+        string actionDescription,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(NexoSkillApprovalStatus.Denied);
+}

--- a/src/Nexo.Infrastructure/Skills/HumanInTheLoopSkillApprovalGate.cs
+++ b/src/Nexo.Infrastructure/Skills/HumanInTheLoopSkillApprovalGate.cs
@@ -1,0 +1,19 @@
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Human-in-the-loop gate: signals the resolver to wait on
+/// <see cref="INexoSkillApprovalStore.WaitForResolutionAsync"/>.
+/// Operators resolve via CLI/API (<c>TryResolve</c>).
+/// </summary>
+public sealed class HumanInTheLoopSkillApprovalGate : INexoSkillApprovalGate
+{
+    /// <inheritdoc />
+    public Task<NexoSkillApprovalStatus> RequestApprovalAsync(
+        string actionDescription,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(NexoSkillApprovalStatus.Pending);
+}

--- a/src/Nexo.Infrastructure/Skills/InMemorySkillApprovalStore.cs
+++ b/src/Nexo.Infrastructure/Skills/InMemorySkillApprovalStore.cs
@@ -5,11 +5,12 @@ using Nexo.Core.Application.Skills.Ports;
 namespace Nexo.Infrastructure.Skills;
 
 /// <summary>
-/// In-memory pending approval store for skill script execution.
+/// In-memory pending approval store with waitable resolution for human-in-the-loop.
 /// </summary>
 public sealed class InMemorySkillApprovalStore : INexoSkillApprovalStore
 {
     private readonly ConcurrentDictionary<string, NexoSkillApprovalRequest> _requests = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<NexoSkillApprovalStatus>> _waiters = new(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
     public NexoSkillApprovalRequest RegisterPending(SkillScriptApprovalKey key, string description)
@@ -22,18 +23,37 @@ public sealed class InMemorySkillApprovalStore : INexoSkillApprovalStore
             NexoSkillApprovalStatus.Pending);
 
         _requests[request.RequestId] = request;
+        _waiters[request.RequestId] = new TaskCompletionSource<NexoSkillApprovalStatus>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         return request;
     }
+
+    /// <inheritdoc />
+    public bool TryGet(string requestId, out NexoSkillApprovalRequest? request)
+        => _requests.TryGetValue(requestId, out request);
 
     /// <inheritdoc />
     public bool TryResolve(string requestId, NexoSkillApprovalStatus status, out NexoSkillApprovalRequest? request)
     {
         request = null;
+        if (status is NexoSkillApprovalStatus.Pending or NexoSkillApprovalStatus.AutoApproved)
+            return false;
+
         if (!_requests.TryGetValue(requestId, out var existing))
             return false;
 
+        if (existing.Status != NexoSkillApprovalStatus.Pending)
+        {
+            request = existing;
+            return false;
+        }
+
         request = existing with { Status = status };
         _requests[requestId] = request;
+
+        if (_waiters.TryRemove(requestId, out var waiter))
+            waiter.TrySetResult(status);
+
         return true;
     }
 
@@ -43,4 +63,33 @@ public sealed class InMemorySkillApprovalStore : INexoSkillApprovalStore
             .Where(static request => request.Status == NexoSkillApprovalStatus.Pending)
             .OrderBy(static request => request.RequestedAt)
             .ToList();
+
+    /// <inheritdoc />
+    public async Task<NexoSkillApprovalStatus> WaitForResolutionAsync(
+        string requestId,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_requests.TryGetValue(requestId, out var existing))
+            return NexoSkillApprovalStatus.Denied;
+
+        if (existing.Status != NexoSkillApprovalStatus.Pending)
+            return existing.Status;
+
+        if (!_waiters.TryGetValue(requestId, out var waiter))
+            return NexoSkillApprovalStatus.Denied;
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+
+        try
+        {
+            return await waiter.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            TryResolve(requestId, NexoSkillApprovalStatus.TimedOut, out _);
+            return NexoSkillApprovalStatus.TimedOut;
+        }
+    }
 }

--- a/src/Nexo.Infrastructure/Skills/InMemorySkillApprovalStore.cs
+++ b/src/Nexo.Infrastructure/Skills/InMemorySkillApprovalStore.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// In-memory pending approval store for skill script execution.
+/// </summary>
+public sealed class InMemorySkillApprovalStore : INexoSkillApprovalStore
+{
+    private readonly ConcurrentDictionary<string, NexoSkillApprovalRequest> _requests = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public NexoSkillApprovalRequest RegisterPending(SkillScriptApprovalKey key, string description)
+    {
+        var request = new NexoSkillApprovalRequest(
+            Guid.NewGuid().ToString("N"),
+            key,
+            description,
+            DateTimeOffset.UtcNow,
+            NexoSkillApprovalStatus.Pending);
+
+        _requests[request.RequestId] = request;
+        return request;
+    }
+
+    /// <inheritdoc />
+    public bool TryResolve(string requestId, NexoSkillApprovalStatus status, out NexoSkillApprovalRequest? request)
+    {
+        request = null;
+        if (!_requests.TryGetValue(requestId, out var existing))
+            return false;
+
+        request = existing with { Status = status };
+        _requests[requestId] = request;
+        return true;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<NexoSkillApprovalRequest> GetPending()
+        => _requests.Values
+            .Where(static request => request.Status == NexoSkillApprovalStatus.Pending)
+            .OrderBy(static request => request.RequestedAt)
+            .ToList();
+}

--- a/src/Nexo.Infrastructure/Skills/LocalProcessScriptSandbox.cs
+++ b/src/Nexo.Infrastructure/Skills/LocalProcessScriptSandbox.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using System.Text;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Local process sandbox with timeout and output-size enforcement.
+/// </summary>
+public sealed class LocalProcessScriptSandbox : INexoScriptSandbox
+{
+    /// <inheritdoc />
+    public async Task<SandboxScriptResult> RunAsync(
+        string scriptAbsolutePath,
+        string workingDirectory,
+        TimeSpan timeout,
+        int maxOutputBytes,
+        CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(workingDirectory);
+
+        var extension = Path.GetExtension(scriptAbsolutePath).ToLowerInvariant();
+        var (fileName, arguments) = ResolveCommand(scriptAbsolutePath, extension);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+        var stopwatch = Stopwatch.StartNew();
+
+        if (!process.Start())
+        {
+            return new SandboxScriptResult(
+                string.Empty,
+                "Failed to start script process.",
+                1,
+                false,
+                stopwatch.Elapsed);
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var stdoutTask = ReadLimitedAsync(process.StandardOutput, maxOutputBytes, timeoutCts.Token);
+        var stderrTask = ReadLimitedAsync(process.StandardError, maxOutputBytes, timeoutCts.Token);
+
+        var timeoutMs = (int)Math.Clamp(timeout.TotalMilliseconds, 1, int.MaxValue);
+        var exited = await Task.Run(() => process.WaitForExit(timeoutMs), cancellationToken).ConfigureAwait(false);
+        if (!exited)
+        {
+            TryKill(process);
+            stopwatch.Stop();
+            return new SandboxScriptResult(
+                string.Empty,
+                $"Script timed out after {timeout.TotalSeconds:0}s.",
+                124,
+                false,
+                stopwatch.Elapsed);
+        }
+
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+        stopwatch.Stop();
+
+        return new SandboxScriptResult(
+            stdout.Text,
+            stderr.Text,
+            process.ExitCode,
+            stdout.Truncated || stderr.Truncated,
+            stopwatch.Elapsed);
+    }
+
+    private static (string FileName, string Arguments) ResolveCommand(string scriptAbsolutePath, string extension)
+        => extension switch
+        {
+            ".sh" => ("bash", Quote(scriptAbsolutePath)),
+            ".py" => ("python3", Quote(scriptAbsolutePath)),
+            ".ps1" => ("pwsh", $"-NoProfile -File {Quote(scriptAbsolutePath)}"),
+            _ => (scriptAbsolutePath, string.Empty),
+        };
+
+    private static string Quote(string value) => $"\"{value.Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    private static async Task<(string Text, bool Truncated)> ReadLimitedAsync(
+        StreamReader reader,
+        int maxOutputBytes,
+        CancellationToken cancellationToken)
+    {
+        var builder = new StringBuilder();
+        var buffer = new char[256];
+        var totalBytes = 0;
+        var truncated = false;
+
+        while (!reader.EndOfStream)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = await reader.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+            if (read <= 0)
+                break;
+
+            var chunk = new string(buffer, 0, read);
+            var chunkBytes = Encoding.UTF8.GetByteCount(chunk);
+            if (totalBytes + chunkBytes > maxOutputBytes)
+            {
+                var allowed = maxOutputBytes - totalBytes;
+                if (allowed > 0)
+                {
+                    var partial = TruncateToByteLimit(chunk, allowed);
+                    builder.Append(partial);
+                }
+
+                truncated = true;
+                break;
+            }
+
+            builder.Append(chunk);
+            totalBytes += chunkBytes;
+        }
+
+        return (builder.ToString(), truncated);
+    }
+
+    private static string TruncateToByteLimit(string value, int maxBytes)
+    {
+        if (maxBytes <= 0)
+            return string.Empty;
+
+        var bytes = Encoding.UTF8.GetBytes(value);
+        if (bytes.Length <= maxBytes)
+            return value;
+
+        return Encoding.UTF8.GetString(bytes, 0, maxBytes);
+    }
+}

--- a/src/Nexo.Infrastructure/Skills/NexoScriptRunner.cs
+++ b/src/Nexo.Infrastructure/Skills/NexoScriptRunner.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Nexo.Core.Application.Execution.Routing;
+using Nexo.Core.Application.Skills;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Domain;
+using Nexo.Core.Domain.Execution;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Routes skill script execution through Nexo execution-target selection with local sandbox enforcement.
+/// </summary>
+public sealed class NexoScriptRunner : INexoScriptRunner
+{
+    private readonly INexoScriptSandbox _sandbox;
+    private readonly INexoSkillPolicyEvaluator _policyEvaluator;
+    private readonly ICapabilityRouter? _capabilityRouter;
+
+    /// <summary>Initializes a new Nexo script runner.</summary>
+    public NexoScriptRunner(
+        INexoScriptSandbox sandbox,
+        INexoSkillPolicyEvaluator policyEvaluator,
+        ICapabilityRouter? capabilityRouter = null)
+    {
+        _sandbox = sandbox;
+        _policyEvaluator = policyEvaluator;
+        _capabilityRouter = capabilityRouter;
+    }
+
+    /// <inheritdoc />
+    public async Task<NexoScriptRunResult> RunAsync(
+        string skillName,
+        string scriptPath,
+        string scriptAbsolutePath,
+        string scriptContentHash,
+        JsonElement? args,
+        NexoScriptRunOptions options,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_policyEvaluator.IsScriptAllowed(skillName, scriptPath, context))
+        {
+            return new NexoScriptRunResult(
+                Output: "Script is not on the policy allow-list.",
+                ExitCode: 1,
+                Duration: TimeSpan.Zero,
+                OutputTruncated: false,
+                ScriptContentHash: scriptContentHash,
+                Outcome: "denied");
+        }
+
+        if (!File.Exists(scriptAbsolutePath))
+        {
+            return new NexoScriptRunResult(
+                Output: $"Script not found: {scriptAbsolutePath}",
+                ExitCode: 1,
+                Duration: TimeSpan.Zero,
+                OutputTruncated: false,
+                ScriptContentHash: scriptContentHash,
+                Outcome: "failure");
+        }
+
+        var hash = string.IsNullOrWhiteSpace(scriptContentHash)
+            ? SkillContentHasher.ComputeFileHash(scriptAbsolutePath)
+            : scriptContentHash;
+
+        var target = _capabilityRouter?.ResolveExecutionTarget(new JobRequirements
+        {
+            MinimumVramBytes = 0,
+            ComputeClass = GpuComputeClass.Low,
+            RemoteExecutionPreference = RemoteExecutionPreference.UseSystemDefault,
+        });
+
+        if (target is ExecutionTarget.Remote)
+        {
+            return new NexoScriptRunResult(
+                Output: "Remote skill script execution is not supported in this phase.",
+                ExitCode: 1,
+                Duration: TimeSpan.Zero,
+                OutputTruncated: false,
+                ScriptContentHash: hash,
+                Outcome: "denied");
+        }
+
+        var workingDirectory = CreateIsolatedWorkingDirectory(options.WorkingDirectoryRoot, skillName, hash);
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            WriteArgsFile(workingDirectory, args);
+            var sandboxResult = await _sandbox.RunAsync(
+                scriptAbsolutePath,
+                workingDirectory,
+                options.Timeout,
+                options.MaxOutputBytes,
+                cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+
+            var output = CombineOutput(sandboxResult.StandardOutput, sandboxResult.StandardError);
+            var outcome = sandboxResult.ExitCode == 0
+                ? sandboxResult.OutputTruncated ? "truncated" : "success"
+                : "failure";
+
+            return new NexoScriptRunResult(
+                Output: output,
+                ExitCode: sandboxResult.ExitCode,
+                Duration: stopwatch.Elapsed,
+                OutputTruncated: sandboxResult.OutputTruncated,
+                ScriptContentHash: hash,
+                Outcome: outcome);
+        }
+        finally
+        {
+            TryDeleteDirectory(workingDirectory);
+        }
+    }
+
+    private static string CreateIsolatedWorkingDirectory(string root, string skillName, string hash)
+    {
+        var directory = Path.Combine(
+            root,
+            "nexo-skill-runs",
+            Sanitize(skillName),
+            hash[..Math.Min(12, hash.Length)]);
+
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void WriteArgsFile(string workingDirectory, JsonElement? args)
+    {
+        if (args == null)
+            return;
+
+        var path = Path.Combine(workingDirectory, "args.json");
+        File.WriteAllText(path, args.Value.GetRawText());
+    }
+
+    private static string CombineOutput(string stdout, string stderr)
+    {
+        if (string.IsNullOrWhiteSpace(stderr))
+            return stdout;
+        if (string.IsNullOrWhiteSpace(stdout))
+            return stderr;
+        return stdout + Environment.NewLine + stderr;
+    }
+
+    private static string Sanitize(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+            builder.Append(invalid.Contains(ch) ? '_' : ch);
+        return builder.ToString();
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Nexo.Infrastructure/Skills/NexoSkillExecutionContextFactory.cs
+++ b/src/Nexo.Infrastructure/Skills/NexoSkillExecutionContextFactory.cs
@@ -1,0 +1,42 @@
+using Nexo.Abstractions.Barriers;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Trust.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Builds skill execution context from barrier identity and active policy pack.
+/// </summary>
+public sealed class NexoSkillExecutionContextFactory : INexoSkillExecutionContextFactory
+{
+    private readonly IBarrierContextAccessor _barrierContextAccessor;
+    private readonly ITrustPolicyPackRegistry _policyPackRegistry;
+
+    /// <summary>Initializes a new skill execution context factory.</summary>
+    public NexoSkillExecutionContextFactory(
+        IBarrierContextAccessor barrierContextAccessor,
+        ITrustPolicyPackRegistry policyPackRegistry)
+    {
+        _barrierContextAccessor = barrierContextAccessor;
+        _policyPackRegistry = policyPackRegistry;
+    }
+
+    /// <inheritdoc />
+    public NexoSkillExecutionContext Create(
+        PeerTrustTier trustTier,
+        string? actingIdentity = null,
+        string? correlationId = null)
+    {
+        var barrier = _barrierContextAccessor.Current;
+        var activePack = _policyPackRegistry.GetActivePack();
+
+        return new NexoSkillExecutionContext(
+            ActingIdentity: actingIdentity ?? barrier?.IssuedTo ?? "unknown",
+            BarrierLevel: barrier?.Level ?? "public",
+            TrustTier: trustTier,
+            PolicyPackId: activePack?.Id,
+            CorrelationId: correlationId ?? barrier?.CorrelationId ?? Guid.NewGuid().ToString("N"));
+    }
+}

--- a/src/Nexo.Infrastructure/Skills/Sdk/Extensions/SkillsServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Skills/Sdk/Extensions/SkillsServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ public static class SkillsServiceCollectionExtensions
         services.TryAddSingleton<INexoScriptSandbox, LocalProcessScriptSandbox>();
         services.TryAddSingleton<INexoScriptRunner, NexoScriptRunner>();
         services.TryAddSingleton<INexoSkillApprovalStore, InMemorySkillApprovalStore>();
-        services.TryAddSingleton<INexoSkillApprovalGate, DenySkillApprovalGate>();
+        services.TryAddSingleton<INexoSkillApprovalGate, HumanInTheLoopSkillApprovalGate>();
         services.TryAddSingleton<INexoSkillApprovalResolver, SkillApprovalResolver>();
         services.TryAddSingleton<INexoSkillAuditLog, SkillAuditEmitter>();
         services.TryAddSingleton<INexoSkillCacheController, SkillContentHashCacheController>();

--- a/src/Nexo.Infrastructure/Skills/Sdk/Extensions/SkillsServiceCollectionExtensions.cs
+++ b/src/Nexo.Infrastructure/Skills/Sdk/Extensions/SkillsServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Infrastructure.Skills;
+
+namespace Nexo.Infrastructure.Skills.Sdk.Extensions;
+
+/// <summary>
+/// DI registration for Nexo skill infrastructure services.
+/// </summary>
+public static class SkillsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers Nexo skill policy, runner, approval, audit, and cache services.
+    /// </summary>
+    public static IServiceCollection AddNexoSkills(this IServiceCollection services)
+    {
+        services.TryAddSingleton<INexoSkillPolicyEvaluator, SkillPolicyEvaluator>();
+        services.TryAddSingleton<INexoScriptSandbox, LocalProcessScriptSandbox>();
+        services.TryAddSingleton<INexoScriptRunner, NexoScriptRunner>();
+        services.TryAddSingleton<INexoSkillApprovalStore, InMemorySkillApprovalStore>();
+        services.TryAddSingleton<INexoSkillApprovalGate, DenySkillApprovalGate>();
+        services.TryAddSingleton<INexoSkillApprovalResolver, SkillApprovalResolver>();
+        services.TryAddSingleton<INexoSkillAuditLog, SkillAuditEmitter>();
+        services.TryAddSingleton<INexoSkillCacheController, SkillContentHashCacheController>();
+        services.TryAddSingleton<INexoSkillExecutionContextFactory, NexoSkillExecutionContextFactory>();
+        return services;
+    }
+}

--- a/src/Nexo.Infrastructure/Skills/SkillApprovalResolver.cs
+++ b/src/Nexo.Infrastructure/Skills/SkillApprovalResolver.cs
@@ -1,0 +1,51 @@
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Trust.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Resolves skill script approval via policy auto-approve or the human-in-the-loop gate.
+/// </summary>
+public sealed class SkillApprovalResolver : INexoSkillApprovalResolver
+{
+    private readonly INexoSkillPolicyEvaluator _policyEvaluator;
+    private readonly INexoSkillApprovalStore _approvalStore;
+    private readonly INexoSkillApprovalGate _approvalGate;
+    private readonly TimeSpan _approvalTimeout;
+
+    /// <summary>Initializes a new skill approval resolver.</summary>
+    public SkillApprovalResolver(
+        INexoSkillPolicyEvaluator policyEvaluator,
+        INexoSkillApprovalStore approvalStore,
+        INexoSkillApprovalGate approvalGate,
+        TimeSpan? approvalTimeout = null)
+    {
+        _policyEvaluator = policyEvaluator;
+        _approvalStore = approvalStore;
+        _approvalGate = approvalGate;
+        _approvalTimeout = approvalTimeout ?? TimeSpan.FromMinutes(5);
+    }
+
+    /// <inheritdoc />
+    public async Task<NexoSkillApprovalStatus> ResolveScriptApprovalAsync(
+        SkillScriptApprovalKey key,
+        string description,
+        CancellationToken cancellationToken = default)
+    {
+        if (_policyEvaluator.IsScriptAutoApproved(key.SkillName, key.ScriptPath, CreateContext(key)))
+            return NexoSkillApprovalStatus.AutoApproved;
+
+        _approvalStore.RegisterPending(key, description);
+        return await _approvalGate.RequestApprovalAsync(description, _approvalTimeout, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static NexoSkillExecutionContext CreateContext(SkillScriptApprovalKey key)
+        => new(
+            ActingIdentity: "skill-approval",
+            BarrierLevel: key.BarrierLevel,
+            TrustTier: key.TrustTier,
+            PolicyPackId: key.PolicyPackId,
+            CorrelationId: Guid.NewGuid().ToString("N"));
+}

--- a/src/Nexo.Infrastructure/Skills/SkillApprovalResolver.cs
+++ b/src/Nexo.Infrastructure/Skills/SkillApprovalResolver.cs
@@ -1,11 +1,11 @@
 using Nexo.Core.Application.Skills.Models;
 using Nexo.Core.Application.Skills.Ports;
-using Nexo.Core.Application.Trust.Ports;
 
 namespace Nexo.Infrastructure.Skills;
 
 /// <summary>
-/// Resolves skill script approval via policy auto-approve or the human-in-the-loop gate.
+/// Resolves skill script approval via policy auto-approve, immediate gate decision,
+/// or human-in-the-loop wait on the approval store.
 /// </summary>
 public sealed class SkillApprovalResolver : INexoSkillApprovalResolver
 {
@@ -36,9 +36,18 @@ public sealed class SkillApprovalResolver : INexoSkillApprovalResolver
         if (_policyEvaluator.IsScriptAutoApproved(key.SkillName, key.ScriptPath, CreateContext(key)))
             return NexoSkillApprovalStatus.AutoApproved;
 
-        _approvalStore.RegisterPending(key, description);
-        return await _approvalGate.RequestApprovalAsync(description, _approvalTimeout, cancellationToken)
+        var pending = _approvalStore.RegisterPending(key, description);
+        var gateResult = await _approvalGate.RequestApprovalAsync(description, _approvalTimeout, cancellationToken)
             .ConfigureAwait(false);
+
+        if (gateResult == NexoSkillApprovalStatus.Pending)
+        {
+            return await _approvalStore.WaitForResolutionAsync(pending.RequestId, _approvalTimeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        _approvalStore.TryResolve(pending.RequestId, gateResult, out _);
+        return gateResult;
     }
 
     private static NexoSkillExecutionContext CreateContext(SkillScriptApprovalKey key)

--- a/src/Nexo.Infrastructure/Skills/SkillAuditEmitter.cs
+++ b/src/Nexo.Infrastructure/Skills/SkillAuditEmitter.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using Nexo.Abstractions.Barriers;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Trust.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Emits skill audit events to barrier and data-decision audit sinks.
+/// </summary>
+public sealed class SkillAuditEmitter : INexoSkillAuditLog
+{
+    private readonly IBarrierAuditLog? _barrierAuditLog;
+    private readonly IDataDecisionAuditLog? _dataDecisionAuditLog;
+
+    /// <summary>Initializes a new skill audit emitter.</summary>
+    public SkillAuditEmitter(
+        IBarrierAuditLog? barrierAuditLog = null,
+        IDataDecisionAuditLog? dataDecisionAuditLog = null)
+    {
+        _barrierAuditLog = barrierAuditLog;
+        _dataDecisionAuditLog = dataDecisionAuditLog;
+    }
+
+    /// <inheritdoc />
+    public void Log(NexoSkillAuditEvent auditEvent)
+    {
+        if (_barrierAuditLog != null)
+        {
+            _ = _barrierAuditLog.RecordAsync(new BarrierAuditEvent(
+                auditEvent.EventType,
+                auditEvent.BarrierLevel,
+                auditEvent.ActingIdentity,
+                auditEvent.SkillName,
+                auditEvent.CorrelationId,
+                string.Empty,
+                auditEvent.OccurredAt,
+                BuildDetail(auditEvent)));
+        }
+
+        _dataDecisionAuditLog?.LogSkillDisclosure(auditEvent);
+    }
+
+    private static string BuildDetail(NexoSkillAuditEvent auditEvent)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["trustTier"] = auditEvent.TrustTier,
+            ["policyPackId"] = auditEvent.PolicyPackId,
+            ["resourcePath"] = auditEvent.ResourcePath,
+            ["scriptPath"] = auditEvent.ScriptPath,
+            ["scriptContentHash"] = auditEvent.ScriptContentHash,
+            ["outcome"] = auditEvent.Outcome,
+            ["durationMs"] = auditEvent.DurationMs,
+            ["detail"] = auditEvent.Detail,
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+}

--- a/src/Nexo.Infrastructure/Skills/SkillContentHashCacheController.cs
+++ b/src/Nexo.Infrastructure/Skills/SkillContentHashCacheController.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Content-hash based skill cache invalidation controller.
+/// </summary>
+public sealed class SkillContentHashCacheController : INexoSkillCacheController
+{
+    private readonly ConcurrentDictionary<string, string> _hashes = new(StringComparer.OrdinalIgnoreCase);
+    private int _globalGeneration;
+
+    /// <inheritdoc />
+    public void InvalidateAll() => Interlocked.Increment(ref _globalGeneration);
+
+    /// <inheritdoc />
+    public void InvalidateIfContentChanged(string skillsRootPath)
+    {
+        if (string.IsNullOrWhiteSpace(skillsRootPath))
+            return;
+
+        var fullPath = Path.GetFullPath(skillsRootPath);
+        var hash = ComputeContentHash(fullPath);
+        _hashes.AddOrUpdate(fullPath, hash, (_, previous) =>
+        {
+            if (!string.Equals(previous, hash, StringComparison.Ordinal))
+                Interlocked.Increment(ref _globalGeneration);
+            return hash;
+        });
+    }
+
+    /// <inheritdoc />
+    public string ComputeContentHash(string skillsRootPath)
+    {
+        if (string.IsNullOrWhiteSpace(skillsRootPath) || !Directory.Exists(skillsRootPath))
+            return string.Empty;
+
+        var builder = new StringBuilder();
+        builder.Append(_globalGeneration);
+        builder.Append('|');
+
+        foreach (var file in Directory.EnumerateFiles(skillsRootPath, "*", SearchOption.AllDirectories)
+                     .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase))
+        {
+            var info = new FileInfo(file);
+            builder.Append(info.FullName);
+            builder.Append(':');
+            builder.Append(info.Length);
+            builder.Append(':');
+            builder.Append(info.LastWriteTimeUtc.Ticks);
+            builder.Append(';');
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/src/Nexo.Infrastructure/Skills/SkillPolicyEvaluator.cs
+++ b/src/Nexo.Infrastructure/Skills/SkillPolicyEvaluator.cs
@@ -1,0 +1,134 @@
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Trust.Ports;
+
+namespace Nexo.Infrastructure.Skills;
+
+/// <summary>
+/// Evaluates skill visibility and script governance from the active trust policy pack.
+/// </summary>
+public sealed class SkillPolicyEvaluator : INexoSkillPolicyEvaluator
+{
+    private static readonly NexoScriptRunOptions DefaultLimits = new(
+        Timeout: TimeSpan.FromSeconds(30),
+        MaxOutputBytes: 65_536,
+        WorkingDirectoryRoot: Path.GetTempPath());
+
+    private readonly ITrustPolicyPackRegistry _policyPackRegistry;
+
+    /// <summary>Initializes a new skill policy evaluator.</summary>
+    public SkillPolicyEvaluator(ITrustPolicyPackRegistry policyPackRegistry)
+        => _policyPackRegistry = policyPackRegistry;
+
+    /// <inheritdoc />
+    public SkillPolicyRules? GetActiveSkillRules()
+    {
+        var active = _policyPackRegistry.GetActivePack();
+        if (active == null)
+            return null;
+
+        return _policyPackRegistry.GetById(active.Id)?.SkillRules;
+    }
+
+    /// <inheritdoc />
+    public bool IsSkillVisible(NexoSkillDescriptor skill, NexoSkillExecutionContext context)
+    {
+        var rules = ResolveRules(context);
+        if (rules?.Visibility == null || rules.Visibility.Count == 0)
+            return true;
+
+        var tierKey = context.TrustTier.ToString();
+        if (!rules.Visibility.TryGetValue(tierKey, out var tierRules))
+            return false;
+
+        if (MatchesAnyPattern(skill.Name, tierRules.Deny))
+            return false;
+
+        if (tierRules.Allow.Count == 0)
+            return true;
+
+        return MatchesAnyPattern(skill.Name, tierRules.Allow);
+    }
+
+    /// <inheritdoc />
+    public bool IsScriptAllowed(string skillName, string scriptPath, NexoSkillExecutionContext context)
+    {
+        var rules = ResolveRules(context);
+        if (rules?.AllowedScripts == null || rules.AllowedScripts.Count == 0)
+            return true;
+
+        if (!rules.AllowedScripts.TryGetValue(skillName, out var allowed))
+            return false;
+
+        return allowed.Any(pattern => MatchesScriptPattern(scriptPath, pattern));
+    }
+
+    /// <inheritdoc />
+    public bool IsScriptAutoApproved(string skillName, string scriptPath, NexoSkillExecutionContext context)
+    {
+        var rules = ResolveRules(context);
+        if (rules?.AutoApproveScripts == null)
+            return false;
+
+        var tier = context.TrustTier.ToString();
+        return rules.AutoApproveScripts.Any(rule =>
+            string.Equals(rule.Skill, skillName, StringComparison.OrdinalIgnoreCase)
+            && MatchesScriptPattern(scriptPath, rule.Script)
+            && rule.Tiers.Any(t => string.Equals(t, tier, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <inheritdoc />
+    public NexoScriptRunOptions GetScriptLimits(NexoSkillExecutionContext context)
+    {
+        var rules = ResolveRules(context);
+        if (rules?.ScriptLimits == null)
+            return DefaultLimits;
+
+        return new NexoScriptRunOptions(
+            Timeout: TimeSpan.FromSeconds(Math.Max(1, rules.ScriptLimits.TimeoutSeconds)),
+            MaxOutputBytes: Math.Max(1024, rules.ScriptLimits.MaxOutputBytes),
+            WorkingDirectoryRoot: DefaultLimits.WorkingDirectoryRoot);
+    }
+
+    private SkillPolicyRules? ResolveRules(NexoSkillExecutionContext context)
+    {
+        if (!string.IsNullOrWhiteSpace(context.PolicyPackId))
+        {
+            var pack = _policyPackRegistry.GetById(context.PolicyPackId);
+            if (pack?.SkillRules != null)
+                return pack.SkillRules;
+        }
+
+        return GetActiveSkillRules();
+    }
+
+    private static bool MatchesAnyPattern(string value, IReadOnlyList<string> patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            if (string.Equals(pattern, "*", StringComparison.Ordinal))
+                return true;
+
+            if (pattern.EndsWith("*", StringComparison.Ordinal))
+            {
+                var prefix = pattern[..^1];
+                if (value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            else if (string.Equals(value, pattern, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesScriptPattern(string scriptPath, string pattern)
+    {
+        var normalizedScript = scriptPath.Replace('\\', '/');
+        var normalizedPattern = pattern.Replace('\\', '/');
+        return string.Equals(normalizedScript, normalizedPattern, StringComparison.OrdinalIgnoreCase)
+            || normalizedScript.EndsWith('/' + normalizedPattern.TrimStart('/'), StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Nexo.Skills.AgentFramework/AgentFrameworkScriptRunnerBridge.cs
+++ b/src/Nexo.Skills.AgentFramework/AgentFrameworkScriptRunnerBridge.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Nexo.Core.Application.Skills;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.Skills.AgentFramework;
+
+/// <summary>
+/// Bridges Microsoft Agent Skills script runner delegate to Nexo script execution.
+/// </summary>
+public sealed class AgentFrameworkScriptRunnerBridge
+{
+    private readonly INexoScriptRunner _scriptRunner;
+    private readonly INexoSkillPolicyEvaluator _policyEvaluator;
+    private readonly AsyncLocal<NexoSkillExecutionContext?> _context = new();
+
+    /// <summary>Initializes a new script runner bridge.</summary>
+    public AgentFrameworkScriptRunnerBridge(
+        INexoScriptRunner scriptRunner,
+        INexoSkillPolicyEvaluator policyEvaluator)
+    {
+        _scriptRunner = scriptRunner;
+        _policyEvaluator = policyEvaluator;
+    }
+
+    /// <summary>Sets the Nexo execution context for the current async flow.</summary>
+    public IDisposable BindContext(NexoSkillExecutionContext context)
+    {
+        var previous = _context.Value;
+        _context.Value = context;
+        return new ContextScope(_context, previous);
+    }
+
+    /// <summary>Microsoft Agent Skills script runner delegate implementation.</summary>
+    public async Task<object?> RunAsync(
+        AgentFileSkill skill,
+        AgentFileSkillScript script,
+        JsonElement? args,
+        IServiceProvider? serviceProvider,
+        CancellationToken cancellationToken = default)
+    {
+        var context = _context.Value
+            ?? throw new InvalidOperationException("Nexo skill execution context is not bound.");
+
+        var scriptPath = script.Name;
+        var absolutePath = ResolveScriptPath(skill, scriptPath);
+        var hash = SkillContentHasher.ComputeFileHash(absolutePath);
+        var limits = _policyEvaluator.GetScriptLimits(context);
+
+        var result = await _scriptRunner.RunAsync(
+            skill.Frontmatter.Name,
+            scriptPath,
+            absolutePath,
+            hash,
+            args,
+            limits,
+            context,
+            cancellationToken).ConfigureAwait(false);
+
+        return (object?)result.Output;
+    }
+
+    private static string ResolveScriptPath(AgentFileSkill skill, string scriptPath)
+    {
+        if (Path.IsPathRooted(scriptPath))
+            return scriptPath;
+
+        var skillRoot = skill.Path ?? throw new InvalidOperationException("File skill path is unavailable.");
+        return Path.GetFullPath(Path.Combine(skillRoot, scriptPath));
+    }
+
+    private sealed class ContextScope : IDisposable
+    {
+        private readonly AsyncLocal<NexoSkillExecutionContext?> _holder;
+        private readonly NexoSkillExecutionContext? _previous;
+        private bool _disposed;
+
+        public ContextScope(AsyncLocal<NexoSkillExecutionContext?> holder, NexoSkillExecutionContext? previous)
+        {
+            _holder = holder;
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _holder.Value = _previous;
+            _disposed = true;
+        }
+    }
+}

--- a/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillCatalog.cs
+++ b/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillCatalog.cs
@@ -1,0 +1,345 @@
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Core.Application.Skills;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Skills.AgentFramework.ClassSkills;
+
+namespace Nexo.Skills.AgentFramework;
+
+/// <summary>
+/// Nexo skill catalog adapter over Microsoft Agent Skills provider builder.
+/// </summary>
+public sealed class AgentFrameworkSkillCatalog : INexoSkillCatalog, IDisposable
+{
+    private readonly AgentSkillsProvider _provider;
+    private readonly AgentSkillsSource _source;
+    private readonly INexoSkillPolicyEvaluator _policyEvaluator;
+    private readonly INexoSkillAuditLog _auditLog;
+    private readonly INexoSkillApprovalResolver _approvalResolver;
+    private readonly AgentFrameworkScriptRunnerBridge _scriptRunnerBridge;
+    private readonly ILoggerFactory _loggerFactory;
+    private bool _disposed;
+
+    /// <summary>Initializes a new Agent Framework skill catalog.</summary>
+    public AgentFrameworkSkillCatalog(
+        IOptions<NexoSkillsOptions> options,
+        INexoSkillPolicyEvaluator policyEvaluator,
+        INexoSkillAuditLog auditLog,
+        INexoSkillApprovalResolver approvalResolver,
+        AgentFrameworkScriptRunnerBridge scriptRunnerBridge,
+        INexoSkillCacheController cacheController,
+        NexoActivePolicyPackSkill classSkill,
+        ILoggerFactory? loggerFactory = null)
+    {
+        _policyEvaluator = policyEvaluator;
+        _auditLog = auditLog;
+        _approvalResolver = approvalResolver;
+        _scriptRunnerBridge = scriptRunnerBridge;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+
+        var skillRoots = options.Value.SkillRootPaths
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        _source = BuildSourcePipeline(skillRoots, cacheController, scriptRunnerBridge, classSkill, _loggerFactory);
+        _provider = new AgentSkillsProvider(
+            _source,
+            new AgentSkillsProviderOptions
+            {
+                DisableLoadSkillApproval = true,
+                DisableReadSkillResourceApproval = true,
+                DisableRunSkillScriptApproval = false,
+            },
+            _loggerFactory,
+            ownsSource: true);
+    }
+
+    /// <summary>Exposes the underlying Microsoft Agent Skills provider for agent wiring.</summary>
+    public AgentSkillsProvider Provider => _provider;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<NexoSkillDescriptor>> AdvertiseAsync(
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using (_scriptRunnerBridge.BindContext(context))
+        {
+            var skills = await _source.GetSkillsAsync(CreateSourceContext(), cancellationToken).ConfigureAwait(false);
+            var visible = skills
+                .Select(MapDescriptor)
+                .Where(descriptor => _policyEvaluator.IsSkillVisible(descriptor, context))
+                .ToList();
+
+            foreach (var descriptor in visible)
+            {
+                EmitAudit(
+                    NexoSkillAuditEventType.SkillAdvertised,
+                    descriptor.Name,
+                    context,
+                    detail: descriptor.Description);
+            }
+
+            return visible;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string> LoadAsync(
+        string skillName,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using (_scriptRunnerBridge.BindContext(context))
+        {
+            var skill = await FindSkillAsync(skillName, context, cancellationToken).ConfigureAwait(false);
+            var content = await skill.GetContentAsync(cancellationToken).ConfigureAwait(false);
+            EmitAudit(NexoSkillAuditEventType.SkillLoaded, skillName, context);
+            return content;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ReadResourceAsync(
+        string skillName,
+        string resourcePath,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using (_scriptRunnerBridge.BindContext(context))
+        {
+            var skill = await FindSkillAsync(skillName, context, cancellationToken).ConfigureAwait(false);
+            var resource = await skill.GetResourceAsync(resourcePath, cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Resource '{resourcePath}' was not found in skill '{skillName}'.");
+            var content = await resource.ReadAsync(serviceProvider: null, cancellationToken).ConfigureAwait(false);
+            var text = content?.ToString() ?? string.Empty;
+            EmitAudit(
+                NexoSkillAuditEventType.SkillResourceRead,
+                skillName,
+                context,
+                resourcePath: resourcePath);
+            return text;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<NexoScriptRunResult> RunScriptAsync(
+        string skillName,
+        string scriptPath,
+        JsonElement? args,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using (_scriptRunnerBridge.BindContext(context))
+        {
+            var skill = await FindSkillAsync(skillName, context, cancellationToken).ConfigureAwait(false);
+            var script = await skill.GetScriptAsync(scriptPath, cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Script '{scriptPath}' was not found in skill '{skillName}'.");
+
+            var absolutePath = ResolveScriptAbsolutePath(skill, scriptPath);
+            var hash = File.Exists(absolutePath)
+                ? SkillContentHasher.ComputeFileHash(absolutePath)
+                : string.Empty;
+
+            var approvalKey = new SkillScriptApprovalKey(
+                skillName,
+                scriptPath,
+                context.TrustTier,
+                context.BarrierLevel,
+                context.PolicyPackId);
+
+            EmitAudit(
+                NexoSkillAuditEventType.SkillScriptApprovalRequested,
+                skillName,
+                context,
+                scriptPath: scriptPath,
+                scriptContentHash: hash);
+
+            var approval = await _approvalResolver.ResolveScriptApprovalAsync(
+                approvalKey,
+                $"Run skill script {skillName}:{scriptPath}",
+                cancellationToken).ConfigureAwait(false);
+
+            EmitAudit(
+                NexoSkillAuditEventType.SkillScriptApprovalResolved,
+                skillName,
+                context,
+                scriptPath: scriptPath,
+                scriptContentHash: hash,
+                outcome: approval.ToString());
+
+            if (approval is NexoSkillApprovalStatus.Denied or NexoSkillApprovalStatus.TimedOut or NexoSkillApprovalStatus.Pending)
+            {
+                return new NexoScriptRunResult(
+                    Output: $"Script approval {approval}.",
+                    ExitCode: 1,
+                    Duration: TimeSpan.Zero,
+                    OutputTruncated: false,
+                    ScriptContentHash: hash,
+                    Outcome: approval.ToString().ToLowerInvariant());
+            }
+
+            var started = DateTimeOffset.UtcNow;
+            object? output;
+            try
+            {
+                output = await script.RunAsync(skill, args, serviceProvider: null, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                var failed = DateTimeOffset.UtcNow - started;
+                EmitAudit(
+                    NexoSkillAuditEventType.SkillScriptExecuted,
+                    skillName,
+                    context,
+                    scriptPath: scriptPath,
+                    scriptContentHash: hash,
+                    outcome: "failure",
+                    durationMs: (long)failed.TotalMilliseconds,
+                    detail: ex.Message);
+
+                return new NexoScriptRunResult(
+                    Output: ex.Message,
+                    ExitCode: 1,
+                    Duration: failed,
+                    OutputTruncated: false,
+                    ScriptContentHash: hash,
+                    Outcome: "failure");
+            }
+
+            var duration = DateTimeOffset.UtcNow - started;
+            var text = output?.ToString() ?? string.Empty;
+            EmitAudit(
+                NexoSkillAuditEventType.SkillScriptExecuted,
+                skillName,
+                context,
+                scriptPath: scriptPath,
+                scriptContentHash: hash,
+                outcome: "success",
+                durationMs: (long)duration.TotalMilliseconds);
+
+            return new NexoScriptRunResult(
+                Output: text,
+                ExitCode: 0,
+                Duration: duration,
+                OutputTruncated: false,
+                ScriptContentHash: hash,
+                Outcome: "success");
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _provider.Dispose();
+        _disposed = true;
+    }
+
+    private async Task<AgentSkill> FindSkillAsync(
+        string skillName,
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        var skills = await _source.GetSkillsAsync(CreateSourceContext(), cancellationToken).ConfigureAwait(false);
+        var skill = skills.FirstOrDefault(item =>
+            string.Equals(item.Frontmatter.Name, skillName, StringComparison.OrdinalIgnoreCase));
+
+        if (skill == null)
+            throw new InvalidOperationException($"Skill '{skillName}' was not found.");
+
+        var descriptor = MapDescriptor(skill);
+        if (!_policyEvaluator.IsSkillVisible(descriptor, context))
+            throw new InvalidOperationException($"Skill '{skillName}' is not visible for the current trust context.");
+
+        return skill;
+    }
+
+    private static AgentSkillsSource BuildSourcePipeline(
+        IReadOnlyList<string> skillRoots,
+        INexoSkillCacheController cacheController,
+        AgentFrameworkScriptRunnerBridge scriptRunnerBridge,
+        NexoActivePolicyPackSkill classSkill,
+        ILoggerFactory loggerFactory)
+    {
+        AgentSkillsSource source = new AgentInMemorySkillsSource([classSkill]);
+        if (skillRoots.Count > 0)
+        {
+            source = new AggregatingAgentSkillsSource(
+            [
+                source,
+                new AgentFileSkillsSource(skillRoots, scriptRunnerBridge.RunAsync, null, loggerFactory),
+            ]);
+        }
+
+        source = new CachingAgentSkillsSource(source);
+        source = new ContentHashInvalidatingSkillsSource(source, cacheController, skillRoots);
+        source = new DeduplicatingAgentSkillsSource(source, loggerFactory);
+        return source;
+    }
+
+    private static AgentSkillsSourceContext CreateSourceContext()
+        => CatalogSourceContextFactory.Create();
+
+    private static NexoSkillDescriptor MapDescriptor(AgentSkill skill)
+    {
+        var allowedTools = skill.Frontmatter.AllowedTools;
+        IReadOnlyList<string>? tools = string.IsNullOrWhiteSpace(allowedTools)
+            ? null
+            : allowedTools.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return new NexoSkillDescriptor(
+            Name: skill.Frontmatter.Name,
+            Description: skill.Frontmatter.Description,
+            License: skill.Frontmatter.License,
+            Compatibility: skill.Frontmatter.Compatibility,
+            AllowedTools: tools);
+    }
+
+    private static string ResolveScriptAbsolutePath(AgentSkill skill, string scriptPath)
+    {
+        if (skill is AgentFileSkill fileSkill && !string.IsNullOrWhiteSpace(fileSkill.Path))
+        {
+            if (Path.IsPathRooted(scriptPath))
+                return scriptPath;
+            return Path.GetFullPath(Path.Combine(fileSkill.Path, scriptPath));
+        }
+
+        return scriptPath;
+    }
+
+    private void EmitAudit(
+        string eventType,
+        string skillName,
+        NexoSkillExecutionContext context,
+        string? resourcePath = null,
+        string? scriptPath = null,
+        string? scriptContentHash = null,
+        string? outcome = null,
+        long? durationMs = null,
+        string? detail = null)
+    {
+        _auditLog.Log(new NexoSkillAuditEvent(
+            eventType,
+            skillName,
+            context.ActingIdentity,
+            context.BarrierLevel,
+            context.TrustTier.ToString(),
+            context.PolicyPackId,
+            context.CorrelationId,
+            DateTimeOffset.UtcNow,
+            resourcePath,
+            scriptPath,
+            scriptContentHash,
+            outcome,
+            durationMs,
+            detail));
+    }
+}

--- a/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillCatalog.cs
+++ b/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillCatalog.cs
@@ -13,7 +13,7 @@ namespace Nexo.Skills.AgentFramework;
 /// <summary>
 /// Nexo skill catalog adapter over Microsoft Agent Skills provider builder.
 /// </summary>
-public sealed class AgentFrameworkSkillCatalog : INexoSkillCatalog, IDisposable
+public sealed class AgentFrameworkSkillCatalog : INexoSkillCatalog, INexoSkillAgentBridge, IDisposable
 {
     private readonly AgentSkillsProvider _provider;
     private readonly AgentSkillsSource _source;
@@ -62,6 +62,28 @@ public sealed class AgentFrameworkSkillCatalog : INexoSkillCatalog, IDisposable
 
     /// <summary>Exposes the underlying Microsoft Agent Skills provider for agent wiring.</summary>
     public AgentSkillsProvider Provider => _provider;
+
+    /// <inheritdoc />
+    public async Task<string> BuildSkillInstructionsAsync(
+        NexoSkillExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var skills = await AdvertiseAsync(context, cancellationToken).ConfigureAwait(false);
+        if (skills.Count == 0)
+            return string.Empty;
+
+        var lines = new List<string>
+        {
+            "## Available Nexo skills",
+            "Use load_skill / read_skill_resource / run_skill_script to progressively disclose capability packages.",
+            string.Empty,
+        };
+
+        foreach (var skill in skills)
+            lines.Add($"- **{skill.Name}**: {skill.Description}");
+
+        return string.Join(Environment.NewLine, lines);
+    }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<NexoSkillDescriptor>> AdvertiseAsync(

--- a/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillsServiceCollectionExtensions.cs
+++ b/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillsServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Skills.AgentFramework.ClassSkills;
+
+namespace Nexo.Skills.AgentFramework;
+
+/// <summary>
+/// DI registration for the Microsoft Agent Framework skills adapter.
+/// </summary>
+public static class AgentFrameworkSkillsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Agent Framework adapter as the Nexo skill catalog implementation.
+    /// </summary>
+    public static IServiceCollection AddNexoAgentFrameworkSkills(
+        this IServiceCollection services,
+        Action<NexoSkillsOptions>? configure = null)
+    {
+        services.AddOptions<NexoSkillsOptions>();
+        if (configure != null)
+            services.Configure(configure);
+
+        services.TryAddSingleton<AgentFrameworkScriptRunnerBridge>();
+        services.TryAddSingleton<NexoActivePolicyPackSkill>();
+        services.TryAddSingleton<INexoSkillCatalog, AgentFrameworkSkillCatalog>();
+        return services;
+    }
+}

--- a/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillsServiceCollectionExtensions.cs
+++ b/src/Nexo.Skills.AgentFramework/AgentFrameworkSkillsServiceCollectionExtensions.cs
@@ -23,7 +23,10 @@ public static class AgentFrameworkSkillsServiceCollectionExtensions
 
         services.TryAddSingleton<AgentFrameworkScriptRunnerBridge>();
         services.TryAddSingleton<NexoActivePolicyPackSkill>();
-        services.TryAddSingleton<INexoSkillCatalog, AgentFrameworkSkillCatalog>();
+        services.TryAddSingleton<AgentFrameworkSkillCatalog>();
+        services.TryAddSingleton<INexoSkillCatalog>(sp => sp.GetRequiredService<AgentFrameworkSkillCatalog>());
+        services.TryAddSingleton<INexoSkillAgentBridge>(sp => sp.GetRequiredService<AgentFrameworkSkillCatalog>());
+        services.TryAddSingleton(sp => sp.GetRequiredService<AgentFrameworkSkillCatalog>().Provider);
         return services;
     }
 }

--- a/src/Nexo.Skills.AgentFramework/CatalogSourceContextFactory.cs
+++ b/src/Nexo.Skills.AgentFramework/CatalogSourceContextFactory.cs
@@ -1,0 +1,59 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Nexo.Skills.AgentFramework;
+
+/// <summary>
+/// Minimal agent stub used only to satisfy AgentSkillsSourceContext for catalog operations.
+/// </summary>
+internal sealed class CatalogSourceAgent : AIAgent
+{
+    protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default)
+        => ValueTask.FromResult<AgentSession>(new CatalogSourceSession());
+
+    protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+        AgentSession session,
+        JsonSerializerOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(default(JsonElement));
+
+    protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+        JsonElement serializedSession,
+        JsonSerializerOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => ValueTask.FromResult<AgentSession>(new CatalogSourceSession());
+
+    protected override Task<AgentResponse> RunCoreAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session = null,
+        AgentRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Catalog stub agent cannot run chat requests.");
+
+    protected override IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session = null,
+        AgentRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Catalog stub agent cannot run chat requests.");
+}
+
+internal sealed class CatalogSourceSession : AgentSession
+{
+}
+
+internal static class CatalogSourceContextFactory
+{
+    private static readonly ConditionalWeakTable<IServiceProvider, AgentSkillsSourceContext> Contexts = new();
+
+    public static AgentSkillsSourceContext Create(IServiceProvider? serviceProvider = null)
+    {
+        if (serviceProvider == null)
+            return new AgentSkillsSourceContext(new CatalogSourceAgent(), new CatalogSourceSession());
+
+        return Contexts.GetValue(serviceProvider, static _ =>
+            new AgentSkillsSourceContext(new CatalogSourceAgent(), new CatalogSourceSession()));
+    }
+}

--- a/src/Nexo.Skills.AgentFramework/ClassSkills/NexoActivePolicyPackSkill.cs
+++ b/src/Nexo.Skills.AgentFramework/ClassSkills/NexoActivePolicyPackSkill.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Nexo.Core.Application.Skills;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Trust.Ports;
+
+namespace Nexo.Skills.AgentFramework.ClassSkills;
+
+/// <summary>
+/// Class-based skill that returns the active trust policy pack id and version.
+/// </summary>
+public sealed class NexoActivePolicyPackSkill : AgentClassSkill<NexoActivePolicyPackSkill>
+{
+    private readonly ITrustPolicyPackRegistry _registry;
+
+    /// <summary>Initializes a new active policy pack skill.</summary>
+    public NexoActivePolicyPackSkill(ITrustPolicyPackRegistry registry)
+        : base(null)
+        => _registry = registry;
+
+    /// <inheritdoc />
+    public override AgentSkillFrontmatter Frontmatter { get; } =
+        new("nexo-active-policy-pack", "Returns the active Nexo trust policy pack id and version.");
+
+    /// <inheritdoc />
+    protected override string Instructions =>
+        "Use this skill to inspect which trust policy pack is currently active in Nexo.";
+
+    /// <summary>Returns the active policy pack summary.</summary>
+    [AgentSkillScript]
+    public string GetActivePolicySummary(JsonElement? args)
+    {
+        var active = _registry.GetActivePack();
+        if (active == null)
+            return "No active trust policy pack.";
+
+        var pack = _registry.GetById(active.Id);
+        var version = pack?.Version ?? active.Version;
+        var displayName = pack?.DisplayName ?? active.Id;
+        return $"{displayName} ({active.Id}@{version}) activated at {active.ActivatedAtUtc:O}";
+    }
+}

--- a/src/Nexo.Skills.AgentFramework/ContentHashInvalidatingSkillsSource.cs
+++ b/src/Nexo.Skills.AgentFramework/ContentHashInvalidatingSkillsSource.cs
@@ -1,0 +1,33 @@
+using Microsoft.Agents.AI;
+using Nexo.Core.Application.Skills.Ports;
+
+namespace Nexo.Skills.AgentFramework;
+
+/// <summary>
+/// Invalidates cached skill lists when the content hash of skill roots changes.
+/// </summary>
+internal sealed class ContentHashInvalidatingSkillsSource : DelegatingAgentSkillsSource
+{
+    private readonly INexoSkillCacheController _cacheController;
+    private readonly IReadOnlyList<string> _skillRootPaths;
+
+    public ContentHashInvalidatingSkillsSource(
+        AgentSkillsSource innerSource,
+        INexoSkillCacheController cacheController,
+        IEnumerable<string> skillRootPaths)
+        : base(innerSource)
+    {
+        _cacheController = cacheController;
+        _skillRootPaths = skillRootPaths.ToList();
+    }
+
+    public override Task<IList<AgentSkill>> GetSkillsAsync(
+        AgentSkillsSourceContext context,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var root in _skillRootPaths)
+            _cacheController.InvalidateIfContentChanged(root);
+
+        return InnerSource.GetSkillsAsync(context, cancellationToken);
+    }
+}

--- a/src/Nexo.Skills.AgentFramework/Nexo.Skills.AgentFramework.csproj
+++ b/src/Nexo.Skills.AgentFramework/Nexo.Skills.AgentFramework.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nexo.Core.Application\Nexo.Core.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Agents.AI" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="10.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nexo.Skills.AgentFramework/NexoSkillsOptions.cs
+++ b/src/Nexo.Skills.AgentFramework/NexoSkillsOptions.cs
@@ -1,0 +1,13 @@
+namespace Nexo.Skills.AgentFramework;
+
+/// <summary>
+/// Configuration for Nexo Agent Framework skill catalog registration.
+/// </summary>
+public sealed class NexoSkillsOptions
+{
+    /// <summary>Root directories containing file-based SKILL.md packages.</summary>
+    public IList<string> SkillRootPaths { get; } = [];
+
+    /// <summary>Timeout for human-in-the-loop script approval.</summary>
+    public TimeSpan ApprovalTimeout { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
+++ b/src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj
@@ -85,6 +85,7 @@
     <ProjectReference Include="..\Nexo.Runtime\Nexo.Runtime.csproj" />
     <ProjectReference Include="..\Nexo.Bricks.Owasp\Nexo.Bricks.Owasp.csproj" />
     <ProjectReference Include="..\Nexo.Hosting\Nexo.Hosting.csproj" />
+    <ProjectReference Include="..\Nexo.Skills.AgentFramework\Nexo.Skills.AgentFramework.csproj" />
     <ProjectReference Include="..\Nexo.Ingress.DynamoDb\Nexo.Ingress.DynamoDb.csproj" />
     <ProjectReference Include="..\Nexo.Client\Nexo.Client.csproj" />
   </ItemGroup>

--- a/src/Nexo.Tests.Infrastructure/Tests/Adaptation/AdversarialScopeEscapeTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Adaptation/AdversarialScopeEscapeTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using FluentAssertions;
 using Nexo.Abstractions;
+using Nexo.Core.Application.Skills.Models;
 using Nexo.Core.Application.Trust.Models;
 using Nexo.Core.Application.Trust.Ports;
 using Nexo.Policies.Dev;
@@ -207,6 +208,8 @@ public sealed class AdversarialScopeEscapeTests
         public void LogAmbientAction(string agentId, string summary, int toolCallsExecuted) { }
 
         public void LogCopilotTask(string tenantId, string taskId, bool success) { }
+
+        public void LogSkillDisclosure(NexoSkillAuditEvent auditEvent) { }
 
         public void LogSanitization(SanitizationAuditEntryDto entry) { }
         public void LogBoundaryChange(BoundaryChangeEvent evt) { }

--- a/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/BackgroundAgents/BackgroundAgentLifecycleE2ETests.cs
@@ -11,6 +11,7 @@ using Nexo.BackgroundAgents.Logging;
 using Nexo.BackgroundAgents.Registry;
 using Nexo.BackgroundAgents.Scheduling;
 using Nexo.BackgroundAgents.Trust;
+using Nexo.Core.Application.Skills.Models;
 using Nexo.Core.Application.Trust.Models;
 using Nexo.Core.Application.Trust.Ports;
 using Nexo.Core.Domain;
@@ -236,6 +237,7 @@ public sealed class BackgroundAgentLifecycleE2ETests
         public void LogAmbientAction(string agentId, string summary, int toolCallsExecuted) =>
             _captured.Add((agentId, summary, toolCallsExecuted));
         public void LogCopilotTask(string tenantId, string taskId, bool success) { }
+        public void LogSkillDisclosure(NexoSkillAuditEvent auditEvent) { }
         public void LogSanitization(SanitizationAuditEntryDto entry) { }
         public void LogBoundaryChange(BoundaryChangeEvent evt) { }
         public void LogClassification(string dataType, string levelName, string? reason) { }

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/InMemorySkillApprovalStoreTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/InMemorySkillApprovalStoreTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Infrastructure.Skills;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class InMemorySkillApprovalStoreTests
+{
+    [Fact]
+    public async Task WaitForResolutionAsync_times_out()
+    {
+        var store = new InMemorySkillApprovalStore();
+        var pending = store.RegisterPending(
+            new SkillScriptApprovalKey("skill", "s.sh", PeerTrustTier.Trusted, "internal", "pack"),
+            "desc");
+
+        var status = await store.WaitForResolutionAsync(pending.RequestId, TimeSpan.FromMilliseconds(50));
+        status.Should().Be(NexoSkillApprovalStatus.TimedOut);
+    }
+
+    [Fact]
+    public async Task TryResolve_completes_waiter()
+    {
+        var store = new InMemorySkillApprovalStore();
+        var pending = store.RegisterPending(
+            new SkillScriptApprovalKey("skill", "s.sh", PeerTrustTier.Trusted, "internal", "pack"),
+            "desc");
+
+        var wait = store.WaitForResolutionAsync(pending.RequestId, TimeSpan.FromSeconds(2));
+        store.TryResolve(pending.RequestId, NexoSkillApprovalStatus.Denied, out _).Should().BeTrue();
+        (await wait).Should().Be(NexoSkillApprovalStatus.Denied);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/NexoScriptRunnerTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/NexoScriptRunnerTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Infrastructure.Skills;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class NexoScriptRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_rejects_script_not_on_allow_list()
+    {
+        var runner = new NexoScriptRunner(
+            new LocalProcessScriptSandbox(),
+            new DenyScriptsPolicyEvaluator());
+
+        using var temp = new TempScriptRoot();
+        var scriptPath = temp.WriteScript("echo ok");
+
+        var result = await runner.RunAsync(
+            "skill",
+            "scripts/run.sh",
+            scriptPath,
+            "hash",
+            null,
+            new NexoScriptRunOptions(TimeSpan.FromSeconds(5), 4096, temp.WorkRoot),
+            new NexoSkillExecutionContext("tester", "internal", PeerTrustTier.Trusted, "pack", "corr"));
+
+        result.Outcome.Should().Be("denied");
+    }
+
+    [Fact]
+    public async Task RunAsync_truncates_output_when_over_cap()
+    {
+        var runner = new NexoScriptRunner(
+            new LocalProcessScriptSandbox(),
+            new AllowAllScriptsPolicyEvaluator());
+
+        using var temp = new TempScriptRoot();
+        var scriptPath = temp.WriteScript("python3 - <<'PY'\nprint('x' * 5000)\nPY");
+
+        var result = await runner.RunAsync(
+            "skill",
+            "scripts/run.sh",
+            scriptPath,
+            "hash",
+            null,
+            new NexoScriptRunOptions(TimeSpan.FromSeconds(10), 128, temp.WorkRoot),
+            new NexoSkillExecutionContext("tester", "internal", PeerTrustTier.Trusted, "pack", "corr"));
+
+        result.OutputTruncated.Should().BeTrue();
+        result.Outcome.Should().Be("truncated");
+    }
+
+    [Fact]
+    public async Task RunAsync_applies_timeout_from_options()
+    {
+        var sandbox = new RecordingSandbox(timeoutExitCode: 124);
+        var runner = new NexoScriptRunner(sandbox, new AllowAllScriptsPolicyEvaluator());
+
+        using var temp = new TempScriptRoot();
+        var scriptPath = temp.WriteScript("echo ok");
+
+        var result = await runner.RunAsync(
+            "skill",
+            "scripts/run.sh",
+            scriptPath,
+            "hash",
+            null,
+            new NexoScriptRunOptions(TimeSpan.FromMilliseconds(500), 4096, temp.WorkRoot),
+            new NexoSkillExecutionContext("tester", "internal", PeerTrustTier.Trusted, "pack", "corr"));
+
+        result.ExitCode.Should().Be(124);
+        sandbox.ReceivedTimeout.Should().Be(TimeSpan.FromMilliseconds(500));
+    }
+
+    private sealed class AllowAllScriptsPolicyEvaluator : INexoSkillPolicyEvaluator
+    {
+        public bool IsSkillVisible(NexoSkillDescriptor skill, NexoSkillExecutionContext context) => true;
+        public bool IsScriptAllowed(string skillName, string scriptPath, NexoSkillExecutionContext context) => true;
+        public bool IsScriptAutoApproved(string skillName, string scriptPath, NexoSkillExecutionContext context) => false;
+        public NexoScriptRunOptions GetScriptLimits(NexoSkillExecutionContext context) => new(TimeSpan.FromSeconds(10), 4096, Path.GetTempPath());
+        public SkillPolicyRules? GetActiveSkillRules() => null;
+    }
+
+    private sealed class DenyScriptsPolicyEvaluator : INexoSkillPolicyEvaluator
+    {
+        public bool IsSkillVisible(NexoSkillDescriptor skill, NexoSkillExecutionContext context) => true;
+        public bool IsScriptAllowed(string skillName, string scriptPath, NexoSkillExecutionContext context) => false;
+        public bool IsScriptAutoApproved(string skillName, string scriptPath, NexoSkillExecutionContext context) => false;
+        public NexoScriptRunOptions GetScriptLimits(NexoSkillExecutionContext context) => new(TimeSpan.FromSeconds(10), 4096, Path.GetTempPath());
+        public SkillPolicyRules? GetActiveSkillRules() => null;
+    }
+
+    private sealed class TempScriptRoot : IDisposable
+    {
+        public string WorkRoot { get; } = Path.Combine(Path.GetTempPath(), "nexo-script-" + Guid.NewGuid().ToString("N"));
+
+        public TempScriptRoot() => Directory.CreateDirectory(WorkRoot);
+
+        public string WriteScript(string body)
+        {
+            var path = Path.Combine(WorkRoot, "run.sh");
+            File.WriteAllText(path, "#!/usr/bin/env bash\n" + body + "\n");
+            return path;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(WorkRoot))
+                    Directory.Delete(WorkRoot, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private sealed class RecordingSandbox(int timeoutExitCode) : INexoScriptSandbox
+    {
+        public TimeSpan ReceivedTimeout { get; private set; }
+
+        public Task<SandboxScriptResult> RunAsync(
+            string scriptAbsolutePath,
+            string workingDirectory,
+            TimeSpan timeout,
+            int maxOutputBytes,
+            CancellationToken cancellationToken = default)
+        {
+            ReceivedTimeout = timeout;
+            return Task.FromResult(new SandboxScriptResult(
+                string.Empty,
+                "timed out",
+                timeoutExitCode,
+                false,
+                timeout));
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillAgentBridgeTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillAgentBridgeTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Trust.Ports;
+using Nexo.Infrastructure.Skills;
+using Nexo.Infrastructure.Skills.Sdk.Extensions;
+using Nexo.Infrastructure.Trust;
+using Nexo.Skills.AgentFramework;
+using Nexo.Skills.AgentFramework.ClassSkills;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class SkillAgentBridgeTests
+{
+    [Fact]
+    public async Task BuildSkillInstructionsAsync_includes_visible_skills()
+    {
+        var repoRoot = Nexo.Core.Application.Paths.RepoPathResolver.FindRepoRoot();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ITrustPolicyPackRegistry>(_ =>
+            new TrustPolicyPackRegistry(Path.Combine(repoRoot, "config", "trust-packs")));
+        services.AddSingleton<Nexo.Abstractions.Barriers.IBarrierContextAccessor, StubBarrier>();
+        services.AddNexoSkills();
+        services.AddNexoAgentFrameworkSkills(options =>
+            options.SkillRootPaths.Add(Path.Combine(repoRoot, "skills")));
+
+        using var provider = services.BuildServiceProvider();
+        await provider.GetRequiredService<ITrustPolicyPackRegistry>().ActivateAsync("internal-only");
+        var bridge = provider.GetRequiredService<INexoSkillAgentBridge>();
+        var ctxFactory = provider.GetRequiredService<INexoSkillExecutionContextFactory>();
+
+        var text = await bridge.BuildSkillInstructionsAsync(
+            ctxFactory.Create(PeerTrustTier.Trusted, "tester"));
+
+        text.Should().Contain("nexo-trust-inspector");
+        text.Should().Contain("Available Nexo skills");
+        provider.GetRequiredService<Microsoft.Agents.AI.AgentSkillsProvider>().Should().NotBeNull();
+    }
+
+    private sealed class StubBarrier : Nexo.Abstractions.Barriers.IBarrierContextAccessor
+    {
+        public Nexo.Abstractions.Barriers.BarrierContext? Current { get; private set; }
+        public void Initialize(Nexo.Abstractions.Barriers.BarrierContext context) => Current = context;
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillApprovalResolverTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillApprovalResolverTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Infrastructure.Skills;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class SkillApprovalResolverTests
+{
+    [Fact]
+    public async Task ResolveScriptApprovalAsync_auto_approves_when_policy_matches()
+    {
+        var evaluator = new StubPolicyEvaluator(autoApprove: true);
+        var store = new InMemorySkillApprovalStore();
+        var resolver = new SkillApprovalResolver(evaluator, store, new StubApprovalGate(NexoSkillApprovalStatus.Denied));
+
+        var status = await resolver.ResolveScriptApprovalAsync(
+            new SkillScriptApprovalKey("skill", "scripts/a.sh", PeerTrustTier.Trusted, "internal", "pack"),
+            "test");
+
+        status.Should().Be(NexoSkillApprovalStatus.AutoApproved);
+        store.GetPending().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveScriptApprovalAsync_registers_pending_and_uses_gate()
+    {
+        var evaluator = new StubPolicyEvaluator(autoApprove: false);
+        var store = new InMemorySkillApprovalStore();
+        var resolver = new SkillApprovalResolver(evaluator, store, new StubApprovalGate(NexoSkillApprovalStatus.Approved));
+
+        var status = await resolver.ResolveScriptApprovalAsync(
+            new SkillScriptApprovalKey("skill", "scripts/a.sh", PeerTrustTier.Untrusted, "internal", "pack"),
+            "test");
+
+        status.Should().Be(NexoSkillApprovalStatus.Approved);
+        store.GetPending().Should().ContainSingle(p => p.Status == NexoSkillApprovalStatus.Pending);
+    }
+
+    [Fact]
+    public async Task ResolveScriptApprovalAsync_returns_denied_when_gate_denies()
+    {
+        var evaluator = new StubPolicyEvaluator(autoApprove: false);
+        var store = new InMemorySkillApprovalStore();
+        var resolver = new SkillApprovalResolver(evaluator, store, new StubApprovalGate(NexoSkillApprovalStatus.Denied));
+
+        var status = await resolver.ResolveScriptApprovalAsync(
+            new SkillScriptApprovalKey("skill", "scripts/a.sh", PeerTrustTier.Untrusted, "internal", "pack"),
+            "test");
+
+        status.Should().Be(NexoSkillApprovalStatus.Denied);
+    }
+
+    private sealed class StubPolicyEvaluator(bool autoApprove) : INexoSkillPolicyEvaluator
+    {
+        public bool IsSkillVisible(NexoSkillDescriptor skill, NexoSkillExecutionContext context) => true;
+
+        public bool IsScriptAllowed(string skillName, string scriptPath, NexoSkillExecutionContext context) => true;
+
+        public bool IsScriptAutoApproved(string skillName, string scriptPath, NexoSkillExecutionContext context) => autoApprove;
+
+        public NexoScriptRunOptions GetScriptLimits(NexoSkillExecutionContext context)
+            => new(TimeSpan.FromSeconds(5), 4096, Path.GetTempPath());
+
+        public SkillPolicyRules? GetActiveSkillRules() => null;
+    }
+
+    private sealed class StubApprovalGate(NexoSkillApprovalStatus status) : INexoSkillApprovalGate
+    {
+        public Task<NexoSkillApprovalStatus> RequestApprovalAsync(
+            string actionDescription,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(status);
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillApprovalResolverTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillApprovalResolverTests.cs
@@ -14,7 +14,7 @@ public sealed class SkillApprovalResolverTests
     {
         var evaluator = new StubPolicyEvaluator(autoApprove: true);
         var store = new InMemorySkillApprovalStore();
-        var resolver = new SkillApprovalResolver(evaluator, store, new StubApprovalGate(NexoSkillApprovalStatus.Denied));
+        var resolver = new SkillApprovalResolver(evaluator, store, new HumanInTheLoopSkillApprovalGate());
 
         var status = await resolver.ResolveScriptApprovalAsync(
             new SkillScriptApprovalKey("skill", "scripts/a.sh", PeerTrustTier.Trusted, "internal", "pack"),
@@ -25,18 +25,27 @@ public sealed class SkillApprovalResolverTests
     }
 
     [Fact]
-    public async Task ResolveScriptApprovalAsync_registers_pending_and_uses_gate()
+    public async Task ResolveScriptApprovalAsync_waits_for_operator_approve()
     {
         var evaluator = new StubPolicyEvaluator(autoApprove: false);
         var store = new InMemorySkillApprovalStore();
-        var resolver = new SkillApprovalResolver(evaluator, store, new StubApprovalGate(NexoSkillApprovalStatus.Approved));
+        var resolver = new SkillApprovalResolver(
+            evaluator,
+            store,
+            new HumanInTheLoopSkillApprovalGate(),
+            approvalTimeout: TimeSpan.FromSeconds(5));
 
-        var status = await resolver.ResolveScriptApprovalAsync(
+        var resolveTask = resolver.ResolveScriptApprovalAsync(
             new SkillScriptApprovalKey("skill", "scripts/a.sh", PeerTrustTier.Untrusted, "internal", "pack"),
             "test");
 
+        await WaitForPendingAsync(store);
+        var pending = store.GetPending().Single();
+        store.TryResolve(pending.RequestId, NexoSkillApprovalStatus.Approved, out _).Should().BeTrue();
+
+        var status = await resolveTask;
         status.Should().Be(NexoSkillApprovalStatus.Approved);
-        store.GetPending().Should().ContainSingle(p => p.Status == NexoSkillApprovalStatus.Pending);
+        store.GetPending().Should().BeEmpty();
     }
 
     [Fact]
@@ -44,13 +53,26 @@ public sealed class SkillApprovalResolverTests
     {
         var evaluator = new StubPolicyEvaluator(autoApprove: false);
         var store = new InMemorySkillApprovalStore();
-        var resolver = new SkillApprovalResolver(evaluator, store, new StubApprovalGate(NexoSkillApprovalStatus.Denied));
+        var resolver = new SkillApprovalResolver(evaluator, store, new DenySkillApprovalGate());
 
         var status = await resolver.ResolveScriptApprovalAsync(
             new SkillScriptApprovalKey("skill", "scripts/a.sh", PeerTrustTier.Untrusted, "internal", "pack"),
             "test");
 
         status.Should().Be(NexoSkillApprovalStatus.Denied);
+        store.GetPending().Should().BeEmpty();
+    }
+
+    private static async Task WaitForPendingAsync(INexoSkillApprovalStore store)
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            if (store.GetPending().Count > 0)
+                return;
+            await Task.Delay(20);
+        }
+
+        throw new TimeoutException("Pending approval was not registered.");
     }
 
     private sealed class StubPolicyEvaluator(bool autoApprove) : INexoSkillPolicyEvaluator
@@ -65,14 +87,5 @@ public sealed class SkillApprovalResolverTests
             => new(TimeSpan.FromSeconds(5), 4096, Path.GetTempPath());
 
         public SkillPolicyRules? GetActiveSkillRules() => null;
-    }
-
-    private sealed class StubApprovalGate(NexoSkillApprovalStatus status) : INexoSkillApprovalGate
-    {
-        public Task<NexoSkillApprovalStatus> RequestApprovalAsync(
-            string actionDescription,
-            TimeSpan timeout,
-            CancellationToken cancellationToken = default)
-            => Task.FromResult(status);
     }
 }

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillAuditEmitterTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillAuditEmitterTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Nexo.BackgroundAgents.Trust;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Infrastructure.Skills;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class SkillAuditEmitterTests
+{
+    [Fact]
+    public void Log_emits_skill_event_to_data_decision_audit_log()
+    {
+        var auditLog = new DataDecisionAuditLog();
+        var emitter = new SkillAuditEmitter(dataDecisionAuditLog: auditLog);
+
+        emitter.Log(new NexoSkillAuditEvent(
+            NexoSkillAuditEventType.SkillAdvertised,
+            "nexo-trust-inspector",
+            "tester",
+            "internal",
+            "Trusted",
+            "internal-only",
+            "corr-1",
+            DateTimeOffset.UtcNow,
+            Detail: "advertised"));
+
+        var entries = auditLog.GetRecent(10, eventType: NexoSkillAuditEventType.SkillAdvertised);
+        entries.Should().ContainSingle();
+        entries[0].SkillName.Should().Be("nexo-trust-inspector");
+        entries[0].TrustTier.Should().Be("Trusted");
+        entries[0].PolicyPackId.Should().Be("internal-only");
+    }
+
+    [Theory]
+    [InlineData("SKILL_LOADED")]
+    [InlineData("SKILL_RESOURCE_READ")]
+    [InlineData("SKILL_SCRIPT_APPROVAL_REQUESTED")]
+    [InlineData("SKILL_SCRIPT_APPROVAL_RESOLVED")]
+    [InlineData("SKILL_SCRIPT_EXECUTED")]
+    public void Log_records_each_disclosure_stage(string eventType)
+    {
+        var auditLog = new DataDecisionAuditLog();
+        var emitter = new SkillAuditEmitter(dataDecisionAuditLog: auditLog);
+
+        emitter.Log(new NexoSkillAuditEvent(
+            eventType,
+            "skill",
+            "tester",
+            "public",
+            "Untrusted",
+            "strict-enterprise",
+            "corr-2",
+            DateTimeOffset.UtcNow,
+            ScriptPath: "scripts/a.sh",
+            ScriptContentHash: "ABC",
+            Outcome: "success",
+            DurationMs: 12));
+
+        auditLog.GetRecent(5, eventType: eventType).Should().ContainSingle();
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillContentHashCacheControllerTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillContentHashCacheControllerTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Nexo.Infrastructure.Skills;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class SkillContentHashCacheControllerTests
+{
+    [Fact]
+    public void InvalidateIfContentChanged_bumps_generation_when_files_change()
+    {
+        using var temp = new TempDir();
+        var controller = new SkillContentHashCacheController();
+        File.WriteAllText(Path.Combine(temp.Path, "SKILL.md"), "v1");
+
+        var first = controller.ComputeContentHash(temp.Path);
+        controller.InvalidateIfContentChanged(temp.Path);
+        File.WriteAllText(Path.Combine(temp.Path, "SKILL.md"), "v2-changed");
+        controller.InvalidateIfContentChanged(temp.Path);
+        var second = controller.ComputeContentHash(temp.Path);
+
+        second.Should().NotBe(first);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "nexo-skill-cache-" + Guid.NewGuid().ToString("N"));
+
+        public TempDir() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                    Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillPolicyEvaluatorTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillPolicyEvaluatorTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Trust.Models;
+using Nexo.Infrastructure.Skills;
+using Nexo.Infrastructure.Trust;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class SkillPolicyEvaluatorTests
+{
+    [Fact]
+    public async Task IsSkillVisible_respects_tier_allow_and_deny_lists()
+    {
+        using var temp = new TempTrustPackRoot();
+        WritePack(temp, CreateInternalOnlyPack());
+        var registry = new TrustPolicyPackRegistry(temp.Path);
+        await registry.ActivateAsync("internal-only");
+        var evaluator = new SkillPolicyEvaluator(registry);
+
+        var trustedContext = CreateContext(PeerTrustTier.Trusted, "internal-only");
+        var untrustedContext = CreateContext(PeerTrustTier.Untrusted, "internal-only");
+
+        evaluator.IsSkillVisible(new NexoSkillDescriptor("nexo-trust-inspector", "x"), trustedContext)
+            .Should().BeTrue();
+        evaluator.IsSkillVisible(new NexoSkillDescriptor("nexo-active-policy-pack", "x"), trustedContext)
+            .Should().BeTrue();
+        evaluator.IsSkillVisible(new NexoSkillDescriptor("nexo-trust-inspector", "x"), untrustedContext)
+            .Should().BeTrue();
+        evaluator.IsSkillVisible(new NexoSkillDescriptor("nexo-active-policy-pack", "x"), untrustedContext)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsScriptAutoApproved_matches_policy_tuple()
+    {
+        using var temp = new TempTrustPackRoot();
+        WritePack(temp, CreateInternalOnlyPack());
+        var registry = new TrustPolicyPackRegistry(temp.Path);
+        await registry.ActivateAsync("internal-only");
+        var evaluator = new SkillPolicyEvaluator(registry);
+
+        var trusted = CreateContext(PeerTrustTier.Trusted, "internal-only");
+        var untrusted = CreateContext(PeerTrustTier.Untrusted, "internal-only");
+
+        evaluator.IsScriptAutoApproved("nexo-trust-inspector", "scripts/list-packs.sh", trusted)
+            .Should().BeTrue();
+        evaluator.IsScriptAutoApproved("nexo-trust-inspector", "scripts/list-packs.sh", untrusted)
+            .Should().BeFalse();
+    }
+
+    private static NexoSkillExecutionContext CreateContext(PeerTrustTier tier, string packId)
+        => new("tester", "internal", tier, packId, "corr-1");
+
+    private static TrustPolicyPack CreateInternalOnlyPack()
+        => new(
+            "internal-only",
+            "1.0.0",
+            "Internal only",
+            "test",
+            false,
+            new Dictionary<string, bool> { ["file-contents"] = true },
+            new Dictionary<string, bool> { ["shell"] = true },
+            [],
+            SkillRules: new SkillPolicyRules(
+                new Dictionary<string, SkillTierVisibilityRules>
+                {
+                    ["Trusted"] = new(["nexo-trust-inspector", "nexo-active-policy-pack"], []),
+                    ["Untrusted"] = new(["nexo-trust-inspector"], ["nexo-active-policy-pack"]),
+                },
+                new Dictionary<string, IReadOnlyList<string>>
+                {
+                    ["nexo-trust-inspector"] = ["scripts/list-packs.sh"],
+                },
+                [new SkillScriptAutoApprovalRule("nexo-trust-inspector", "scripts/list-packs.sh", ["Trusted"])],
+                new SkillScriptLimits(30, 65536)));
+
+    private static void WritePack(TempTrustPackRoot temp, TrustPolicyPack pack)
+    {
+        var path = Path.Combine(temp.Path, $"{pack.Id}.json");
+        File.WriteAllText(path, System.Text.Json.JsonSerializer.Serialize(pack, new System.Text.Json.JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+        }));
+    }
+
+    private sealed class TempTrustPackRoot : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "nexo-skill-policy-" + Guid.NewGuid().ToString("N"));
+
+        public TempTrustPackRoot() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                    Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}

--- a/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillsDisclosureFlowIntegrationTests.cs
+++ b/src/Nexo.Tests.Infrastructure/Tests/Skills/SkillsDisclosureFlowIntegrationTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nexo.Abstractions.Barriers;
+using Nexo.BackgroundAgents.Trust;
+using Nexo.Core.Application.Mesh.Models;
+using Nexo.Core.Application.Paths;
+using Nexo.Core.Application.Skills.Models;
+using Nexo.Core.Application.Skills.Ports;
+using Nexo.Core.Application.Trust.Ports;
+using Nexo.Infrastructure.Skills;
+using Nexo.Infrastructure.Skills.Sdk.Extensions;
+using Nexo.Infrastructure.Trust;
+using Nexo.Runtime.Barriers;
+using Nexo.Skills.AgentFramework;
+using Nexo.Skills.AgentFramework.ClassSkills;
+using Xunit;
+
+namespace Nexo.Tests.Infrastructure.Tests.Skills;
+
+public sealed class SkillsDisclosureFlowIntegrationTests
+{
+    [Fact]
+    public async Task Full_disclosure_flow_filters_tiers_and_emits_audit_trail()
+    {
+        var repoRoot = RepoPathResolver.FindRepoRoot();
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var packsPath = Path.Combine(repoRoot, "config", "trust-packs");
+        Environment.SetEnvironmentVariable("NEXO_TRUST_POLICY_PACKS_PATH", packsPath);
+
+        services.AddSingleton<ITrustPolicyPackRegistry>(_ => new TrustPolicyPackRegistry(packsPath));
+        services.AddSingleton<IBarrierContextAccessor, StubBarrierContextAccessor>();
+        services.AddSingleton<IDataDecisionAuditLog, DataDecisionAuditLog>();
+        services.AddNexoSkills();
+        services.AddSingleton<INexoSkillApprovalGate>(_ => new AlwaysApproveSkillGate());
+        services.AddNexoAgentFrameworkSkills(options =>
+        {
+            options.SkillRootPaths.Add(Path.Combine(repoRoot, "skills"));
+        });
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        var registry = provider.GetRequiredService<ITrustPolicyPackRegistry>();
+        await registry.ActivateAsync("internal-only");
+
+        var catalog = provider.GetRequiredService<INexoSkillCatalog>();
+        var auditLog = provider.GetRequiredService<IDataDecisionAuditLog>();
+        var contextFactory = provider.GetRequiredService<INexoSkillExecutionContextFactory>();
+
+        var trustedContext = contextFactory.Create(PeerTrustTier.Trusted, "integration-tester", "corr-trusted");
+        var untrustedContext = contextFactory.Create(PeerTrustTier.Untrusted, "integration-tester", "corr-untrusted");
+
+        var trustedAds = await catalog.AdvertiseAsync(trustedContext);
+        var untrustedAds = await catalog.AdvertiseAsync(untrustedContext);
+
+        trustedAds.Select(static s => s.Name).Should().Contain("nexo-trust-inspector");
+        trustedAds.Select(static s => s.Name).Should().Contain("nexo-active-policy-pack");
+        untrustedAds.Select(static s => s.Name).Should().Contain("nexo-trust-inspector");
+        untrustedAds.Select(static s => s.Name).Should().NotContain("nexo-active-policy-pack");
+
+        var loaded = await catalog.LoadAsync("nexo-trust-inspector", trustedContext);
+        loaded.Should().Contain("Nexo Trust Inspector");
+
+        var resource = await catalog.ReadResourceAsync(
+            "nexo-trust-inspector",
+            "references/pack-schema.md",
+            trustedContext);
+        resource.Should().Contain("skillRules");
+
+        var scriptResult = await catalog.RunScriptAsync(
+            "nexo-trust-inspector",
+            "scripts/list-packs.sh",
+            null,
+            trustedContext);
+        scriptResult.Outcome.Should().BeOneOf("success", "truncated");
+        scriptResult.Output.Should().Contain("Trust policy packs");
+
+        auditLog.GetRecent(100).Should().Contain(e => e.EventType == NexoSkillAuditEventType.SkillAdvertised);
+        auditLog.GetRecent(100).Should().Contain(e => e.EventType == NexoSkillAuditEventType.SkillLoaded);
+        auditLog.GetRecent(100).Should().Contain(e => e.EventType == NexoSkillAuditEventType.SkillResourceRead);
+        auditLog.GetRecent(100).Should().Contain(e => e.EventType == NexoSkillAuditEventType.SkillScriptApprovalRequested);
+        auditLog.GetRecent(100).Should().Contain(e => e.EventType == NexoSkillAuditEventType.SkillScriptApprovalResolved);
+        auditLog.GetRecent(100).Should().Contain(e => e.EventType == NexoSkillAuditEventType.SkillScriptExecuted);
+    }
+
+    private sealed class StubBarrierContextAccessor : IBarrierContextAccessor
+    {
+        public BarrierContext? Current { get; private set; }
+
+        public void Initialize(BarrierContext context) => Current = context;
+    }
+
+    private sealed class AlwaysApproveSkillGate : INexoSkillApprovalGate
+    {
+        public Task<NexoSkillApprovalStatus> RequestApprovalAsync(
+            string actionDescription,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(NexoSkillApprovalStatus.Approved);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Nexo's policy-gated capability-extension layer using the Microsoft Agent Skills `SKILL.md` format, with Nexo-owned ports as the public contract and `Microsoft.Agents.AI` isolated to a single adapter project.

### Architecture

- **Nexo-owned ports** (`Nexo.Core.Application.Skills`): `INexoSkillCatalog`, `INexoSkillPolicyEvaluator`, `INexoScriptRunner`, `INexoSkillApprovalResolver`, `INexoSkillAuditLog`, `INexoSkillCacheController`
- **Infrastructure** (`Nexo.Infrastructure.Skills`): policy evaluator, local sandbox runner, approval resolver, audit emitter, content-hash cache controller
- **Adapter** (`Nexo.Skills.AgentFramework`): wraps `AgentSkillsProvider` / file + class skills; only project referencing `Microsoft.Agents.AI` **1.13.0**

### Policy & trust

- Extended `TrustPolicyPack` with optional `skillRules` (visibility by tier, script allow-list, auto-approve tuples, script limits)
- Sample rules added to `internal-only.json` and `strict-enterprise.json`
- Visibility resolved from **policy pack × trust tier × barrier identity**

### Script execution

- `NexoScriptRunner` routes through `ICapabilityRouter` seam (local-only this phase) with `INexoScriptSandbox` swappable implementation
- Enforces timeout, output cap, working-directory isolation, and policy script allow-list
- Script approval via policy auto-approve or `IApprovalGate` bridge (`ApprovalGateSkillApprovalBridge`)

### Audit contract

Stable `NexoSkillAuditEvent` schema with six event types:
`SKILL_ADVERTISED`, `SKILL_LOADED`, `SKILL_RESOURCE_READ`, `SKILL_SCRIPT_APPROVAL_REQUESTED`, `SKILL_SCRIPT_APPROVAL_RESOLVED`, `SKILL_SCRIPT_EXECUTED`

Events fan out to `IBarrierAuditLog` and `IDataDecisionAuditLog.LogSkillDisclosure`.

### Dogfood skills

| Skill | Type | Purpose |
|-------|------|---------|
| `nexo-trust-inspector` | File (`SKILL.md` + `scripts/list-packs.sh`) | Lists trust policy packs |
| `nexo-active-policy-pack` | Class (`AgentClassSkill<T>`) | Returns active pack id/version |

### Tests

15 tests covering policy filter mapping, approval paths, runner enforcement (allow-list, output cap, timeout passthrough), audit emission per stage, and end-to-end disclosure flow integration.

## Test plan

- [x] `dotnet test src/Nexo.Tests.Infrastructure/Nexo.Tests.Infrastructure.csproj -f net8.0 --filter "FullyQualifiedName~Nexo.Tests.Infrastructure.Tests.Skills"`
- [x] `dotnet build src/Nexo.Hosting/Nexo.Hosting.csproj`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2d22333-384a-4a9f-a60b-6e1fcdea4a18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2d22333-384a-4a9f-a60b-6e1fcdea4a18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

