### PR TITLE
fix(ci): unblock mesh Fleet.Host + StableSdk package consumer

### DIFF
--- a/commercial/src/Nexo.Commercial.Fleet.Host/Nexo.Commercial.Fleet.Host.csproj
+++ b/commercial/src/Nexo.Commercial.Fleet.Host/Nexo.Commercial.Fleet.Host.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Nexo.Commercial.Fleet.Api\Nexo.Commercial.Fleet.Api.csproj" />
     <ProjectReference Include="..\Nexo.Commercial.Fleet.Contracts\Nexo.Commercial.Fleet.Contracts.csproj" />
     <ProjectReference Include="..\Nexo.Commercial.Fleet.Infrastructure\Nexo.Commercial.Fleet.Infrastructure.csproj" />
+    <ProjectReference Include="..\Nexo.Commercial.GameDirector.Mcp\GameDirector.Mcp.csproj" />
     <ProjectReference Include="..\..\..\application\src\Nexo.API\Nexo.API.csproj" />
     <ProjectReference Include="..\..\..\src\Nexo.Hosting\Nexo.Hosting.csproj" />
   </ItemGroup>

--- a/commercial/src/Nexo.Commercial.Fleet.Host/Program.cs
+++ b/commercial/src/Nexo.Commercial.Fleet.Host/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using GameDirector.Mcp.Endpoints;
+using Nexo.API.Endpoints;
 using Nexo.API.Middleware.Ingress;
 using Nexo.API.Security;
 using Nexo.BackgroundAgents.Extending;

--- a/docs/samples/StableSdkHostSample/Program.cs
+++ b/docs/samples/StableSdkHostSample/Program.cs
@@ -5,6 +5,7 @@ using Nexo.Core.Domain.Bricks;
 using Nexo.Core.Domain.Execution;
 using Nexo.Hosting;
 using Nexo.Hosting.Sdk;
+using Nexo.Hosting.Sdk.Extensions;
 
 var services = new ServiceCollection();
 
@@ -28,7 +29,7 @@ services.AddNexo(options =>
 using var provider = services.BuildServiceProvider();
 Console.WriteLine("Stable SDK host sample bootstrapped successfully.");
 
-public sealed class SampleHostBrick : DomainBrick
+public sealed class SampleHostBrick : Brick
 {
     public SampleHostBrick()
     {

--- a/docs/samples/StableSdkHostSample/package-consumer/Directory.Build.props
+++ b/docs/samples/StableSdkHostSample/package-consumer/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Explicit transitive pins for local-feed restore (repo root skips versionless refs for this project name). -->
   <!-- Align with repo Directory.Packages.props / GHSA mitigations: NU1904, NU1903, NU1902. -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="1.15.3" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #236: fixes the two integration failures that blocked mesh lab / StableSdk package consumer on the MEAI cutover.

## Changes

- **Fleet.Host (mesh lab):** reference `GameDirector.Mcp` and `using Nexo.API.Endpoints` so `MapNexoEndpoints` resolves during Docker publish
- **StableSdkHostSample package-consumer:** pin `System.Text.Encodings.Web` **10.0.9** (NU1605 vs Hosting.Bundle), use `Brick` instead of repo-only `DomainBrick` alias, add `Nexo.Hosting.Sdk.Extensions` for `AddNexoSdk`

## Testing

- [x] `dotnet build commercial/src/Nexo.Commercial.Fleet.Host`
- [x] `NEXO_SDK_PACKAGE_VERSION=… bash scripts/verify-stable-sdk-host-sample-packages.sh` OK

- [x] Not a versioned release — skip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5487f09-1e79-4b74-9db3-8e1722025a04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5487f09-1e79-4b74-9db3-8e1722025a04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

